### PR TITLE
Support graceful resignation of leader

### DIFF
--- a/src/handle_client_request.cxx
+++ b/src/handle_client_request.cxx
@@ -38,7 +38,7 @@ ptr<resp_msg> raft_server::handle_cli_req(req_msg& req) {
                            msg_type::append_entries_response,
                            id_,
                            leader_ );
-    if (role_ != srv_role::leader) {
+    if (role_ != srv_role::leader || write_paused_) {
         resp->set_result_code( cmd_result_code::NOT_LEADER );
         return resp;
     }

--- a/src/handle_join_leave.cxx
+++ b/src/handle_join_leave.cxx
@@ -48,7 +48,7 @@ ptr<resp_msg> raft_server::handle_add_srv_req(req_msg& req) {
         return resp;
     }
 
-    if (role_ != srv_role::leader) {
+    if (role_ != srv_role::leader || write_paused_) {
         p_er("this is not a leader, cannot handle AddServerRequest");
         resp->set_result_code(cmd_result_code::NOT_LEADER);
         return resp;
@@ -321,7 +321,7 @@ ptr<resp_msg> raft_server::handle_rm_srv_req(req_msg& req) {
         return resp;
     }
 
-    if (role_ != srv_role::leader) {
+    if (role_ != srv_role::leader || write_paused_) {
         p_wn("this is not a leader, cannot handle RemoveServerRequest");
         resp->set_result_code(cmd_result_code::NOT_LEADER);
         return resp;


### PR DESCRIPTION
* To reduce the uncertainty of leader reelection, the current leader
should pause write, and finish the catch-up of the latest log with the
highest priority peer (excluding myself) node. Then most likely that
peer node will be elected as a next leader.