### PR TITLE
Fix race on ASIO client during prevote and vote

### DIFF
--- a/include/libnuraft/asio_service.hxx
+++ b/include/libnuraft/asio_service.hxx
@@ -42,13 +42,6 @@ public:
     using meta_cb_params = asio_service_meta_cb_params;
     using options = asio_service_options;
 
-    enum log_level {
-        debug = 0x0,
-        info,
-        warnning,
-        error
-    };
-
     asio_service(const options& _opt = options(),
                  ptr<logger> _l = nullptr);
 

--- a/include/libnuraft/peer.hxx
+++ b/include/libnuraft/peer.hxx
@@ -89,6 +89,8 @@ public:
         , reconn_backoff_(0)
         , suppress_following_error_(false)
         , abandoned_(false)
+        , rsv_msg_(nullptr)
+        , rsv_msg_handler_(nullptr)
         , l_(logger)
     {
         reset_ls_timer();
@@ -292,6 +294,14 @@ public:
         return suppress_following_error_.compare_exchange_strong(exp, desired);
     }
 
+    void set_rsv_msg(const ptr<req_msg>& m, const rpc_handler& h) {
+        rsv_msg_ = m;
+        rsv_msg_handler_ = h;
+    }
+
+    ptr<req_msg> get_rsv_msg() const { return rsv_msg_; }
+    rpc_handler get_rsv_msg_handler() const { return rsv_msg_handler_; }
+
 private:
     void handle_rpc_result(ptr<peer> myself,
                            ptr<rpc_client> my_rpc_client,
@@ -409,6 +419,12 @@ private:
     // if `true`, this peer is removed and shut down.
     // All operations on this peer should be rejected.
     std::atomic<bool> abandoned_;
+
+    // Reserved message that should be sent next time.
+    ptr<req_msg> rsv_msg_;
+
+    // Handler for reserved message.
+    rpc_handler rsv_msg_handler_;
 
     // Logger instance.
     ptr<logger> l_;

--- a/include/libnuraft/rpc_cli.hxx
+++ b/include/libnuraft/rpc_cli.hxx
@@ -26,6 +26,8 @@ limitations under the License.
 #include "resp_msg.hxx"
 #include "rpc_exception.hxx"
 
+#include <cstdint>
+
 namespace nuraft {
 
 class resp_msg;
@@ -39,6 +41,8 @@ class rpc_client {
 
 public:
     virtual void send(ptr<req_msg>& req, rpc_handler& when_done) = 0;
+
+    virtual uint64_t get_id() const = 0;
 };
 
 }

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -121,8 +121,23 @@ bool raft_server::request_append_entries(ptr<peer> p) {
 
     if (p->make_busy()) {
         p_tr("send request to %d\n", (int)p->get_id());
-        ptr<req_msg> msg = create_append_entries_req(*p);
+
+        // If reserved message exists, process it first.
+        ptr<req_msg> msg = p->get_rsv_msg();
+        rpc_handler m_handler = p->get_rsv_msg_handler();
+        if (msg) {
+            // Clear the reserved message.
+            p->set_rsv_msg(nullptr, nullptr);
+            p_in("found reserved message to peer %d, type %d",
+                 p->get_id(), msg->get_type());
+
+        } else {
+            // Normal message.
+            msg = create_append_entries_req(*p);
+            m_handler = resp_handler_;
+        }
         if (!msg) {
+            // Even normal message doesn't exist.
             p->set_free();
             return true;
         }
@@ -153,7 +168,7 @@ bool raft_server::request_append_entries(ptr<peer> p) {
             p->reset_manual_free();
         }
 
-        p->send_req(p, msg, resp_handler_);
+        p->send_req(p, msg, m_handler);
         p->reset_ls_timer();
 
         if ( srv_to_leave_ &&

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -163,6 +163,8 @@ bool raft_server::request_append_entries(ptr<peer> p) {
             p->reset_long_pause_warnings();
 
         } else {
+            // FIXME: `manual_free` is deprecated, need to get rid of it.
+
             // It means that this is not an actual recovery,
             // but just temporarily freed busy flag.
             p->reset_manual_free();

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -788,7 +788,12 @@ void raft_server::handle_append_entries_resp(resp_msg& resp) {
     if ( write_paused_ &&
          p->get_id() == next_leader_candidate_ &&
          p_matched_idx &&
-         p_matched_idx == log_store_->next_slot() - 1 ) {
+         p_matched_idx == log_store_->next_slot() - 1 &&
+         p->make_busy() ) {
+        // NOTE:
+        //   If `make_busy` fails (very unlikely to happen), next
+        //   response handler (of heartbeat, append_entries ..) will
+        //   retry this.
         p_in("ready to resign, server id %d, "
              "latest log index %zu, "
              "%zu us elapsed, resign now",

--- a/src/handle_priority.cxx
+++ b/src/handle_priority.cxx
@@ -137,7 +137,12 @@ void raft_server::broadcast_priority_change(const int srv_id,
         v.push_back(le);
 
         ptr<peer> pp = it->second;
-        pp->send_req(pp, req, resp_handler_);
+        if (pp->make_busy()) {
+            pp->send_req(pp, req, resp_handler_);
+        } else {
+            p_er("peer %d is currently busy, cannot send request",
+                 pp->get_id());
+        }
     }
 }
 

--- a/src/peer.cxx
+++ b/src/peer.cxx
@@ -90,7 +90,7 @@ void peer::handle_rpc_result( ptr<peer> myself,
     if (err == nilptr) {
         // Succeeded.
         {   std::lock_guard<std::mutex> l(rpc_protector_);
-            // The same as below, freeing bush flag should be done
+            // The same as below, freeing busy flag should be done
             // only if the RPC hasn't been changed.
             uint64_t cur_rpc_id = rpc_ ? rpc_->get_id() : 0;
             uint64_t given_rpc_id = my_rpc_client ? my_rpc_client->get_id() : 0;

--- a/src/peer.cxx
+++ b/src/peer.cxx
@@ -110,7 +110,8 @@ void peer::handle_rpc_result( ptr<peer> myself,
         if ( req->get_type() == msg_type::append_entries_request ||
              req->get_type() == msg_type::install_snapshot_request ||
              req->get_type() == msg_type::request_vote_request ||
-             req->get_type() == msg_type::pre_vote_request ) {
+             req->get_type() == msg_type::pre_vote_request ||
+             req->get_type() == msg_type::leave_cluster_request ) {
             set_free();
         }
 
@@ -142,7 +143,8 @@ void peer::handle_rpc_result( ptr<peer> myself,
                 if ( req->get_type() == msg_type::append_entries_request ||
                      req->get_type() == msg_type::install_snapshot_request ||
                      req->get_type() == msg_type::request_vote_request ||
-                     req->get_type() == msg_type::pre_vote_request ) {
+                     req->get_type() == msg_type::pre_vote_request ||
+                     req->get_type() == msg_type::leave_cluster_request ) {
                     set_free();
                 }
 

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -860,7 +860,6 @@ void raft_server::become_leader() {
             // reconnect_client(*pp);
 
             pp->set_next_log_idx(log_store_->next_slot());
-            pp->set_free();
             enable_hb_for_peer(*pp);
         }
 

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -759,7 +759,12 @@ void raft_server::send_reconnect_request() {
                                             leader_,
                                             0, 0, 0 );
 
-        p_leader->send_req(p_leader, req, ex_resp_handler_);
+        if (p_leader->make_busy()) {
+            p_leader->send_req(p_leader, req, ex_resp_handler_);
+        } else {
+            p_er("previous message to leader %d hasn't been responded yet",
+                 p_leader->get_id());
+        }
 
     } else {
         // LCOV_EXCL_START
@@ -1171,7 +1176,12 @@ void raft_server::handle_ext_resp_err(rpc_exception& err) {
 void raft_server::on_retryable_req_err(ptr<peer>& p, ptr<req_msg>& req) {
     p_db( "retry the request %s for %d",
           msg_type_to_string(req->get_type()).c_str(), p->get_id() );
-    p->send_req(p, req, ex_resp_handler_);
+    if (p->make_busy()) {
+        p->send_req(p, req, ex_resp_handler_);
+    } else {
+        p_er("retry request %d failed: peer %d is busy",
+             req->get_type(), p->get_id());
+    }
 }
 
 ulong raft_server::term_for_log(ulong log_idx) {

--- a/tests/unit/failure_test.cxx
+++ b/tests/unit/failure_test.cxx
@@ -420,6 +420,9 @@ int uncommitted_conf_new_leader_test() {
         s1.fNet->execReqResp(s2_addr);
         s1.fNet->execReqResp(s3_addr);
     }
+    // One more time, to make sure there is no message in-flight.
+    s1.fNet->execReqResp(s2_addr);
+    s1.fNet->execReqResp(s3_addr);
 
     // Now remove S2 (who was a member of the latest quorum).
     s1.raftServer->remove_srv(2);

--- a/tests/unit/fake_network.cxx
+++ b/tests/unit/fake_network.cxx
@@ -287,10 +287,12 @@ void FakeNetwork::shutdown() {
 
 
 // === FakeClient
+static std::atomic<uint64_t> fake_client_id_counter(1);
 
 FakeClient::FakeClient(FakeNetwork* mother,
                        FakeNetwork* dst)
-    : motherNet(mother)
+    : myId(fake_client_id_counter.fetch_add(1))
+    , motherNet(mother)
     , dstNet(dst)
 {}
 
@@ -313,6 +315,10 @@ void FakeClient::dropPackets() {
 bool FakeClient::isDstOnline() {
     if (!dstNet) return false;
     return dstNet->isOnline();
+}
+
+uint64_t FakeClient::get_id() const {
+    return myId;
 }
 
 

--- a/tests/unit/fake_network.hxx
+++ b/tests/unit/fake_network.hxx
@@ -143,7 +143,10 @@ public:
 
     bool isDstOnline();
 
+    uint64_t get_id() const;
+
 private:
+    uint64_t myId;
     FakeNetwork* motherNet;
     FakeNetwork* dstNet;
     std::list<FakeNetwork::ReqPkg> pendingReqs;


### PR DESCRIPTION
* Both prevote and vote requests also should honor `busy_flag_` in
`peer`. Otherwise, race on the same client happens and it will result
in various memory corruptions.