### PR TITLE
Skip processing `srv_to_leave_` on replaying old configs

### DIFF
--- a/include/libnuraft/peer.hxx
+++ b/include/libnuraft/peer.hxx
@@ -281,9 +281,13 @@ public:
     bool need_to_reconnect() {
         if (abandoned_) return false;
 
-        if (reconn_scheduled_ && reconn_timer_.timeout()) return true;
+        if (reconn_scheduled_ && reconn_timer_.timeout()) {
+            return true;
+        }
         {   std::lock_guard<std::mutex> l(rpc_protector_);
-            if (!rpc_.get()) return true;
+            if (!rpc_.get()) {
+                return true;
+            }
         }
         return false;
     }

--- a/src/handle_join_leave.cxx
+++ b/src/handle_join_leave.cxx
@@ -496,7 +496,7 @@ void raft_server::rm_srv_from_cluster(int32 srv_id) {
 
 void raft_server::handle_join_leave_rpc_err(msg_type t_msg, ptr<peer> p) {
     if (t_msg == msg_type::leave_cluster_request) {
-        p_in( "rpc failed again for the removing server (%d), "
+        p_in( "rpc failed for removing server (%d), "
               "will remove this server directly",
               p->get_id() );
 

--- a/tests/unit/raft_package_fake.hxx
+++ b/tests/unit/raft_package_fake.hxx
@@ -110,6 +110,11 @@ public:
         _s_info(ll) << msg;
     }
 
+    void localLog(const std::string& msg) {
+        SimpleLogger* ll = myLogWrapper->getLogger();
+        _s_info(ll) << msg;
+    }
+
     int myId;
     std::string myEndpoint;
     ptr<FakeNetworkBase> fBase;


### PR DESCRIPTION
* If `srv_to_leave_` is NULL on removing server in reconfigure, that
means Raft is replaying old log, and there is no current request by
user. In such case, we can skip the logic handling `srv_to_leave_`.