### PR TITLE
Adapt `get_current_params` and `update_params`

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,7 +3,7 @@ codecov:
     require_ci_to_pass: yes
 
 coverage:
-  precision: 2
+  precision: 3
   round: down
   range: "70...85"
 

--- a/docs/custom_quorum_size.md
+++ b/docs/custom_quorum_size.md
@@ -20,7 +20,7 @@ The default value of both parameters is 0, which follows the original algorithm.
 Those parameters are dynamically adjustable; you can change the size of quorum without shutting down Raft server:
 
 ```C++
-raft_params* params = server->get_current_params();
+ptr<raft_params> params = server->get_current_params();
 params->custom_commit_quorum_size_ = 2;
 params->custom_election_quorum_size_ = 4;
 server->update_params(params);

--- a/include/libnuraft/context.hxx
+++ b/include/libnuraft/context.hxx
@@ -64,9 +64,9 @@ public:
         return params_;
     }
 
-    void set_params(raft_params* to) {
+    void set_params(ptr<raft_params>& to) {
         std::lock_guard<std::mutex> l(lock_);
-        params_ = std::shared_ptr<raft_params>(to);
+        params_ = to;
     }
 
     __nocopy__(context);

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -325,22 +325,18 @@ public:
     /**
      * Update Raft parameters.
      *
-     * WARNING: Given `new_params` will be converted to `shared_ptr`
-     *          internally and then directly used, so that caller SHOULD NOT
-     *          free the memory of `new_params`.
-     *
      * @param new_params Parameters to set.
      */
-    void update_params(raft_params* new_params);
+    void update_params(ptr<raft_params>& new_params);
 
     /**
      * Get the current Raft parameters.
-     * It will allocate a new memory and the caller is responsible for
-     * deallocating the returned address.
+     * Returned instance is the clone of the original one,
+     * so that user can modify its contents.
      *
-     * @return Raft parameters.
+     * @return Clone of Raft parameters.
      */
-    raft_params* get_current_params() const;
+    ptr<raft_params> get_current_params() const;
 
 protected:
     typedef std::unordered_map<int32, ptr<peer>>::const_iterator peer_itor;

--- a/src/crc32.cxx
+++ b/src/crc32.cxx
@@ -19,6 +19,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 **************************************************************************/
 
+// LCOV_EXCL_START
+
 #include "crc32.hxx"
 
 #include <stdlib.h>
@@ -380,4 +382,6 @@ uint32_t crc32_8_last8(const void* data, size_t len, uint32_t prev_value) {
 #endif
     return crc32_8(src, min, prev_value);
 }
+
+// LCOV_EXCL_STOP
 

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -251,10 +251,9 @@ void raft_server::update_rand_timeout() {
          params->election_timeout_upper_bound_);
 }
 
-void raft_server::update_params(raft_params* new_params) {
+void raft_server::update_params(ptr<raft_params>& new_params) {
     recur_lock(lock_);
     ctx_->set_params(new_params);
-    ptr<raft_params> ptr_new_params = ctx_->get_params();
     log_current_params();
 
     update_rand_timeout();
@@ -263,7 +262,7 @@ void raft_server::update_params(raft_params* new_params) {
     }
     for (auto& entry: peers_) {
         peer* p = entry.second.get();
-        p->set_hb_interval(ptr_new_params->heart_beat_interval_);
+        p->set_hb_interval(new_params->heart_beat_interval_);
         p->resume_hb_speed();
     }
 }
@@ -294,8 +293,8 @@ void raft_server::log_current_params() {
           params->custom_election_quorum_size_ );
 }
 
-raft_params* raft_server::get_current_params() const {
-    return ctx_->get_params()->copy_to();
+ptr<raft_params> raft_server::get_current_params() const {
+    return ptr<raft_params>( ctx_->get_params()->copy_to() );
 }
 
 void raft_server::stop_server() {

--- a/tests/unit/asio_service_test.cxx
+++ b/tests/unit/asio_service_test.cxx
@@ -524,7 +524,7 @@ int async_append_handler_test() {
     // Set async.
     for (auto& entry: pkgs) {
         RaftAsioPkg* pp = entry;
-        raft_params* param = pp->raftServer->get_current_params();
+        ptr<raft_params> param = pp->raftServer->get_current_params();
         param->return_method_ = raft_params::async_handler;
         pp->raftServer->update_params(param);
     }

--- a/tests/unit/failure_test.cxx
+++ b/tests/unit/failure_test.cxx
@@ -46,7 +46,7 @@ int simple_conflict_test() {
 
     for (auto& entry: pkgs) {
         RaftPkg* pp = entry;
-        raft_params* param = pp->raftServer->get_current_params();
+        ptr<raft_params> param = pp->raftServer->get_current_params();
         param->return_method_ = raft_params::async_handler;
         pp->raftServer->update_params(param);
     }

--- a/tests/unit/raft_server_test.cxx
+++ b/tests/unit/raft_server_test.cxx
@@ -185,14 +185,13 @@ int update_params_test() {
 
     for (auto& entry: pkgs) {
         RaftPkg* pp = entry;
-        raft_params* param = pp->raftServer->get_current_params();
+        ptr<raft_params> param = pp->raftServer->get_current_params();
         int old_value = param->election_timeout_upper_bound_;
         param->with_election_timeout_upper( old_value + 1 );
         pp->raftServer->update_params(param);
 
         param = pp->raftServer->get_current_params();
         CHK_EQ( old_value + 1, param->election_timeout_upper_bound_ );
-        delete param;
     }
 
     print_stats(pkgs);
@@ -810,7 +809,7 @@ int async_append_handler_test() {
 
     for (auto& entry: pkgs) {
         RaftPkg* pp = entry;
-        raft_params* param = pp->raftServer->get_current_params();
+        ptr<raft_params> param = pp->raftServer->get_current_params();
         param->return_method_ = raft_params::async_handler;
         pp->raftServer->update_params(param);
     }
@@ -898,7 +897,7 @@ int async_append_handler_cancel_test() {
 
     for (auto& entry: pkgs) {
         RaftPkg* pp = entry;
-        raft_params* param = pp->raftServer->get_current_params();
+        ptr<raft_params> param = pp->raftServer->get_current_params();
         param->return_method_ = raft_params::async_handler;
         pp->raftServer->update_params(param);
     }


### PR DESCRIPTION
* Dealing with raw pointer is error-prone. They should return and
accept `shared_ptr`.