### PR TITLE
Assign unique name to each worker thread

### DIFF
--- a/src/handle_commit.cxx
+++ b/src/handle_commit.cxx
@@ -83,6 +83,11 @@ void raft_server::commit(ulong target_idx) {
 }
 
 void raft_server::commit_in_bg() {
+#ifdef __linux__
+    std::string thread_name = "nuraft_commit";
+    pthread_setname_np(pthread_self(), thread_name.c_str());
+#endif
+
     while (true) {
      try {
         while ( quick_commit_index_ <= sm_commit_index_ ||


### PR DESCRIPTION
* To help debugging and profiling.