### PR TITLE
`srv_to_leave_` timeout should use resp timer

### DIFF
--- a/src/handle_timeout.cxx
+++ b/src/handle_timeout.cxx
@@ -40,15 +40,15 @@ void raft_server::enable_hb_for_peer(peer& p) {
 
 void raft_server::check_srv_to_leave_timeout() {
     if (!srv_to_leave_) return;
-    ulong last_active_ms = srv_to_leave_->get_active_timer_us() / 1000;
-    if ( last_active_ms >
+    ulong last_resp_ms = srv_to_leave_->get_resp_timer_us() / 1000;
+    if ( last_resp_ms >
              (ulong)peer::LEAVE_LIMIT *
              ctx_->get_params()->heart_beat_interval_ ) {
         // Timeout: remove peer.
-        p_wn("server to be removed %d, activity timeout %zu ms. "
+        p_wn("server to be removed %d, response timeout %zu ms. "
              "force remove now",
              srv_to_leave_->get_id(),
-             last_active_ms);
+             last_resp_ms);
         remove_peer_from_peers(srv_to_leave_);
         reset_srv_to_leave();
     }


### PR DESCRIPTION
* Since we count RPC error as an activity, we may not meet the condition
to remove `srv_to_leave_`, if there is continuous traffic and the leader
tries to reach the server.

* Instead we should use resp timer, which doesn't count error as a
valid activity.