### PR TITLE
Exclude fatal errors from code coverage report

### DIFF
--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -174,11 +174,13 @@ ptr<req_msg> raft_server::create_append_entries_req(peer& p) {
     }
 
     if (last_log_idx >= cur_nxt_idx) {
+        // LCOV_EXCL_START
         p_er( "Peer's lastLogIndex is too large %llu v.s. %llu, ",
               last_log_idx, cur_nxt_idx );
         ctx_->state_mgr_->system_exit(raft_err::N8_peer_last_log_idx_too_large);
         ::exit(-1);
         return ptr<req_msg>();
+        // LCOV_EXCL_STOP
     }
 
     // cur_nxt_idx: last log index of myself (leader).

--- a/src/handle_commit.cxx
+++ b/src/handle_commit.cxx
@@ -125,12 +125,14 @@ void raft_server::commit_in_bg() {
                   quick_commit_index_.load(), sm_commit_index_.load() );
 
             if (le->get_term() == 0) {
+                // LCOV_EXCL_START
                 // Zero term means that log store is corrupted
                 // (failed to read log).
                 p_ft( "empty log at idx %llu, must be log corruption",
                       sm_commit_index_.load() );
                 ctx_->state_mgr_->system_exit(raft_err::N19_bad_log_idx_for_term);
                 ::exit(-1);
+                // LCOV_EXCL_STOP
             }
 
             if (le->get_val_type() == log_val_type::app_log) {
@@ -164,12 +166,14 @@ void raft_server::commit_in_bg() {
         }
 
      } catch (std::exception& err) {
+        // LCOV_EXCL_START
         commit_bg_stopped_ = true;
         p_er( "background committing thread encounter err %s, "
               "exiting to protect the system",
               err.what() );
         ctx_->state_mgr_->system_exit(raft_err::N20_background_commit_err);
         ::exit(-1);
+        // LCOV_EXCL_STOP
      }
     }
     commit_bg_stopped_ = true;
@@ -299,12 +303,14 @@ void raft_server::snapshot_and_compact(ulong committed_idx) {
              conf->get_prev_log_idx() > 0 &&
              conf->get_prev_log_idx() < log_store_->start_index() ) {
             if (!local_snp) {
+                // LCOV_EXCL_START
                 p_er("No snapshot could be found while no configuration "
                      "cannot be found in current committed logs, "
                      "this is a system error, exiting");
                 ctx_->state_mgr_->system_exit(raft_err::N6_no_snapshot_found);
                 ::exit(-1);
                 return;
+                // LCOV_EXCL_STOP
             }
             conf = local_snp->get_last_config();
 

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -646,8 +646,10 @@ void raft_server::send_reconnect_request() {
         p_leader->send_req(p_leader, req, ex_resp_handler_);
 
     } else {
+        // LCOV_EXCL_START
         p_ft("cannot find leader!");
         ctx_->state_mgr_->system_exit(-1);
+        // LCOV_EXCL_STOP
     }
 }
 
@@ -1052,8 +1054,10 @@ ulong raft_server::store_log_entry(ptr<log_entry>& entry, ulong index) {
     // cluster membership change log entries.  Losing cluster membership log
     // entries may lead to split brain.
     if ( entry->get_val_type() == log_val_type::conf && !log_store_->flush() ) {
+        // LCOV_EXCL_START
         p_ft("log store flush failed");
         ctx_->state_mgr_->system_exit(N21_log_flush_failed);
+        // LCOV_EXCL_STOP
     }
 
     return log_index;


### PR DESCRIPTION
* Fatal errors that we must not reach cannot be verified by using
functional tests.

* Also excluded legacy snapshot type (i.e., `raw_binary`).