### PR TITLE
Fix rare hang during raft_server->shutdown().

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -693,6 +693,9 @@ protected:
     // `true` if background commit thread has been terminated.
     std::atomic<bool> commit_bg_stopped_;
 
+    // `true` if background append thread has been terminated.
+    std::atomic<bool> append_bg_stopped_;
+
     // `true` if write operation is paused, as the first phase of
     // leader re-election.
     std::atomic<bool> write_paused_;

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -53,6 +53,7 @@ void raft_server::append_entries_in_bg() {
         recur_lock(lock_);
         request_append_entries();
     } while (!stopping_);
+    append_bg_stopped_ = true;
     p_in("bg append_entries thread terminated");
 }
 


### PR DESCRIPTION
If bg_append_ea_->invoke(); is invoked between reset() and wait() it will become a no-op, and the background append thread will wait forever.

Added other cosmetic changes to improve diagnostic logging.