### PR TITLE
Allow election timer on restart_election_timer API

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -194,6 +194,8 @@ public:
 
     /**
      * Start the election timer on this server, if this server is a follower.
+     * It will allow the election timer permanently, if it was disabled
+     * by state manager.
      */
     void restart_election_timer();
 

--- a/src/handle_timeout.cxx
+++ b/src/handle_timeout.cxx
@@ -120,6 +120,12 @@ void raft_server::restart_election_timer() {
         return;
     }
 
+    // If election timer was not allowed, clear the flag.
+    if (!state_->is_election_timer_allowed()) {
+        state_->allow_election_timer(true);
+        ctx_->state_mgr_->save_state(*state_);
+    }
+
     if (election_task_) {
         p_tr("cancel existing timer");
         cancel_task(election_task_);

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -960,10 +960,6 @@ bool raft_server::update_term(ulong term) {
         become_follower();
         return true;
     }
-    if (!state_->is_election_timer_allowed()) {
-        state_->allow_election_timer(true);
-        ctx_->state_mgr_->save_state(*state_);
-    }
     return false;
 }
 


### PR DESCRIPTION
* Election timer flag should be updated on election timer restart,
as the flag will not be effective anymore if timer is initiated.