### PR TITLE
Throw exception on listener creation error

### DIFF
--- a/examples/example_common.hxx
+++ b/examples/example_common.hxx
@@ -193,6 +193,12 @@ void init_raft(ptr<state_machine> sm_instance) {
                                                 stuff.port_,
                                                 asio_opt,
                                                 params);
+    if (!stuff.raft_instance_) {
+        std::cerr << "Failed to initialize launcher (see the message "
+                     "in the log file)." << std::endl;
+        log_wrap.reset();
+        exit(-1);
+    }
 
     // Wait until Raft server is ready (upto 5 seconds).
     const size_t MAX_TRY = 20;
@@ -207,6 +213,7 @@ void init_raft(ptr<state_machine> sm_instance) {
         TestSuite::sleep_ms(250);
     }
     std::cout << " FAILED" << std::endl;
+    log_wrap.reset();
     exit(-1);
 }
 

--- a/include/libnuraft/launcher.hxx
+++ b/include/libnuraft/launcher.hxx
@@ -38,6 +38,7 @@ public:
      * @param asio_options ASIO options.
      * @param params Raft parameters.
      * @return Raft server instance.
+     *         `nullptr` on any errors.
      */
     ptr<raft_server> init(ptr<state_machine> sm,
                           ptr<state_mgr> smgr,

--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -1611,12 +1611,18 @@ ptr<rpc_client> asio_service::create_client(const std::string& endpoint) {
 ptr<rpc_listener> asio_service::create_rpc_listener( ushort listening_port,
                                                      ptr<logger>& l )
 {
-    return cs_new< asio_rpc_listener >
-                 ( impl_,
-                   impl_->io_svc_,
-                   impl_->ssl_server_ctx_,
-                   listening_port,
-                   impl_->my_opt_.enable_ssl_,
-                   l );
+    try {
+        return cs_new< asio_rpc_listener >
+                     ( impl_,
+                       impl_->io_svc_,
+                       impl_->ssl_server_ctx_,
+                       listening_port,
+                       impl_->my_opt_.enable_ssl_,
+                       l );
+    } catch (std::exception& ee) {
+        // Most likely exception happens due to wrong endpoint.
+        p_er("got exception: %s", ee.what());
+        return nullptr;
+    }
 }
 

--- a/src/launcher.cxx
+++ b/src/launcher.cxx
@@ -36,6 +36,8 @@ ptr<raft_server> raft_launcher::init(ptr<state_machine> sm,
 {
     asio_svc_ = cs_new<asio_service>(asio_options, lg);
     asio_listener_ = asio_svc_->create_rpc_listener(port_number, lg);
+    if (!asio_listener_) return nullptr;
+
     ptr<delayed_task_scheduler> scheduler = asio_svc_;
     ptr<rpc_client_factory> rpc_cli_factory = asio_svc_;
 


### PR DESCRIPTION
* Most likely wrong endpoint causes exception. We should gracefully
handle it.