### PR TITLE
Do not remove server from peer list immediately

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -537,6 +537,7 @@ protected:
     void handle_ext_resp_err(rpc_exception& err);
     void handle_join_leave_rpc_err(msg_type t_msg, ptr<peer> p);
     void reset_srv_to_join();
+    void reset_srv_to_leave();
     ptr<req_msg> create_append_entries_req(peer& p);
     ptr<req_msg> create_sync_snapshot_req(peer& p,
                                           ulong last_log_idx,
@@ -587,6 +588,8 @@ protected:
     ptr<resp_msg> handle_leadership_takeover(req_msg& req,
                                              ptr<custom_notification_msg> msg,
                                              ptr<resp_msg> resp);
+
+    void remove_peer_from_peers(const ptr<peer>& pp);
 
 protected:
     static const int default_snapshot_sync_block_size;
@@ -785,6 +788,15 @@ protected:
     // Server that is preparing to join,
     // protected by `lock_`.
     ptr<peer> srv_to_join_;
+
+    // Server that is agreed to leave,
+    // protected by `lock_`.
+    ptr<peer> srv_to_leave_;
+
+    // Target log index number containing the config that
+    // this server is actually removed.
+    // Connection to `srv_to_leave_` should be kept until this log.
+    ulong srv_to_leave_target_idx_;
 
     // Config of the server preparing to join,
     // protected by `lock_`.

--- a/src/handle_join_leave.cxx
+++ b/src/handle_join_leave.cxx
@@ -407,17 +407,6 @@ void raft_server::handle_leave_cluster_resp(resp_msg& resp) {
 }
 
 void raft_server::rm_srv_from_cluster(int32 srv_id) {
-    // WARNING: before removing server from configuration,
-    //          set step down flag of the peer first
-    //          to avoid HB handler doing something with it.
-    auto pit = peers_.find(srv_id);
-    if (pit == peers_.end()) {
-        p_er("trying to remove server %d, but it does not exist now", srv_id);
-    } else {
-        ptr<peer> pp = pit->second;
-        pp->step_down();
-    }
-
     ptr<cluster_config> cur_conf = get_config();
 
     // NOTE: Need to honor uncommitted config,
@@ -510,6 +499,11 @@ void raft_server::reset_srv_to_join() {
         state_machine_->free_user_snp_ctx(user_ctx);
     }
     srv_to_join_.reset();
+}
+
+void raft_server::reset_srv_to_leave() {
+    srv_to_leave_.reset();
+    srv_to_leave_target_idx_ = 0;
 }
 
 } // namespace nuraft;

--- a/src/handle_timeout.cxx
+++ b/src/handle_timeout.cxx
@@ -77,8 +77,6 @@ void raft_server::handle_hb_timeout(int32 srv_id) {
         }
     }
 
-    if (p->is_stepping_down()) return;
-
     cb_func::Param param(id_, leader_, p->get_id());
     uint64_t last_log_idx = log_store_->next_slot() - 1;
     param.ctx = &last_log_idx;

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -79,6 +79,8 @@ raft_server::raft_server(context* ctx, const init_options& opt)
     , config_(ctx->state_mgr_->load_config())
     , uncommitted_config_(nullptr)
     , srv_to_join_(nullptr)
+    , srv_to_leave_(nullptr)
+    , srv_to_leave_target_idx_(0)
     , conf_to_add_(nullptr)
     , resp_handler_( (rpc_handler)std::bind( &raft_server::handle_peer_resp,
                                              this,
@@ -366,6 +368,14 @@ void raft_server::shutdown() {
         ctx_->rpc_listener_.reset();
         ctx_->rpc_cli_factory_.reset();
         ctx_->scheduler_.reset();
+    }
+
+    // Server to join/leave.
+    if (srv_to_join_) {
+        reset_srv_to_join();
+    }
+    if (srv_to_leave_) {
+        reset_srv_to_leave();
     }
 
     // Wait for BG commit thread.


### PR DESCRIPTION
* We should not remove the server from the list immediately,
due to the issue as follows:

0) Let's suppose there are 3 servers: S1, S2, and S3,
   where S1 is the leader and S3 is going to leave.
1) Generate a conf log for removing server S3.
2) The conf log is committed by S1 and S2 only.
3) Before delivering the conf log to S3, S1 removes
   the S3 peer info from the list.
4) It closes the connection to S3.
5) S3 cannot commit the config (containing removing S3).
6) Callback function for `RemovedFromCluster` will be missing,
   but S3 will step down itself after 2 timeout period.

* To address it, we will remove S3 only after the commit index
of the last config is delivered to S3. Also we will have timeout
for it. If we fail to deliver the commit index, S3 will be just
force removed.