### PR TITLE
Batch size hint on append entry response.

### DIFF
--- a/include/libnuraft/log_store.hxx
+++ b/include/libnuraft/log_store.hxx
@@ -104,11 +104,12 @@ public:
      *
      * @param start The start log index number (inclusive).
      * @param end The end log index number (exclusive).
+     * @param batch_size_hint_in_bytes total size (in bytes) of the returned entries
      * @return The log entries between [start, end) and limited by the total size
-     *         given by the batch_size_hint.
+     *         given by the batch_size_hint_in_bytes.
      */
-    virtual ptr<std::vector<ptr<log_entry>>> log_entries_ext(ulong start, ulong end,
-                                                             ulong batch_size_hint = 0) {
+    virtual ptr<std::vector<ptr<log_entry>>> log_entries_ext(
+            ulong start, ulong end, ulong batch_size_hint_in_bytes = 0) {
         return log_entries(start, end);
     }
 

--- a/include/libnuraft/peer.hxx
+++ b/include/libnuraft/peer.hxx
@@ -69,7 +69,7 @@ public:
         , rpc_backoff_( ctx.get_params()->rpc_failure_backoff_ )
         , max_hb_interval_( ctx.get_params()->max_hb_interval() )
         , next_log_idx_(0)
-        , next_batch_size_hint_(0)
+        , next_batch_size_hint_in_bytes_(0)
         , matched_idx_(0)
         , busy_flag_(false)
         , pending_commit_flag_(false)
@@ -170,12 +170,12 @@ public:
         next_log_idx_ = idx;
     }
 
-    ulong get_next_batch_size_hint() const {
-        return next_batch_size_hint_;
+    ulong get_next_batch_size_hint_in_bytes() const {
+        return next_batch_size_hint_in_bytes_;
     }
 
-    void set_next_batch_size_hint(ulong batch_size) {
-        next_batch_size_hint_ = batch_size;
+    void set_next_batch_size_hint_in_bytes(ulong batch_size) {
+        next_batch_size_hint_in_bytes_ = batch_size;
     }
 
     ulong get_matched_idx() const {
@@ -333,7 +333,7 @@ private:
     std::atomic<ulong> next_log_idx_;
 
     // Hint of the next log batch size in bytes.
-    std::atomic<ulong> next_batch_size_hint_;
+    std::atomic<ulong> next_batch_size_hint_in_bytes_;
 
     // The last log index whose term matches up with the leader.
     ulong matched_idx_;

--- a/include/libnuraft/resp_msg.hxx
+++ b/include/libnuraft/resp_msg.hxx
@@ -43,7 +43,7 @@ public:
              bool accepted = false)
         : msg_base(term, type, src, dst)
         , next_idx_(next_idx)
-        , next_batch_size_hint_(0)
+        , next_batch_size_hint_in_bytes_(0)
         , accepted_(accepted)
         , ctx_(nullptr)
         , cb_func_(nullptr)
@@ -58,12 +58,12 @@ public:
         return next_idx_;
     }
 
-    ulong get_next_batch_size_hint() const {
-        return next_batch_size_hint_;
+    ulong get_next_batch_size_hint_in_bytes() const {
+        return next_batch_size_hint_in_bytes_;
     }
 
-    void set_next_batch_size_hint(ulong bytes) {
-        next_batch_size_hint_ = bytes;
+    void set_next_batch_size_hint_in_bytes(ulong bytes) {
+        next_batch_size_hint_in_bytes_ = bytes;
     }
 
     bool get_accepted() const {
@@ -119,7 +119,7 @@ public:
 
 private:
     ulong next_idx_;
-    ulong next_batch_size_hint_;
+    ulong next_batch_size_hint_in_bytes_;
     bool accepted_;
     ptr<buffer> ctx_;
     resp_cb cb_func_;

--- a/include/libnuraft/state_machine.hxx
+++ b/include/libnuraft/state_machine.hxx
@@ -129,7 +129,7 @@ public:
      *
      * @return the preferred size of the next log batch
      */
-    virtual ulong get_next_batch_size_hint() { return 0; }
+    virtual ulong get_next_batch_size_hint_in_bytes() { return 0; }
 
     /**
      * (Deprecated)

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -236,7 +236,7 @@ ptr<req_msg> raft_server::create_append_entries_req(peer& p) {
         log_entries( (last_log_idx + 1) >= cur_nxt_idx
                      ? ptr<std::vector<ptr<log_entry>>>()
                      : log_store_->log_entries_ext(last_log_idx + 1, end_idx,
-                                                   p.get_next_batch_size_hint()) );
+                                                   p.get_next_batch_size_hint_in_bytes()) );
     p_db( "append_entries for %d with LastLogIndex=%llu, "
           "LastLogTerm=%llu, EntriesLength=%d, CommitIndex=%llu, "
           "Term=%llu, peer_last_sent_idx %zu",
@@ -357,7 +357,8 @@ ptr<resp_msg> raft_server::handle_append_entries(req_msg& req)
                  local_snp->get_last_log_idx(),
                  local_snp->get_last_log_term());
         }
-        resp->set_next_batch_size_hint(state_machine_->get_next_batch_size_hint());
+        resp->set_next_batch_size_hint_in_bytes(
+                state_machine_->get_next_batch_size_hint_in_bytes() );
         return resp;
     }
 
@@ -501,7 +502,8 @@ ptr<resp_msg> raft_server::handle_append_entries(req_msg& req)
         restart_election_timer();
     }
 
-    resp->set_next_batch_size_hint(state_machine_->get_next_batch_size_hint());
+    resp->set_next_batch_size_hint_in_bytes(
+            state_machine_->get_next_batch_size_hint_in_bytes() );
     return resp;
 }
 
@@ -525,7 +527,7 @@ void raft_server::handle_append_entries_resp(resp_msg& resp) {
     ptr<peer> p = it->second;
     p_tr("handle append entries resp (from %d), resp.get_next_idx(): %d\n",
          (int)p->get_id(), (int)resp.get_next_idx());
-    p->set_next_batch_size_hint(resp.get_next_batch_size_hint());
+    p->set_next_batch_size_hint_in_bytes(resp.get_next_batch_size_hint_in_bytes());
     if (resp.get_accepted()) {
         uint64_t prev_matched_idx = 0;
         uint64_t new_matched_idx = 0;


### PR DESCRIPTION
Add a batch size hint to the response of append entry request to give the leader a hint about how many logs to send in the next batch.

This is useful to control the rate of the leader sending log entries and limiting the memory consumed for those log entries.