### PR TITLE
Allow zero-priority member to be temporary leader

### DIFF
--- a/include/libnuraft/raft_params.hxx
+++ b/include/libnuraft/raft_params.hxx
@@ -57,6 +57,7 @@ struct raft_params {
         , custom_commit_quorum_size_(0)
         , custom_election_quorum_size_(0)
         , leadership_expiry_(0)
+        , allow_temporary_zero_priority_leader_(true)
         , auto_forwarding_(false)
         , return_method_(blocking)
         {}
@@ -358,10 +359,18 @@ public:
     // (the same as the original Raft logic).
     int32 leadership_expiry_;
 
+    // If true, zero-priority member can initiate vote
+    // when leader is not elected long time (that can happen
+    // only the zero-priority member has the latest log).
+    // Once the zero-priority member becomes a leader,
+    // it will immediately yield leadership so that other
+    // higher priority node can takeover.
+    bool allow_temporary_zero_priority_leader_;
+
     // If true, follower node will forward client request
     // to the current leader.
     // Otherwise, it will return error to client immediately.
-    bool  auto_forwarding_;
+    bool auto_forwarding_;
 
     // To choose blocking call or asynchronous call.
     return_method_type return_method_;

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -476,6 +476,8 @@ protected:
     void handle_leave_cluster_resp(resp_msg& resp);
 
     bool handle_snapshot_sync_req(snapshot_sync_req& req);
+
+    bool check_cond_for_zp_election();
     void request_prevote();
     void initiate_vote(bool ignore_priority = false);
     void request_vote(bool ignore_priority);
@@ -567,6 +569,9 @@ protected:
 
     // Current target priority for vote, protected by `lock_`.
     int32 target_priority_;
+
+    // Timer that will be reset on `target_priority_` change.
+    timer_helper priority_change_timer_;
 
     // Number of servers responded my vote request, protected by `lock_`.
     int32 votes_responded_;

--- a/src/handle_priority.cxx
+++ b/src/handle_priority.cxx
@@ -205,6 +205,10 @@ void raft_server::decay_target_priority() {
     target_priority_ = std::max(1, target_priority_ - gap);
     p_in("[PRIORITY] decay, target %d -> %d, mine %d",
          prev_priority, target_priority_, my_priority_);
+
+    // Once `target_priority_` becomes 1,
+    // `priority_change_timer_` starts ticking.
+    if (prev_priority > 1) priority_change_timer_.reset();
 }
 
 void raft_server::update_target_priority() {
@@ -221,6 +225,7 @@ void raft_server::update_target_priority() {
     } else {
         target_priority_ = srv_config::INIT_PRIORITY;
     }
+    priority_change_timer_.reset();
 
     hb_alive_ = true;
     pre_vote_.reset(state_->get_term());

--- a/tests/unit/fake_network.cxx
+++ b/tests/unit/fake_network.cxx
@@ -69,6 +69,7 @@ FakeNetwork::FakeNetwork(const std::string& _endpoint,
     : myEndpoint(_endpoint)
     , base(_base)
     , handler(nullptr)
+    , online(true)
 {}
 
 ptr<rpc_client> FakeNetwork::create_client(const std::string& endpoint) {
@@ -151,6 +152,9 @@ bool FakeNetwork::delieverReqTo(const std::string& endpoint,
     // this:                    source (sending request)
     // conn->dstNet (endpoint): destination (sending response)
     ptr<FakeClient> conn = findClient(endpoint);
+
+    // If destination is offline, make failure.
+    if (!conn->isDstOnline()) return makeReqFail(endpoint, random_order);
 
     auto pkg_entry = conn->pendingReqs.begin();
     if (pkg_entry == conn->pendingReqs.end()) return false;
@@ -302,6 +306,11 @@ void FakeClient::send(ptr<req_msg>& req, rpc_handler& when_done) {
 void FakeClient::dropPackets() {
     pendingReqs.clear();
     pendingResps.clear();
+}
+
+bool FakeClient::isDstOnline() {
+    if (!dstNet) return false;
+    return dstNet->isOnline();
 }
 
 

--- a/tests/unit/fake_network.hxx
+++ b/tests/unit/fake_network.hxx
@@ -86,6 +86,12 @@ public:
 
     size_t getNumPendingResps(const std::string& endpoint);
 
+    void goesOffline() { online = false; }
+
+    void goesOnline() { online =  true; }
+
+    bool isOnline() const { return online; }
+
     void stop();
 
     void shutdown();
@@ -97,6 +103,7 @@ private:
     std::unordered_map< std::string, ptr<FakeClient> > clients;
     std::mutex clientsLock;
     std::list< ptr<FakeClient> > staleClients;
+    bool online;
 };
 
 class FakeNetworkBase {
@@ -133,6 +140,8 @@ public:
     void send(ptr<req_msg>& req, rpc_handler& when_done);
 
     void dropPackets();
+
+    bool isDstOnline();
 
 private:
     FakeNetwork* motherNet;

--- a/tests/unit/raft_functional_common.hxx
+++ b/tests/unit/raft_functional_common.hxx
@@ -368,7 +368,7 @@ private:
 static VOID_UNUSED reset_log_files() {
     std::stringstream ss;
     for (size_t ii=1; ii<=4; ++ii) {
-        ss << "srv" + std::to_string(ii) + ".log ";
+        ss << "srv" + std::to_string(ii) + ".log* ";
     }
 
 #if defined(__linux__) || defined(__APPLE__)


### PR DESCRIPTION
* There can be an edge case where zero-priority member is the only
node who has the latest log, while all the other nodes with the latest
log are offline. In such case, next leader will never be elected as
the zero-priority member will reject all vote request.

* In such case, the zero-priority member should be a temporary leader.
Once it becomes a leader, it should do graceful resignation immediately;
waits for catching-up and then sends leadership takeover request to the
highest priority node.

* Added a new parameter for this option, and enabled by default.