### PR TITLE
Separate user API from central lock

### DIFF
--- a/include/libnuraft/async.hxx
+++ b/include/libnuraft/async.hxx
@@ -46,7 +46,7 @@ enum cmd_result_code {
     CONFIG_CHANGING = -6,
     SERVER_IS_JOINING = -7,
     SERVER_NOT_FOUND = -8,
-    CANNOT_REMOVE_LEADER = 9,
+    CANNOT_REMOVE_LEADER = -9,
 
     FAILED = -32768,
 };

--- a/include/libnuraft/context.hxx
+++ b/include/libnuraft/context.hxx
@@ -60,12 +60,12 @@ public:
     }
 
     ptr<raft_params> get_params() const {
-        std::lock_guard<std::mutex> l(lock_);
+        std::lock_guard<std::mutex> l(ctx_lock_);
         return params_;
     }
 
     void set_params(ptr<raft_params>& to) {
-        std::lock_guard<std::mutex> l(lock_);
+        std::lock_guard<std::mutex> l(ctx_lock_);
         params_ = to;
     }
 
@@ -97,7 +97,7 @@ public:
     cb_func cb_func_;
 
     // Lock.
-    mutable std::mutex lock_;
+    mutable std::mutex ctx_lock_;
 };
 
 }

--- a/include/libnuraft/error_code.hxx
+++ b/include/libnuraft/error_code.hxx
@@ -47,6 +47,7 @@ enum raft_err {
     N20_background_commit_err = -20,
     N21_log_flush_failed = -21,
     N22_unrecoverable_isolation = -22,
+    N23_precommit_order_inversion = -23,
 };
 
 extern const char * raft_err_msg[];

--- a/include/libnuraft/pp_util.hxx
+++ b/include/libnuraft/pp_util.hxx
@@ -37,7 +37,7 @@ limitations under the License.
     __nocopy__(clazz)
 
 #define auto_lock(lock)     std::lock_guard<std::mutex> guard(lock)
-#define recur_lock(lock)    std::lock_guard<std::recursive_mutex> guard(lock)
+#define recur_lock(lock)    std::unique_lock<std::recursive_mutex> guard(lock)
 
 #define sz_int      sizeof(int32)
 #define sz_ulong    sizeof(ulong)

--- a/src/error_code.cxx
+++ b/src/error_code.cxx
@@ -44,6 +44,7 @@ const char * raft_err_msg[] = {
     "N20: Background committing thread encounter err.",
     "N21: Log store flush failed.",
     "N22: This node does not get messages from leader, while the others do."
+    "N23: Commit is invoked before pre-commit, order inversion happened."
 };
 
 } // namespace nuraft;

