### PR TITLE
Expose restart election timer. 

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -183,6 +183,11 @@ public:
     void yield_leadership();
 
     /**
+     * Start the election timer on this server, if this server is a follower.
+     */
+    void restart_election_timer();
+
+    /**
      * Set custom context to Raft cluster config.
      *
      * @param ctx Custom context.
@@ -456,7 +461,6 @@ protected:
     void become_leader();
     void become_follower();
     void enable_hb_for_peer(peer& p);
-    void restart_election_timer();
     void stop_election_timer();
     void handle_hb_timeout(int32 srv_id);
     void reset_peer_info();

--- a/src/handle_timeout.cxx
+++ b/src/handle_timeout.cxx
@@ -102,7 +102,8 @@ void raft_server::handle_hb_timeout(int32 srv_id) {
 
 void raft_server::restart_election_timer() {
     // don't start the election timer while this server is still catching up the logs
-    if (catching_up_) {
+    // or this server is the leader
+    if (catching_up_ || role_ == srv_role::leader) {
         return;
     }
 

--- a/src/handle_timeout.cxx
+++ b/src/handle_timeout.cxx
@@ -103,6 +103,7 @@ void raft_server::handle_hb_timeout(int32 srv_id) {
 void raft_server::restart_election_timer() {
     // don't start the election timer while this server is still catching up the logs
     // or this server is the leader
+    recur_lock(lock_);
     if (catching_up_ || role_ == srv_role::leader) {
         return;
     }


### PR DESCRIPTION
The idea is the following.  For the provision workflow, the following would happen:
1. Every node is started with `skip_initial_election_timeout_ = true`.
2. The agent will pick one node, and call `/initialize` on this node.  At this time `restart_election_timer()` will be called to elect this node to be the leader.

The idea is to make `/startserver` consistent among all nodes, and use the `/initialize` call to make the designated node the leader.