### PR TITLE
Fix a bug that new leader ignores uncommitted config change

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -275,6 +275,14 @@ public:
     { return is_leader() ? get_committed_log_idx() : leader_commit_index_.load(); }
 
     /**
+     * Calculate the log index to be committed
+     * from current peers' matched indexes.
+     *
+     * @return Expected committed log index.
+     */
+    ulong get_expected_committed_log_idx();
+
+    /**
      * Get the current Raft cluster config.
      *
      * @return Cluster config.

--- a/src/handle_commit.cxx
+++ b/src/handle_commit.cxx
@@ -53,8 +53,8 @@ void raft_server::commit(ulong target_idx) {
         }
     }
 
-    p_tr( "local log idx %lu, target_commit_dx %lu\n"
-          "quick_commit_index_ %lu, state_->get_commit_idx() %lu\n",
+    p_tr( "local log idx %lu, target_commit_idx %lu, "
+          "quick_commit_index_ %lu, state_->get_commit_idx() %lu",
           log_store_->next_slot() - 1, target_idx,
           quick_commit_index_.load(), sm_commit_index_.load() );
 

--- a/tests/unit/raft_package_fake.hxx
+++ b/tests/unit/raft_package_fake.hxx
@@ -44,8 +44,8 @@ public:
         {}
 
     ~RaftPkg() {
-        myLogWrapper->destroy();
-        fNet->shutdown();
+        if (myLogWrapper) myLogWrapper->destroy();
+        if (fNet) fNet->shutdown();
     }
 
     void initServer(raft_params* given_params = nullptr,

--- a/tests/unit/raft_server_test.cxx
+++ b/tests/unit/raft_server_test.cxx
@@ -182,7 +182,6 @@ int init_options_test() {
     RaftPkg s3(f_base, 3, s3_addr);
     std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
 
-
     size_t num_srvs = pkgs.size();
     CHK_GT(num_srvs, 0);
 


### PR DESCRIPTION
* When a new leader is elected before the config change from old leader
is committed, there was a bug that new leader ignores all uncommitted
config change.

* When a node becomes a new leader, it should scan all uncommitted
configs and generate a new config on top of the last one.