### PR TITLE
Support active leadership takeover

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -477,8 +477,8 @@ protected:
 
     bool handle_snapshot_sync_req(snapshot_sync_req& req);
     void request_prevote();
-    void initiate_vote();
-    void request_vote();
+    void initiate_vote(bool ignore_priority = false);
+    void request_vote(bool ignore_priority);
     void request_append_entries();
     bool request_append_entries(ptr<peer> p);
     void handle_peer_resp(ptr<resp_msg>& resp, ptr<rpc_exception>& err);
@@ -539,6 +539,10 @@ protected:
     ptr<resp_msg> handle_out_of_log_msg(req_msg& req,
                                         ptr<custom_notification_msg> msg,
                                         ptr<resp_msg> resp);
+
+    ptr<resp_msg> handle_leadership_takeover(req_msg& req,
+                                             ptr<custom_notification_msg> msg,
+                                             ptr<resp_msg> resp);
 
 protected:
     static const int default_snapshot_sync_block_size;
@@ -623,6 +627,10 @@ protected:
     // `true` if write operation is paused, as the first phase of
     // leader re-election.
     std::atomic<bool> write_paused_;
+
+    // Server ID indicates the candidate for the next leader,
+    // as a part of leadership takeover task.
+    std::atomic<int32> next_leader_candidate_;
 
     // Timer that will start at pausing write.
     timer_helper reelection_timer_;

--- a/src/handle_custom_notification.hxx
+++ b/src/handle_custom_notification.hxx
@@ -27,7 +27,8 @@ namespace nuraft {
 class custom_notification_msg {
 public:
     enum type {
-        out_of_log_range_warning = 1,
+        out_of_log_range_warning    = 1,
+        leadership_takeover         = 2,
     };
 
     custom_notification_msg(type t = out_of_log_range_warning)
@@ -55,6 +56,15 @@ public:
     ptr<buffer> serialize() const;
 
     ulong start_idx_of_leader_;
+};
+
+class force_vote_msg {
+public:
+    force_vote_msg() {}
+
+    static ptr<force_vote_msg> deserialize(buffer& buf);
+
+    ptr<buffer> serialize() const;
 };
 
 } // namespace nuraft;

--- a/tests/unit/raft_functional_common.hxx
+++ b/tests/unit/raft_functional_common.hxx
@@ -25,6 +25,7 @@ limitations under the License.
 
 #include <cassert>
 #include <map>
+#include <sstream>
 
 #define INT_UNUSED      int ATTR_UNUSED
 #define VOID_UNUSED     void ATTR_UNUSED
@@ -365,14 +366,19 @@ private:
 };
 
 static VOID_UNUSED reset_log_files() {
+    std::stringstream ss;
+    for (size_t ii=1; ii<=4; ++ii) {
+        ss << "srv" + std::to_string(ii) + ".log ";
+    }
+
 #if defined(__linux__) || defined(__APPLE__)
-    std::string cmd = "rm -f base.log srv1.log srv2.log srv3.log 2> /dev/null";
+    std::string cmd = "rm -f base.log " + ss.str() + "2> /dev/null";
     FILE* fp = popen(cmd.c_str(), "r");
     int r = pclose(fp);
     (void)r;
 
 #elif defined(WIN32) || defined(_WIN32)
-    std::string cmd = "del /s /f /q base.log srv1.log srv2.log srv3.log > NUL";
+    std::string cmd = "del /s /f /q base.log " + ss.str() + "> NUL";
     int r = system(cmd.c_str());
     (void)r;
 

--- a/tests/unit/raft_package_fake.hxx
+++ b/tests/unit/raft_package_fake.hxx
@@ -125,13 +125,14 @@ public:
     ptr<raft_server> raftServer;
 };
 
-static INT_UNUSED launch_servers(const std::vector<RaftPkg*>& pkgs) {
+static INT_UNUSED launch_servers(const std::vector<RaftPkg*>& pkgs,
+                                 raft_params* custom_params = nullptr) {
     size_t num_srvs = pkgs.size();
     CHK_GT(num_srvs, 0);
 
     for (size_t ii = 0; ii < num_srvs; ++ii) {
         RaftPkg* ff = pkgs[ii];
-        ff->initServer();
+        ff->initServer(custom_params);
         ff->fNet->listen(ff->raftServer);
         ff->fTimer->invoke( timer_task_type::election_timer );
     }


### PR DESCRIPTION
* Once "yield leadership" is requested, the current leader chooses the
next leader. It pauses incoming writes, and waits until the next leader
candidate fully catches up the current latest log. After that, the
current leader sends a custom notification to that candidate.

* Once the next leader candidate receives the notification, it
immediately initiates a special vote which will ignore the current
priority, so that it can be the next leader quickly.