### PR TITLE
Fix to crash in response meta callback

### DIFF
--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -1298,7 +1298,7 @@ private:
                 ( cs_new<rpc_exception>
                   ( sstrfmt( "response meta verification failed: "
                              "from peer %d, %s:%s")
-                           .fmt( rsp->get_dst(), host_.c_str(),
+                           .fmt( req->get_dst(), host_.c_str(),
                                  port_.c_str() ),
                     req ) );
             close_socket();


### PR DESCRIPTION
* If response meta callback function returns `false`, it will cause
null pointer access.

* Added random denial test.