### PR TITLE
Add a new protocol for custom notification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,7 @@ set(RAFT_CORE
     ${ROOT_SRC}/error_code.cxx
     ${ROOT_SRC}/handle_append_entries.cxx
     ${ROOT_SRC}/handle_client_request.cxx
+    ${ROOT_SRC}/handle_custom_notification.cxx
     ${ROOT_SRC}/handle_commit.cxx
     ${ROOT_SRC}/handle_join_leave.cxx
     ${ROOT_SRC}/handle_priority.cxx

--- a/include/libnuraft/callback.hxx
+++ b/include/libnuraft/callback.hxx
@@ -89,7 +89,13 @@ public:
         // It will be invoked only for acceptable logs.
         // ctx: pointer to request.
         GotAppendEntryReqFromLeader = 14,
+
+        // This node is out of log range, which means that
+        // leader has no valid log or snapshot to send for this node.
+        // ctx: pointer to `OutOfLogRangeWarningArgs`.
+        OutOfLogRangeWarning = 15,
     };
+
     struct Param {
         Param(int32_t my_id = -1,
               int32_t leader_id = -1,
@@ -105,13 +111,21 @@ public:
         int32_t peerId;
         void* ctx;
     };
+
     enum ReturnCode {
         Ok = 0,
         ReturnNull = -1,
     };
+
+    struct OutOfLogRangeWarningArgs {
+        OutOfLogRangeWarningArgs(uint64_t x = 0) : startIdxOfLeader(x) {}
+        uint64_t startIdxOfLeader;
+    };
+
     using func_type = std::function<ReturnCode(Type, Param*)>;
 
     cb_func() : func(nullptr) {}
+
     cb_func(func_type _func) : func(_func) {}
 
     ReturnCode call(Type type, Param* param) {
@@ -120,6 +134,7 @@ public:
         }
         return Ok;
     }
+
 private:
     func_type func;
 };

--- a/include/libnuraft/msg_base.hxx
+++ b/include/libnuraft/msg_base.hxx
@@ -22,6 +22,7 @@ limitations under the License.
 #define _MSG_BASE_HXX_
 
 #include "basic_types.hxx"