--- a/src/handle_client_request.cxx
+++ b/src/handle_client_request.cxx
@@ -32,12 +32,47 @@ limitations under the License.
 
 namespace nuraft {
 
+ptr<resp_msg> raft_server::handle_cli_req_prelock(req_msg& req) {
+    ptr<resp_msg> resp = nullptr;
+    ptr<raft_params> params = ctx_->get_params();
+    switch (params->locking_method_type_) {
+        case raft_params::single_mutex: {
+            recur_lock(lock_);
+            resp = handle_cli_req(req);
+            break;
+        }
+        case raft_params::dual_mutex:
+        default: {
+            // TODO: Use RW lock here.
+            auto_lock(cli_lock_);
+            resp = handle_cli_req(req);
+            break;
+        }
+    }
+
+    // Urgent commit, so that the commit will not depend on hb.
+    if (params->use_bg_thread_for_urgent_commit_) {
+        // Let background generate request (some delay may happen).
+        bg_append_ea_->invoke();
+    } else {
+        // Directly generate request in user thread.
+        recur_lock(lock_);
+        request_append_entries();
+    }
+    return resp;
+}
+
 ptr<resp_msg> raft_server::handle_cli_req(req_msg& req) {
-    ptr<resp_msg> resp = cs_new<resp_msg>
-                         ( state_->get_term(),
-                           msg_type::append_entries_response,
-                           id_,
-                           leader_ );
+    ptr<resp_msg> resp = nullptr;
+    ulong last_idx = 0;
+    ptr<buffer> ret_value = nullptr;
+    ulong resp_idx = 1;
+    ulong cur_term = state_->get_term();
+
+    resp = cs_new<resp_msg>( cur_term,
+                             msg_type::append_entries_response,
+                             id_,
+                             leader_ );
     if (role_ != srv_role::leader || write_paused_) {
         resp->set_result_code( cmd_result_code::NOT_LEADER );
         return resp;
@@ -45,12 +80,10 @@ ptr<resp_msg> raft_server::handle_cli_req(req_msg& req) {
 
     std::vector< ptr<log_entry> >& entries = req.log_entries();
     size_t num_entries = entries.size();
-    ulong last_idx = 0;
-    ptr<buffer> ret_value = nullptr;
 
     for (size_t i = 0; i < num_entries; ++i) {
         // force the log's term to current term
-        entries.at(i)->set_term(state_->get_term());
+        entries.at(i)->set_term(cur_term);
 
         ulong next_slot = store_log_entry(entries.at(i));
         p_db("append at log_idx %d\n", (int)next_slot);
@@ -64,6 +97,8 @@ ptr<resp_msg> raft_server::handle_cli_req(req_msg& req) {
     if (num_entries) {
         log_store_->end_of_append_batch(last_idx - num_entries, num_entries);
     }
+    precommit_index_ = last_idx;
+    resp_idx = log_store_->next_slot();
 
     // Finished appending logs and pre_commit of itself.
     cb_func::Param param(id_, leader_);
@@ -79,7 +114,13 @@ ptr<resp_msg> raft_server::handle_cli_req(req_msg& req) {
         elem->result_code_ = cmd_result_code::TIMEOUT;
 
         {   auto_lock(commit_ret_elems_lock_);
-            commit_ret_elems_.insert( std::make_pair(last_idx, elem) );
+            auto entry = commit_ret_elems_.find(last_idx);
+            if (entry != commit_ret_elems_.end()) {
+                // Commit thread was faster than this.
+                elem = entry->second;
+            } else {
+                commit_ret_elems_.insert( std::make_pair(last_idx, elem) );
+            }
 
             switch (ctx_->get_params()->return_method_) {
             case raft_params::blocking:
@@ -93,7 +134,9 @@ ptr<resp_msg> raft_server::handle_cli_req(req_msg& req) {
 
             case raft_params::async_handler:
                 // Async handler: create & set async result object.
-                elem->async_result_ = cs_new< cmd_result< ptr<buffer> > >();
+                if (!elem->async_result_) {
+                    elem->async_result_ = cs_new< cmd_result< ptr<buffer> > >();
+                }
                 resp->set_async_cb
                       ( std::bind( &raft_server::handle_cli_req_callback_async,
                                    this,
@@ -110,10 +153,7 @@ ptr<resp_msg> raft_server::handle_cli_req(req_msg& req) {
         resp->set_ctx(ret_value);
     }
 
-    // urgent commit, so that the commit will not depend on hb
-    request_append_entries();
-    resp->accept(log_store_->next_slot());
-
+    resp->accept(resp_idx);
     return resp;
 }
 
@@ -136,11 +176,11 @@ ptr<resp_msg> raft_server::handle_cli_req_callback(ptr<commit_ret_elem> elem,
     }
 
     if (elem->result_code_ == cmd_result_code::OK) {
-        p_dv( "[OK] commit_ret_cv %lu wake up (%lu us), return value %p\n",
+        p_dv( "[OK] commit_ret_cv %lu wake up (%zu us), return value %p\n",
               idx, elapsed_us, ret_value.get() );
     } else {
         // Null `ret_value`, most likely timeout.
-        p_wn( "[NOT OK] commit_ret_cv %lu wake up (%lu us), "
+        p_wn( "[NOT OK] commit_ret_cv %lu wake up (%zu us), "
               "return value %p, result code %d\n",
               idx, elapsed_us, ret_value.get(), elem->result_code_ );
         bool valid_leader = check_leadership_validity();
@@ -176,6 +216,7 @@ void raft_server::drop_all_pending_commit_elems() {
             p_wn("cancelled blocking client request %zu, waited %zu us",
                  elem->idx_, elem->timer_.get_us());
         }
+        commit_ret_elems_.clear();
         return;
     }
 

--- a/src/handle_join_leave.cxx
+++ b/src/handle_join_leave.cxx
@@ -300,6 +300,7 @@ ptr<resp_msg> raft_server::handle_log_sync_req(req_msg& req) {
 
     log_store_->apply_pack(req.get_last_log_idx() + 1, entries[0]->get_buf());
     p_db("last log %ld\n", log_store_->next_slot() - 1);
+    precommit_index_ = log_store_->next_slot() - 1;
     commit(log_store_->next_slot() - 1);
     resp->accept(log_store_->next_slot());
     return resp;

--- a/src/handle_snapshot_sync.cxx
+++ b/src/handle_snapshot_sync.cxx
@@ -194,12 +194,12 @@ ptr<resp_msg> raft_server::handle_install_snapshot_req(req_msg& req) {
         }
     }
 
-    ptr<resp_msg> resp( cs_new<resp_msg>
-                        ( state_->get_term(),
-                          msg_type::install_snapshot_response,
-                          id_,
-                          req.get_src(),
-                          log_store_->next_slot() ) );
+    ptr<resp_msg> resp = cs_new<resp_msg>
+                         ( state_->get_term(),
+                           msg_type::install_snapshot_response,
+                           id_,
+                           req.get_src(),
+                           log_store_->next_slot() );
 
     if (!catching_up_ && req.get_term() < state_->get_term()) {
         p_wn("received an install snapshot request (%zu) which has lower term "
@@ -216,8 +216,8 @@ ptr<resp_msg> raft_server::handle_install_snapshot_req(req_msg& req) {
         return resp;
     }
 
-    ptr<snapshot_sync_req> sync_req
-        ( snapshot_sync_req::deserialize(entries[0]->get_buf()) );
+    ptr<snapshot_sync_req> sync_req =
+        snapshot_sync_req::deserialize(entries[0]->get_buf());
     if (sync_req->get_snapshot().get_last_log_idx() <= sm_commit_index_) {
         p_wn( "received a snapshot (%zu) that is older than "
               "current commit idx (%zu), last log idx %zu",
@@ -494,6 +494,7 @@ bool raft_server::handle_snapshot_sync_req(snapshot_sync_req& req) {
             ptr<cluster_config> c_conf = get_config();
             ctx_->state_mgr_->save_config(*c_conf);
 
+            precommit_index_ = req.get_snapshot().get_last_log_idx();
             sm_commit_index_ = req.get_snapshot().get_last_log_idx();
             quick_commit_index_ = req.get_snapshot().get_last_log_idx();
 

--- a/src/handle_timeout.cxx
+++ b/src/handle_timeout.cxx
@@ -300,7 +300,7 @@ void raft_server::schedule_task(ptr<delayed_task>& task, int32 milliseconds) {
     if (stopping_) return;
 
     if (!scheduler_) {
-        std::lock_guard<std::mutex> l(ctx_->lock_);
+        std::lock_guard<std::mutex> l(ctx_->ctx_lock_);
         scheduler_ = ctx_->scheduler_;
     }
     if (scheduler_) {

--- a/src/peer.cxx
+++ b/src/peer.cxx
@@ -143,7 +143,7 @@ void peer::recreate_rpc(ptr<srv_config>& config,
     if (abandoned_) return;
 
     ptr<rpc_client_factory> factory = nullptr;
-    {   std::lock_guard<std::mutex> l(ctx.lock_);
+    {   std::lock_guard<std::mutex> l(ctx.ctx_lock_);
         factory = ctx.rpc_cli_factory_;
     }
     if (!factory) return;

--- a/tests/unit/raft_functional_common.hxx
+++ b/tests/unit/raft_functional_common.hxx
@@ -359,6 +359,7 @@ public:
         return myId;
     }
     void system_exit(const int exit_code) {
+        abort();
     }
 
     ptr<srv_config> get_srv_config() const { return mySrvConfig; }

--- a/tests/unit/raft_package_fake.hxx
+++ b/tests/unit/raft_package_fake.hxx
@@ -79,6 +79,8 @@ public:
         } else {
             params = *given_params;
         }
+        // For deterministic test, we should not use BG thread.
+        params.use_bg_thread_for_urgent_commit_ = false;
 
         ctx = new context( sMgr, sm, listener, myLog,
                            rpcCliFactory, scheduler, params );


### PR DESCRIPTION
* Added a new background thread to create append_entries request.

* Now `append_entries` request will not grab `lock_` by default.

* Above options are configurable.