### PR TITLE
Fix to returning stale leader ID issue

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -323,7 +323,13 @@ public:
      * @return Leader ID
      *         -1 if there is no live leader.
      */
-    int32 get_leader() const { return leader_; }
+    int32 get_leader() const {
+        // We should handle the case when `role_` is already
+        // updated, but `leader_` value is stale.
+        if ( leader_ == id_ &&
+             role_ != srv_role::leader ) return -1;
+        return leader_;
+    }
 
     /**
      * Check if this server is leader.

--- a/src/handle_vote.cxx
+++ b/src/handle_vote.cxx
@@ -84,6 +84,7 @@ void raft_server::request_prevote() {
     }
 
     hb_alive_ = false;
+    leader_ = -1;
     pre_vote_.reset(state_->get_term());
     // Count for myself.
     pre_vote_.dead_++;
@@ -147,7 +148,11 @@ void raft_server::initiate_vote(bool ignore_priority) {
         ctx_->state_mgr_->save_state(*state_);
         request_vote(ignore_priority);
     }
-    hb_alive_ = false;
+
+    if (role_ != srv_role::leader) {
+        hb_alive_ = false;
+        leader_ = -1;
+    }
 }
 
 void raft_server::request_vote(bool ignore_priority) {


### PR DESCRIPTION
* Once a leader becomes a follower due to vote requests, its role
immediately changes, but `leader_id_` does not. It may cause an
issue returning a stale leader ID.