### PR TITLE
Add new state: election_timer_allowed

### DIFF
--- a/include/libnuraft/srv_state.hxx
+++ b/include/libnuraft/srv_state.hxx
@@ -22,6 +22,7 @@ limitations under the License.
 #define _SRV_STATE_HXX_
 
 #include "basic_types.hxx"
+#include "buffer_serializer.hxx"
 
 #include <atomic>
 
@@ -32,20 +33,40 @@ public:
     srv_state()
         : term_(0L)
         , voted_for_(-1)
+        , election_timer_allowed_(true)
         {}
 
-    srv_state(ulong term, int voted_for)
+    srv_state(ulong term, int voted_for, bool et_allowed)
         : term_(term)
         , voted_for_(voted_for)
+        , election_timer_allowed_(et_allowed)
         {}
 
     __nocopy__(srv_state);
 
 public:
     static ptr<srv_state> deserialize(buffer& buf) {
+        if (buf.size() > sz_ulong + sz_int) {
+            return deserialize_v1p(buf);
+        }
+        // Backward compatibility.
+        return deserialize_v0(buf);
+    }
+
+    static ptr<srv_state> deserialize_v0(buffer& buf) {
         ulong term = buf.get_ulong();
         int voted_for = buf.get_int();
-        return cs_new<srv_state>(term, voted_for);
+        return cs_new<srv_state>(term, voted_for, true);
+    }
+
+    static ptr<srv_state> deserialize_v1p(buffer& buf) {
+        buffer_serializer bs(buf);
+        uint8_t ver = bs.get_u8();
+        (void)ver;
+        ulong term = bs.get_u64();
+        int voted_for = bs.get_i32();
+        bool et_allowed = (bs.get_u8() == 1);
+        return cs_new<srv_state>(term, voted_for, et_allowed);
     }
 
     ulong   get_term() const        { return term_; }
@@ -55,7 +76,19 @@ public:
     int     get_voted_for() const           { return voted_for_; }
     void    set_voted_for(int voted_for)    { voted_for_ = voted_for; }
 
+    bool is_election_timer_allowed() const {
+        return election_timer_allowed_;
+    }
+
+    void allow_election_timer(bool to) {
+        election_timer_allowed_ = to;
+    }
+
     ptr<buffer> serialize() const {
+        return serialize_v1p(CURRENT_VERSION);
+    }
+
+    ptr<buffer> serialize_v0() const {
         ptr<buffer> buf = buffer::alloc(sz_ulong + sz_int);
         buf->put(term_);
         buf->put(voted_for_);
@@ -63,9 +96,36 @@ public:
         return buf;
     }
 
+    ptr<buffer> serialize_v1p(size_t version) const {
+        //   << Format >>
+        // version          1 byte
+        // term             8 bytes
+        // voted_for        4 bytes
+        // election timer   1 byte
+        ptr<buffer> buf = buffer::alloc( sizeof(uint8_t) +
+                                         sizeof(uint64_t) +
+                                         sizeof(int32_t) +
+                                         sizeof(uint8_t) );
+        buffer_serializer bs(buf);
+        bs.put_u8(version);
+        bs.put_u64(term_);
+        bs.put_i32(voted_for_);
+        bs.put_u8( election_timer_allowed_ ? 1 : 0 );
+        return buf;
+    }
+
 private:
+    const uint8_t CURRENT_VERSION = 1;
+
+    // Term.
     std::atomic<ulong> term_;
+
+    // Server ID that this server voted for.
+    // `-1` if not voted.
     std::atomic<int> voted_for_;
+
+    // `true` if election timer is allowed.
+    std::atomic<bool> election_timer_allowed_;
 };
 
 }

--- a/src/handle_timeout.cxx
+++ b/src/handle_timeout.cxx
@@ -23,6 +23,7 @@ limitations under the License.
 #include "event_awaiter.h"
 #include "peer.hxx"
 #include "state_machine.hxx"
+#include "state_mgr.hxx"
 #include "tracer.hxx"
 
 #include <cassert>
@@ -171,6 +172,8 @@ void raft_server::handle_election_timeout() {
                 }
             }
             */
+            state_->allow_election_timer(false);
+            ctx_->state_mgr_->save_state(*state_);
             reset_peer_info();
             cancel_schedulers();
             return;


### PR DESCRIPTION
* We need a state that a server in a single-node cluster doesn't
trigger leader election to avoid being a self-elected leader. And
this state should be persistent, even after process restart.

* This state can be used for removed server: which already stepped
down itself. It shouldn't be a leader after process restart.