### PR TITLE
Do not force clear the free flag of peer

### DIFF
--- a/include/libnuraft/peer.hxx
+++ b/include/libnuraft/peer.hxx
@@ -44,11 +44,6 @@ public:
     static const int32 RESPONSE_LIMIT   = 20;
 
     // If connection is silent longer than this limit
-    // (multiplied by heartbeat interval), temporarily
-    // reset busy flag to poke that connection.
-    static const int32 BUSY_FLAG_LIMIT  = 20;
-
-    // If connection is silent longer than this limit
     // (multiplied by heartbeat interval), re-establish
     // the connection.
     static const int32 RECONNECT_LIMIT  = 50;

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -135,16 +135,6 @@ bool raft_server::request_append_entries(ptr<peer> p) {
             p_wn("long pause warning to %d is too verbose, "
                  "will suppress it from now", p->get_id());
         }
-
-        // For resiliency, free busy flag once to send heartbeat to the peer.
-        if ( last_ts_ms > params->heart_beat_interval_ *
-                          peer::BUSY_FLAG_LIMIT ) {
-            p_wn("probably something went wrong. "
-                 "temporarily free busy flag for peer %d", p->get_id());
-            p->set_free();
-            p->set_manual_free();
-            p->reset_ls_timer();
-        }
     }
     return false;
 }

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -741,6 +741,8 @@ void raft_server::become_leader() {
             pp->set_snapshot_in_sync(nil_snp);
         }
         // Reset RPC client for all peers.
+        // NOTE: Now we don't reset client, as we already did it
+        //       during pre-vote phase.
         // reconnect_client(*pp);
 
         pp->set_next_log_idx(log_store_->next_slot());


### PR DESCRIPTION
* If we clear the free flag of peer without re-creating RPC client,
it may cause data corruption which results in the exception of Asio
worker thread.

* In addition to that, added exception handling logic to worker_entry,
to avoid immediate termination of worker thread.