### PR TITLE
Fix an issue on `uncommitted_conf_new_leader_test`

### DIFF
--- a/tests/unit/failure_test.cxx
+++ b/tests/unit/failure_test.cxx
@@ -404,6 +404,7 @@ int uncommitted_conf_new_leader_test() {
     // Replicate to all.
     for (size_t ii=0; ii<=NUM_APPENDS_1; ++ii) {
         s1.fNet->execReqResp();
+        s1.fNet->execReqResp();
     }
     TestSuite::sleep_ms(COMMIT_TIME_MS);
 


### PR DESCRIPTION
* There shouldn't be in-flight req/resp before removing server, for
deterministic testing (the traversal order of unordered_map in Mac is
different to that in Linux).