### PR TITLE
Add a new API for offline application of config log

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -33,6 +33,7 @@ limitations under the License.
 #include "timer_task.hxx"
 
 #include <map>
+#include <string>
 #include <unordered_map>
 
 namespace nuraft {
@@ -49,6 +50,7 @@ class req_msg;
 class resp_msg;
 class rpc_exception;
 class state_machine;
+class state_mgr;
 struct context;
 struct raft_params;
 class raft_server {
@@ -412,6 +414,23 @@ public:
      * Reset all existing stats to zero.
      */
     static void reset_all_stats();
+
+    /**
+     * Apply a log entry containing configuration change, while Raft
+     * server is not running.
+     * This API is only for recovery purpose, and user should
+     * make sure that when Raft server starts, the last committed
+     * index should be equal to or bigger than the index number of
+     * the last configuration log entry applied.
+     *
+     * @param le Log entry containing configuration change.
+     * @param s_mgr State manager instance.
+     * @param err_msg Will contain a message if error happens.
+     * @return `true` on success.
+     */
+    static bool apply_config_log_entry(ptr<log_entry>& le,
+                                       ptr<state_mgr>& s_mgr,
+                                       std::string& err_msg);
 
 protected:
     typedef std::unordered_map<int32, ptr<peer>>::const_iterator peer_itor;

--- a/tests/unit/raft_server_test.cxx
+++ b/tests/unit/raft_server_test.cxx
@@ -1953,13 +1953,13 @@ int apply_config_test() {
 
     // Shutdown S3, and do offline replay of pending configs.
 
+    std::string err_msg;
     {   // NULL argument should fail.
         ptr<log_entry> le;
         ptr<state_mgr> smgr;
         CHK_FALSE( raft_server::apply_config_log_entry( le, smgr, err_msg ) );
     }
 
-    std::string err_msg;
     size_t last_s3_commit = s3.sm->last_commit_index();
     ptr<log_store> s1_log_store = s1.sMgr->load_log_store();
     size_t last_log_idx = s1_log_store->next_slot() - 1;


### PR DESCRIPTION
* For recovery purpose, we need a feature to apply config logs while
Raft server is still offline.