### PR TITLE
Handle the case when log do not exist

### DIFF
--- a/examples/in_memory_log_store.cxx
+++ b/examples/in_memory_log_store.cxx
@@ -97,6 +97,7 @@ ptr< std::vector< ptr<log_entry> > >
             auto entry = logs_.find(ii);
             if (entry == logs_.end()) {
                 entry = logs_.find(0);
+                assert(0);
             }
             src = entry->second;
         }
@@ -120,6 +121,7 @@ ptr<std::vector<ptr<log_entry>>>
             auto entry = logs_.find(ii);
             if (entry == logs_.end()) {
                 entry = logs_.find(0);
+                assert(0);
             }
             src = entry->second;
         }

--- a/examples/logger.cc
+++ b/examples/logger.cc
@@ -4,7 +4,7 @@ Author/Developer(s): Jung-Sang Ahn
 
 Original Copyright 2017 Jung-Sang Ahn
 See URL: https://github.com/greensky00/simple_logger
-         (v0.3.22)
+         (v0.3.24)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -584,8 +584,8 @@ SimpleLoggerMgr::~SimpleLoggerMgr() {
     termination = true;
 
 #if defined(__linux__) || defined(__APPLE__)
-    if (oldSigSegvHandler) signal(SIGSEGV, oldSigSegvHandler);
-    if (oldSigAbortHandler) signal(SIGABRT, oldSigAbortHandler);
+    signal(SIGSEGV, oldSigSegvHandler);
+    signal(SIGABRT, oldSigAbortHandler);
 #endif
     {   std::unique_lock<std::mutex> l(cvFlusherLock);
         cvFlusher.notify_all();

--- a/examples/logger.h
+++ b/examples/logger.h
@@ -4,7 +4,7 @@ Author/Developer(s): Jung-Sang Ahn
 
 Original Copyright 2017 Jung-Sang Ahn
 See URL: https://github.com/greensky00/simple_logger
-         (v0.3.22)
+         (v0.3.24)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ limitations under the License.
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <fstream>
 #include <list>
@@ -79,6 +80,55 @@ limitations under the License.
 #define _s_trace(l) _stream_(SimpleLogger::TRACE,   l)
 
 
+// Do printf style log, but print logs in `lv1` level during normal time,
+// once in given `interval_ms` interval, print a log in `lv2` level.
+// The very first log will be printed in `lv2` level.
+//
+// This function is global throughout the process, so that
+// multiple threads will share the interval.
+#define _timed_log_g(l, interval_ms, lv1, lv2, ...)                     \
+{                                                                       \
+    _timed_log_definition(static);                                      \
+    _timed_log_body(l, interval_ms, lv1, lv2, __VA_ARGS__);             \
+}
+
+// Same as `_timed_log_g` but per-thread level.
+#define _timed_log_t(l, interval_ms, lv1, lv2, ...)                     \
+{                                                                       \
+    _timed_log_definition(thread_local);                                \
+    _timed_log_body(l, interval_ms, lv1, lv2, __VA_ARGS__);             \
+}
+
+#define _timed_log_definition(prefix)                                   \
+    prefix std::mutex timer_lock;                                       \
+    prefix bool first_event_fired = false;                              \
+    prefix std::chrono::system_clock::time_point last_timeout =         \
+        std::chrono::system_clock::now();
+
+#define _timed_log_body(l, interval_ms, lv1, lv2, ...)                  \
+    std::chrono::system_clock::time_point cur =                         \
+        std::chrono::system_clock::now();                               \
+    std::chrono::duration<double> elapsed = cur - last_timeout;         \
+    bool timeout = false;                                               \
+    {   std::lock_guard<std::mutex> l(timer_lock);                      \
+        if ( elapsed.count() * 1000 > interval_ms ||                    \
+             !first_event_fired ) {                                     \
+            cur = std::chrono::system_clock::now();                     \
+            elapsed = cur - last_timeout;                               \
+            if ( elapsed.count() * 1000 > interval_ms ||                \
+                 !first_event_fired ) {                                 \
+                timeout = first_event_fired = true;                     \
+                last_timeout = cur;                                     \
+            }                                                           \
+        }                                                               \
+    }                                                                   \
+    if (timeout) {                                                      \
+        _log_(lv2, l, __VA_ARGS__);                                     \
+    } else {                                                            \
+        _log_(lv1, l, __VA_ARGS__);                                     \
+    }
+
+
 class SimpleLoggerMgr;
 class SimpleLogger {
     friend class SimpleLoggerMgr;
@@ -94,6 +144,7 @@ public:
         INFO        = 4,
         DEBUG       = 5,
         TRACE       = 6,
+        UNKNOWN     = 99,
     };
 
     class LoggerStream : public std::ostream {

--- a/src/handle_timeout.cxx
+++ b/src/handle_timeout.cxx
@@ -92,7 +92,7 @@ void raft_server::handle_hb_timeout(int32 srv_id) {
 
     if (!check_leadership_validity()) return;
 
-    p_db("Heartbeat timeout for %d", p->get_id());
+    p_db("heartbeat timeout for %d", p->get_id());
     if (role_ == srv_role::leader) {
         update_target_priority();
         request_append_entries(p);


### PR DESCRIPTION
* If there is no snapshot, and logs are already compacted, leader
should protect itself rather than crashing.

* Update logger to fix recursive crash handler issue.