### PR TITLE
Do not count to-be-removed server in quorum

### DIFF
--- a/include/libnuraft/async.hxx
+++ b/include/libnuraft/async.hxx
@@ -37,18 +37,19 @@ limitations under the License.
 namespace nuraft {
 
 enum cmd_result_code {
-    OK = 0,
-    CANCELLED = -1,
-    TIMEOUT = -2,
-    NOT_LEADER = -3,
-    BAD_REQUEST = -4,
-    SERVER_ALREADY_EXISTS = -5,
-    CONFIG_CHANGING = -6,
-    SERVER_IS_JOINING = -7,
-    SERVER_NOT_FOUND = -8,
-    CANNOT_REMOVE_LEADER = -9,
+    OK                              =  0,
+    CANCELLED                       = -1,
+    TIMEOUT                         = -2,
+    NOT_LEADER                      = -3,
+    BAD_REQUEST                     = -4,
+    SERVER_ALREADY_EXISTS           = -5,
+    CONFIG_CHANGING                 = -6,
+    SERVER_IS_JOINING               = -7,
+    SERVER_NOT_FOUND                = -8,
+    CANNOT_REMOVE_LEADER            = -9,
+    SERVER_IS_LEAVING               = -10,
 
-    FAILED = -32768,
+    FAILED                          = -32768,
 };
 
 template< typename T,

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -482,6 +482,7 @@ protected:
     bool check_leadership_validity();
     void update_rand_timeout();
 
+    bool is_regular_member(const ptr<peer>& p);
     int32 get_num_voting_members();
     int32 get_quorum_for_election();
     int32 get_quorum_for_commit();
@@ -552,6 +553,7 @@ protected:
     void reconnect_client(peer& p);
     void become_leader();
     void become_follower();
+    void check_srv_to_leave_timeout();
     void enable_hb_for_peer(peer& p);
     void stop_election_timer();
     void handle_hb_timeout(int32 srv_id);

--- a/src/handle_commit.cxx
+++ b/src/handle_commit.cxx
@@ -609,10 +609,8 @@ void raft_server::reconfigure(const ptr<cluster_config>& new_config) {
             // commit index, S3 will be just force removed.
 
             if (role_ == srv_role::leader) {
-                srv_to_leave_ = pit->second;
-                srv_to_leave_target_idx_ = new_config->get_log_idx();
-                p_in("server %d will be removed from cluster, config %zu",
-                     srv_removed, srv_to_leave_target_idx_);
+                // If leader, keep the to-be-removed server in peer list
+                // until 1) catch-up is done, or 2) timeout.
             } else {
                 remove_peer_from_peers(pit->second);
                 sprintf(temp_buf, "remove peer %d\n", srv_removed);

--- a/src/handle_vote.cxx
+++ b/src/handle_vote.cxx
@@ -48,7 +48,7 @@ void raft_server::request_prevote() {
     ptr<cluster_config> c_config = get_config();
     for (peer_itor it = peers_.begin(); it != peers_.end(); ++it) {
         ptr<peer> pp = it->second;
-        if (pp->is_learner()) continue;
+        if (!is_regular_member(pp)) continue;
         ptr<srv_config> s_config = c_config->get_server( pp->get_id() );
 
         if (s_config) {
@@ -94,7 +94,7 @@ void raft_server::request_prevote() {
 
     for (peer_itor it = peers_.begin(); it != peers_.end(); ++it) {
         ptr<peer> pp = it->second;
-        if (pp->is_learner()) {
+        if (!is_regular_member(pp)) {
             // Do not send voting request to learner.
             continue;
         }
@@ -152,7 +152,7 @@ void raft_server::request_vote(bool ignore_priority) {
 
     for (peer_itor it = peers_.begin(); it != peers_.end(); ++it) {
         ptr<peer> pp = it->second;
-        if (pp->is_learner()) {
+        if (!is_regular_member(pp)) {
             // Do not send voting request to learner.
             continue;
         }

--- a/tests/unit/failure_test.cxx
+++ b/tests/unit/failure_test.cxx
@@ -478,14 +478,7 @@ int removed_server_late_step_down_test() {
     CHK_Z( launch_servers( pkgs ) );
     CHK_Z( make_group( pkgs ) );
 
-    // Try to remove s3 from non leader, should return error.
-    ptr< cmd_result< ptr<buffer> > > ret =
-        s2.raftServer->remove_srv( s3.getTestMgr()->get_srv_config()->get_id() );
-    CHK_FALSE( ret->get_accepted() );
-    CHK_EQ( cmd_result_code::NOT_LEADER, ret->get_result_code() );
-
     // Remove s3 from leader.
-    s1.dbgLog(" --- remove ---");
     s1.raftServer->remove_srv( s3.getTestMgr()->get_srv_config()->get_id() );
 
     // Leave req/resp.
@@ -511,6 +504,11 @@ int removed_server_late_step_down_test() {
             CHK_EQ(3, configs.size());
         }
     }
+
+    // Removing server again should fail.
+    ptr< cmd_result< ptr<buffer> > > ret =
+        s1.raftServer->remove_srv( s3.getTestMgr()->get_srv_config()->get_id() );
+    CHK_FALSE(ret->get_accepted());
 
     // More catch-up for to-be-removed server.
     s1.fNet->execReqResp();

--- a/tests/unit/raft_server_test.cxx
+++ b/tests/unit/raft_server_test.cxx
@@ -592,7 +592,7 @@ int remove_node_error_cases_test() {
         // Leave req/resp.
         s1.fNet->execReqResp();
 
-        // Now config change is in progress, add S3 to S1.
+        // Now config change is in progress, remove S3.
         ptr<raft_result> ret = s1.raftServer->remove_srv(s3.myId);
 
         // May fail (depends on commit thread wake-up timing).
@@ -600,9 +600,6 @@ int remove_node_error_cases_test() {
         if (ret->get_result_code() == cmd_result_code::OK) {
             // If succeed, S3 is also removed.
             expected_cluster_size = 1;
-        } else {
-            // If not, error code should be CONFIG_CHANGNING.
-            CHK_EQ( cmd_result_code::CONFIG_CHANGING, ret->get_result_code() );
         }
 
         // Finish the task.


### PR DESCRIPTION
* To-be-removed server should be treated the same as learner.

* Set `srv_to_leave_` earlier than commit, to reduce one RPC to remove
a server.