### PR TITLE
Fix to bug regarding stepping down newly added node

### DIFF
--- a/tests/unit/fake_network.cxx
+++ b/tests/unit/fake_network.cxx
@@ -142,7 +142,7 @@ bool FakeNetwork::execReqResp(const std::string& endpoint) {
 ptr<FakeClient> FakeNetwork::findClient(const std::string& endpoint) {
     std::lock_guard<std::mutex> ll(clientsLock);
     auto entry = clients.find(endpoint);
-    assert(entry != clients.end());
+    if (entry == clients.end()) return nullptr;
     return entry->second;
 }
 
@@ -262,11 +262,13 @@ void FakeNetwork::handleAllFrom(const std::string& endpoint) {
 
 size_t FakeNetwork::getNumPendingReqs(const std::string& endpoint) {
     ptr<FakeClient> conn = findClient(endpoint);
+    if (!conn) return 0;
     return conn->pendingReqs.size();
 }
 
 size_t FakeNetwork::getNumPendingResps(const std::string& endpoint) {
     ptr<FakeClient> conn = findClient(endpoint);
+    if (!conn) return 0;
     return conn->pendingResps.size();
 }
 

--- a/tests/unit/raft_functional_common.hxx
+++ b/tests/unit/raft_functional_common.hxx
@@ -375,7 +375,7 @@ private:
 
 static VOID_UNUSED reset_log_files() {
     std::stringstream ss;
-    for (size_t ii=1; ii<=4; ++ii) {
+    for (size_t ii=1; ii<=10; ++ii) {
         ss << "srv" + std::to_string(ii) + ".log* ";
     }
 

--- a/tests/unit/raft_package_fake.hxx
+++ b/tests/unit/raft_package_fake.hxx
@@ -167,7 +167,15 @@ static INT_UNUSED make_group(const std::vector<RaftPkg*>& pkgs) {
 
         // Heartbeat.
         leader->fTimer->invoke( timer_task_type::heartbeat_timer );
-        // Heartbeat req/resp, to finish the catch-up phase.
+        // The new node receives the commit of
+        // the new config (membership change), and now be the part of cluster.
+        leader->fNet->execReqResp();
+        // Wait for bg commit for new node.
+        TestSuite::sleep_ms(COMMIT_TIME_MS);
+
+        // One more heartbeat.
+        leader->fTimer->invoke( timer_task_type::heartbeat_timer );
+        // New node will clear the catch-up flag.
         leader->fNet->execReqResp();
         // Need one-more req/resp.
         leader->fNet->execReqResp();


### PR DESCRIPTION
* Once a new node is added to existing cluster, it should clear the
`catching_up_` flag only after it is successfully added to the
cluster member list (i.e., config commit). Otherwise, there might be
any prior membership change configs that is already outdated so that
does not contain the new node. Then new node will treat it as an
abandon from the cluster so that step down itself.