### PR TITLE
Fix a couple of bugs on removing servers

### DIFF
--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -692,7 +692,8 @@ void raft_server::handle_append_entries_resp(resp_msg& resp) {
     check_srv_to_leave_timeout();
     if ( srv_to_leave_ &&
          srv_to_leave_->get_id() == resp.get_src() &&
-         srv_to_leave_->is_stepping_down() ) {
+         srv_to_leave_->is_stepping_down() &&
+         resp.get_next_idx() > srv_to_leave_target_idx_ ) {
         // Catch-up is done.
         p_in("server to be removed %d fully caught up the "
              "target config log %zu",

--- a/src/handle_join_leave.cxx
+++ b/src/handle_join_leave.cxx
@@ -54,6 +54,8 @@ ptr<resp_msg> raft_server::handle_add_srv_req(req_msg& req) {
         return resp;
     }
 
+    // Before checking duplicate ID, confirm srv_to_leave_ is gone.
+    check_srv_to_leave_timeout();
     ptr<srv_config> srv_conf =
         srv_config::deserialize( entries[0]->get_buf() );
     if ( peers_.find( srv_conf->get_id() ) != peers_.end() ||


### PR DESCRIPTION
* When we check the response from to-be-removed server, we should
make sure that its last log index is bigger than the target index.
If the to-be-removed server restarts, it may return response but
may not sync up the latest config yet.

* Adding server logic should check `srv_to_leave_` node is gone,
before duplicate ID checking.