### PR TITLE
Fix a bug on handling removing server RPC error

### DIFF
--- a/src/handle_commit.cxx
+++ b/src/handle_commit.cxx
@@ -507,6 +507,7 @@ void raft_server::reconfigure(const ptr<cluster_config>& new_config) {
         }
         if (id_ == (*it)->get_id()) {
             my_priority_ = (*it)->get_priority();
+            steps_to_down_ = 0;
             if (role_ == srv_role::follower &&
                 catching_up_) {
                 // If this node is newly added, start election timer
@@ -594,6 +595,7 @@ void raft_server::reconfigure(const ptr<cluster_config>& new_config) {
             CbReturnCode rc = ctx_->cb_func_.call( cb_func::RemovedFromCluster,
                                                    &param );
             (void)rc;
+            steps_to_down_ = 2;
         }
 
         peer_itor pit = peers_.find(srv_removed);

--- a/src/handle_join_leave.cxx
+++ b/src/handle_join_leave.cxx
@@ -415,6 +415,13 @@ void raft_server::handle_leave_cluster_resp(resp_msg& resp) {
 }
 
 void raft_server::rm_srv_from_cluster(int32 srv_id) {
+    if (srv_to_leave_) {
+        p_wn("to-be-removed server %d already exists, "
+             "cannot remove server %d for now",
+             srv_to_leave_->get_id(), srv_id);
+        return;
+    }
+
     ptr<cluster_config> cur_conf = get_config();
 
     // NOTE: Need to honor uncommitted config,

--- a/src/handle_join_leave.cxx
+++ b/src/handle_join_leave.cxx
@@ -343,9 +343,23 @@ ptr<resp_msg> raft_server::handle_rm_srv_req(req_msg& req) {
 
     check_srv_to_leave_timeout();
     if (srv_to_leave_) {
-        p_wn("previous to-be-removed server has not left yet");
+        p_wn("previous to-be-removed server %d has not left yet",
+             srv_to_leave_->get_id());
         resp->set_result_code(cmd_result_code::SERVER_IS_LEAVING);
         return resp;
+    }
+    // NOTE:
+    //   Although `srv_to_leave_` is not set, we should check if
+    //   there is any peer whose leave flag is set.
+    for (auto& entry: peers_) {
+        ptr<peer> pp = entry.second;
+        if (pp->is_leave_flag_set()) {
+            p_wn("leave flag of server %d is set, but the server "
+                 "has not left yet",
+                 pp->get_id());
+            resp->set_result_code(cmd_result_code::SERVER_IS_LEAVING);
+            return resp;
+        }
     }
 
     if (config_changing_) {


### PR DESCRIPTION
* Once RPC to to-be-removed server fails, we don't need to wait for
LEAVE_LIMIT and immediately proceed new configuration.

* The server will be eventually removed from the peer list after
LEAVE_LIMIT since the new config is committed.