+#include "msg_type.hxx"
 #include "pp_util.hxx"
 
 namespace nuraft {

--- a/include/libnuraft/msg_type.hxx
+++ b/include/libnuraft/msg_type.hxx
@@ -31,33 +31,35 @@ namespace nuraft {
 //   need to change `msg_type_to_string()` as well
 //   whenever modify this enum.
 enum msg_type {
-    request_vote_request        = 1,
-    request_vote_response       = 2,
-    append_entries_request      = 3,
-    append_entries_response     = 4,
-    client_request              = 5,
-    add_server_request          = 6,
-    add_server_response         = 7,
-    remove_server_request       = 8,
-    remove_server_response      = 9,
-    sync_log_request            = 10,
-    sync_log_response           = 11,
-    join_cluster_request        = 12,
-    join_cluster_response       = 13,
-    leave_cluster_request       = 14,
-    leave_cluster_response      = 15,
-    install_snapshot_request    = 16,
-    install_snapshot_response   = 17,
-    ping_request                = 18,
-    ping_response               = 19,
-    pre_vote_request            = 20,
-    pre_vote_response           = 21,
-    other_request               = 22,
-    other_response              = 23,
-    priority_change_request     = 24,
-    priority_change_response    = 25,
-    reconnect_request           = 26,
-    reconnect_response          = 27,
+    request_vote_request            = 1,
+    request_vote_response           = 2,
+    append_entries_request          = 3,
+    append_entries_response         = 4,
+    client_request                  = 5,
+    add_server_request              = 6,
+    add_server_response             = 7,
+    remove_server_request           = 8,
+    remove_server_response          = 9,
+    sync_log_request                = 10,
+    sync_log_response               = 11,
+    join_cluster_request            = 12,
+    join_cluster_response           = 13,
+    leave_cluster_request           = 14,
+    leave_cluster_response          = 15,
+    install_snapshot_request        = 16,
+    install_snapshot_response       = 17,
+    ping_request                    = 18,
+    ping_response                   = 19,
+    pre_vote_request                = 20,
+    pre_vote_response               = 21,
+    other_request                   = 22,
+    other_response                  = 23,
+    priority_change_request         = 24,
+    priority_change_response        = 25,
+    reconnect_request               = 26,
+    reconnect_response              = 27,
+    custom_notification_request     = 28,
+    custom_notification_response    = 29,
 };
 
 static bool ATTR_UNUSED is_valid_msg(msg_type type) {
@@ -72,33 +74,35 @@ static bool ATTR_UNUSED is_valid_msg(msg_type type) {
 static std::string ATTR_UNUSED msg_type_to_string(msg_type type)
 {
     switch (type) {
-    case request_vote_request:      return "request_vote_request";
-    case request_vote_response:     return "request_vote_response";
-    case append_entries_request:    return "append_entries_request";
-    case append_entries_response:   return "append_entries_response";
-    case client_request:            return "client_request";
-    case add_server_request:        return "add_server_request";
-    case add_server_response:       return "add_server_response";
-    case remove_server_request:     return "remove_server_request";
-    case remove_server_response:    return "remove_server_response";
-    case sync_log_request:          return "sync_log_request";
-    case sync_log_response:         return "sync_log_response";
-    case join_cluster_request:      return "join_cluster_request";
-    case join_cluster_response:     return "join_cluster_response";
-    case leave_cluster_request:     return "leave_cluster_request";
-    case leave_cluster_response:    return "leave_cluster_response";
-    case install_snapshot_request:  return "install_snapshot_request";
-    case install_snapshot_response: return "install_snapshot_response";
-    case ping_request:              return "ping_request";
-    case ping_response:             return "ping_response";
-    case pre_vote_request:          return "pre_vote_request";
-    case pre_vote_response:         return "pre_vote_response";
-    case other_request:             return "other_request";
-    case other_response:            return "other_response";
-    case priority_change_request:   return "priority_change_request";
-    case priority_change_response:  return "priority_change_response";
-    case reconnect_request:         return "reconnect_request";
-    case reconnect_response:        return "reconnect_response";
+    case request_vote_request:          return "request_vote_request";
+    case request_vote_response:         return "request_vote_response";
+    case append_entries_request:        return "append_entries_request";
+    case append_entries_response:       return "append_entries_response";
+    case client_request:                return "client_request";
+    case add_server_request:            return "add_server_request";
+    case add_server_response:           return "add_server_response";
+    case remove_server_request:         return "remove_server_request";
+    case remove_server_response:        return "remove_server_response";
+    case sync_log_request:              return "sync_log_request";
+    case sync_log_response:             return "sync_log_response";
+    case join_cluster_request:          return "join_cluster_request";
+    case join_cluster_response:         return "join_cluster_response";
+    case leave_cluster_request:         return "leave_cluster_request";
+    case leave_cluster_response:        return "leave_cluster_response";
+    case install_snapshot_request:      return "install_snapshot_request";
+    case install_snapshot_response:     return "install_snapshot_response";
+    case ping_request:                  return "ping_request";
+    case ping_response:                 return "ping_response";
+    case pre_vote_request:              return "pre_vote_request";
+    case pre_vote_response:             return "pre_vote_response";
+    case other_request:                 return "other_request";
+    case other_response:                return "other_response";
+    case priority_change_request:       return "priority_change_request";
+    case priority_change_response:      return "priority_change_response";
+    case reconnect_request:             return "reconnect_request";
+    case reconnect_response:            return "reconnect_response";
+    case custom_notification_request:   return "custom_notification_request";
+    case custom_notification_response:  return "custom_notification_response";
     default:
         return "unknown (" + std::to_string(static_cast<int>(type)) + ")";
     }

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -40,6 +40,7 @@ namespace nuraft {
 using CbReturnCode = cb_func::ReturnCode;
 
 class cluster_config;
+class custom_notification_msg;
 class delayed_task_scheduler;
 class logger;
 class peer;
@@ -468,6 +469,7 @@ protected:
     ptr<resp_msg> handle_leave_cluster_req(req_msg& req);
     ptr<resp_msg> handle_priority_change_req(req_msg& req);
     ptr<resp_msg> handle_reconnect_req(req_msg& req);
+    ptr<resp_msg> handle_custom_notification_req(req_msg& req);
 
     void handle_join_cluster_resp(resp_msg& resp);
     void handle_log_sync_resp(resp_msg& resp);
@@ -487,6 +489,7 @@ protected:
     void handle_vote_resp(resp_msg& resp);
     void handle_priority_change_resp(resp_msg& resp);
     void handle_reconnect_resp(resp_msg& resp);
+    void handle_custom_notification_resp(resp_msg& resp);
 
     void handle_ext_resp(ptr<resp_msg>& resp, ptr<rpc_exception>& err);
     void handle_ext_resp_err(rpc_exception& err);
@@ -532,6 +535,10 @@ protected:
     void set_last_snapshot(const ptr<snapshot>& new_snapshot);
 
     ulong store_log_entry(ptr<log_entry>& entry, ulong index = 0);
+
+    ptr<resp_msg> handle_out_of_log_msg(req_msg& req,
+                                        ptr<custom_notification_msg> msg,
+                                        ptr<resp_msg> resp);
 
 protected:
     static const int default_snapshot_sync_block_size;

--- a/include/libnuraft/req_msg.hxx
+++ b/include/libnuraft/req_msg.hxx
@@ -66,9 +66,20 @@ public:
     }
 
 private:
+    // Term of last log below.
     ulong last_log_term_;
+
+    // Last log index that the destination (i.e., follower) node
+    // currently has. If below `log_entries_` contains logs,
+    // the starting index will be `last_log_idx_ + 1`.
     ulong last_log_idx_;
+
+    // Source (i.e., leader) node's current committed log index.
+    // As a pipelining, follower will do commit on this index number
+    // after appending given logs.
     ulong commit_idx_;
+
+    // Logs. Can be empty.
     std::vector<ptr<log_entry>> log_entries_;
 };
 

--- a/src/handle_custom_notification.cxx
+++ b/src/handle_custom_notification.cxx
@@ -1,0 +1,188 @@
+/************************************************************************
+Modifications Copyright 2017-2019 eBay Inc.
+
+Original Copyright:
+See URL: https://github.com/datatechnology/cornerstone
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+**************************************************************************/
+
+#include "handle_custom_notification.hxx"
+
+#include "buffer_serializer.hxx"
+#include "callback.hxx"
+#include "error_code.hxx"
+#include "peer.hxx"
+#include "raft_server.hxx"
+#include "req_msg.hxx"
+#include "resp_msg.hxx"
+#include "tracer.hxx"
+
+#include <cassert>
+#include <cstring>
+
+namespace nuraft {
+
+// --- custom_notification_msg ---
+
+ptr<custom_notification_msg> custom_notification_msg::deserialize(buffer& buf) {
+    ptr<custom_notification_msg> ret = cs_new<custom_notification_msg>();
+
+    buffer_serializer bs(buf);
+    uint8_t version = bs.get_u8();
+    (void)version;
+    ret->type_ = static_cast<custom_notification_msg::type>(bs.get_u8());
+
+    size_t buf_len = 0;
+    void* ptr = bs.get_bytes(buf_len);
+
+    if (buf_len) {
+        ret->ctx_ = buffer::alloc(buf_len);
+        memcpy(ret->ctx_->data_begin(), ptr, buf_len);
+    } else {
+        ret->ctx_ = nullptr;
+    }
+
+    return ret;
+}
+
+ptr<buffer> custom_notification_msg::serialize() const {
+    //   << Format >>
+    // version          1 byte
+    // type             1 byte
+    // ctx length (X)   4 bytes
+    // ctx              X bytes
+
+    const uint8_t CURRENT_VERSION = 0x0;
+
+    size_t len = sizeof(uint8_t) +
+                 sizeof(uint8_t) +
+                 sizeof(uint32_t) +
+                 ( (ctx_) ? ctx_->size() : 0 );
+
+    ptr<buffer> ret = buffer::alloc(len);
+    buffer_serializer bs(ret);
+    bs.put_u8(CURRENT_VERSION);
+    bs.put_u8(type_);
+    if (ctx_) {
+        bs.put_bytes(ctx_->data_begin(), ctx_->size());
+    } else {
+        bs.put_u32(0);
+    }
+
+    return ret;
+}
+
+
+// --- out_of_log_msg ---
+
+ptr<out_of_log_msg> out_of_log_msg::deserialize(buffer& buf) {
+    ptr<out_of_log_msg> ret = cs_new<out_of_log_msg>();
+
+    buffer_serializer bs(buf);
+    uint8_t version = bs.get_u8();
+    (void)version;
+    ret->start_idx_of_leader_ = bs.get_u64();
+    return ret;
+}
+
+ptr<buffer> out_of_log_msg::serialize() const {
+    //   << Format >>
+    // version                      1 byte
+    // start log index of leader    8 bytes
+
+    const uint8_t CURRENT_VERSION = 0x0;
+
+    size_t len = sizeof(uint8_t) + sizeof(ulong);
+
+    ptr<buffer> ret = buffer::alloc(len);
+    buffer_serializer bs(ret);
+    bs.put_u8(CURRENT_VERSION);
+    bs.put_u64(start_idx_of_leader_);
+    return ret;
+}
+
+
+// --- handlers ---
+
+ptr<resp_msg> raft_server::handle_custom_notification_req(req_msg& req) {
+    ptr<resp_msg> resp = cs_new<resp_msg>( state_->get_term(),
+                                           msg_type::custom_notification_response,
+                                           id_,
+                                           req.get_src(),
+                                           log_store_->next_slot() );
+    resp->accept(log_store_->next_slot());
+
+    std::vector< ptr<log_entry> >& log_entries = req.log_entries();
+    if (!log_entries.size()) {
+        // Empty message, just return.
+        return resp;
+    }
+
+    ptr<log_entry> msg_le = log_entries[0];
+    ptr<buffer> buf = msg_le->get_buf_ptr();
+    if (!buf) return resp;
+
+    ptr<custom_notification_msg> msg = custom_notification_msg::deserialize(*buf);
+
+    switch (msg->type_) {
+    case custom_notification_msg::out_of_log_range_warning: {
+        return handle_out_of_log_msg(req, msg, resp);
+    }
+
+    default:
+        break;
+    }
+
+    return resp;
+}
+
+ptr<resp_msg> raft_server::handle_out_of_log_msg(req_msg& req,
+                                                 ptr<custom_notification_msg> msg,
+                                                 ptr<resp_msg> resp)
+{
+    static timer_helper msg_timer(5000000);
+    int log_lv = msg_timer.timeout_and_reset() ? L_WARN : L_TRACE;
+
+    // As it is a special form of heartbeat, need to update term.
+    update_term(req.get_term());
+
+    ptr<out_of_log_msg> ool_msg = out_of_log_msg::deserialize(*msg->ctx_);
+    p_lv(log_lv, "this node is out of log range. leader's start index: %zu, "
+         "my last index: %zu",
+         ool_msg->start_idx_of_leader_,
+         log_store_->next_slot() - 1);
+
+    cb_func::Param param(id_, leader_);
+    cb_func::OutOfLogRangeWarningArgs args(ool_msg->start_idx_of_leader_);
+    param.ctx = &args;
+    ctx_->cb_func_.call(cb_func::OutOfLogRangeWarning, &param);
+
+    return resp;
+}
+
+void raft_server::handle_custom_notification_resp(resp_msg& resp) {
+    if (!resp.get_accepted()) return;
+
+    peer_itor it = peers_.find(resp.get_src());
+    if (it == peers_.end()) {
+        p_in("the response is from an unknown peer %d", resp.get_src());
+        return;
+    }
+    ptr<peer> p = it->second;
+
+    p->set_next_log_idx(resp.get_next_idx());
+}
+
+} // namespace nuraft;
+

--- a/src/handle_custom_notification.hxx
+++ b/src/handle_custom_notification.hxx
@@ -1,6 +1,5 @@
 /************************************************************************
 Modifications Copyright 2017-2019 eBay Inc.
-Author/Developer(s): Jung-Sang Ahn
 
 Original Copyright:
 See URL: https://github.com/datatechnology/cornerstone
@@ -18,19 +17,43 @@ See the License for the specific language governing permissions and
 limitations under the License.
 **************************************************************************/
 
-#ifndef _LOG_VALUE_TYPE_HXX_
-#define _LOG_VALUE_TYPE_HXX_
+#pragma once
+
+#include "buffer.hxx"
+#include "ptr.hxx"
 
 namespace nuraft {
 
-enum log_val_type {
-    app_log         = 1,
-    conf            = 2,
-    cluster_server  = 3,
-    log_pack        = 4,
-    snp_sync_req    = 5,
-    custom          = 999,
+struct custom_notification_msg {
+    enum type {
+        out_of_log_range_warning = 1,
+    };
+
+    custom_notification_msg(type t = out_of_log_range_warning)
+        : type_(t)
+        , ctx_(nullptr)
+        {}
+
+    static ptr<custom_notification_msg> deserialize(buffer& buf);
+
+    ptr<buffer> serialize() const;
+
+    type type_;
+
+    ptr<buffer> ctx_;
 };
 
-}
-#endif // _LOG_VALUE_TYPE_HXX_
+struct out_of_log_msg {
+    out_of_log_msg()
+        : start_idx_of_leader_(0)
+        {}
+
+    static ptr<out_of_log_msg> deserialize(buffer& buf);
+
+    ptr<buffer> serialize() const;
+
+    ulong start_idx_of_leader_;
+};
+
+} // namespace nuraft;
+

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -638,6 +638,10 @@ void raft_server::handle_peer_resp(ptr<resp_msg>& resp, ptr<rpc_exception>& err)
         p_in("got ping response from %d", resp->get_src());
         break;
 
+    case msg_type::custom_notification_response:
+        handle_custom_notification_resp(*resp);
+        break;
+
     default:
         p_er( "received an unexpected response: %s, ignore it",
               msg_type_to_string(resp->get_type()).c_str() );
@@ -889,6 +893,9 @@ ptr<resp_msg> raft_server::handle_ext_msg(req_msg& req) {
 
     case msg_type::reconnect_request:
         return handle_reconnect_req(req);
+
+    case msg_type::custom_notification_request:
+        return handle_custom_notification_req(req);
 
     default:
         p_er( "received request: %s, ignore it",

--- a/tests/unit/raft_package_fake.hxx
+++ b/tests/unit/raft_package_fake.hxx
@@ -50,7 +50,8 @@ public:
 
     void initServer(raft_params* given_params = nullptr,
                     const raft_server::init_options opt =
-                        raft_server::init_options())
+                        raft_server::init_options(),
+                    cb_func::func_type raft_callback = nullptr)
     {
         fNet = cs_new<FakeNetwork>( myEndpoint, fBase );
         fBase->addNetwork(fNet);
@@ -81,6 +82,9 @@ public:
 
         ctx = new context( sMgr, sm, listener, myLog,
                            rpcCliFactory, scheduler, params );
+        if (raft_callback) {
+            ctx->set_cb_func(raft_callback);
+        }
         raftServer = cs_new<raft_server>(ctx, opt);
     }
 

--- a/tests/unit/serialization_test.cxx
+++ b/tests/unit/serialization_test.cxx
@@ -18,6 +18,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 **************************************************************************/
 
+#include "handle_custom_notification.hxx"
 #include "nuraft.hxx"
 #include "strfmt.hxx"
 
@@ -220,6 +221,47 @@ int log_entry_test() {
     return 0;
 }
 
+int custom_notification_msg_test(bool empty_context) {
+    custom_notification_msg orig_msg;
+    orig_msg.type_ = custom_notification_msg::out_of_log_range_warning;
+
+    const std::string MSG_STR = "test_message";
+    if (empty_context) {
+        orig_msg.ctx_ = nullptr;
+    } else {
+        ptr<buffer> ctx = buffer::alloc(sizeof(uint32_t) + MSG_STR.size());
+        buffer_serializer bs(ctx);
+        bs.put_str(MSG_STR);
+        orig_msg.ctx_ = ctx;
+    }
+
+    ptr<buffer> enc_msg = orig_msg.serialize();
+    ptr<custom_notification_msg> dec_msg =
+        custom_notification_msg::deserialize(*enc_msg);
+
+    CHK_EQ( orig_msg.type_ , dec_msg->type_ );
+    if (empty_context) {
+        CHK_NULL( dec_msg->ctx_ );
+    } else {
+        buffer_serializer bs(dec_msg->ctx_);
+        std::string result_str = bs.get_str();
+        CHK_EQ(MSG_STR, result_str);
+    }
+
+    return 0;
+}
+
+int out_of_log_msg_test() {
+    out_of_log_msg orig_msg;
+    orig_msg.start_idx_of_leader_ = 1234;
+
+    ptr<buffer> enc_msg = orig_msg.serialize();
+    ptr<out_of_log_msg> dec_msg = out_of_log_msg::deserialize(*enc_msg);
+
+    CHK_EQ( orig_msg.start_idx_of_leader_, dec_msg->start_idx_of_leader_ );
+    return 0;
+}
+
 }  // namespace serialization_test;
 using namespace serialization_test;
 
@@ -238,6 +280,10 @@ int main(int argc, char** argv) {
                snapshot_sync_req_zero_buffer_test,
                TestRange<bool>( {true, false} ) );
     ts.doTest( "log_entry test", log_entry_test );
+    ts.doTest( "custom_notification_msg test",
+               custom_notification_msg_test,
+               TestRange<bool>( {true, false} ) );
+    ts.doTest( "out_of_log_msg test", out_of_log_msg_test );
 
     return 0;
 }


### PR DESCRIPTION
* Currently we are using this protocol for the notification of
out-of-log-range for lagging follower, in case when log has been
compacted without creating any snapshots (it should not happen in
normal case, must be user's fault).

* Added a new callback type for out-of-log-range, so that user can
handle this situation smoothly, rather than crash or abort.