### PR TITLE
Add missing description of `write_at` API

### DIFF
--- a/examples/in_memory_log_store.cxx
+++ b/examples/in_memory_log_store.cxx
@@ -74,10 +74,12 @@ ulong inmem_log_store::append(ptr<log_entry>& entry) {
 void inmem_log_store::write_at(ulong index, ptr<log_entry>& entry) {
     ptr<log_entry> clone = make_clone(entry);
 
-    // Find first and erase existing one.
+    // Discard all logs equal to or greater than `index.
     std::lock_guard<std::mutex> l(logs_lock_);
-    auto existing = logs_.find(index);
-    if (existing != logs_.end()) logs_.erase(existing);
+    auto itr = logs_.lower_bound(index);
+    while (itr != logs_.end()) {
+        itr = logs_.erase(itr);
+    }
     logs_[index] = clone;
 }
 

--- a/include/libnuraft/log_store.hxx
+++ b/include/libnuraft/log_store.hxx
@@ -67,6 +67,9 @@ public:
 
     /**
      * Overwrite a log entry at the given `index`.
+     * This API should make sure that all log entries
+     * after the given `index` should be truncated (if exist),
+     * as a result of this function call.
      *
      * @param index Log index number to overwrite.
      * @param entry New log entry to overwrite.


### PR DESCRIPTION
* `write_at` API should purge all stale logs whose indexes are greater
than given index.

* Modified in-memory log store properly.