### PR TITLE
Support auto adjusting quorum size for 2-node cluster

### DIFF
--- a/include/libnuraft/peer.hxx
+++ b/include/libnuraft/peer.hxx
@@ -60,6 +60,13 @@ public:
      */
     static const int32 LEAVE_LIMIT      = 5;
 
+    /**
+     * For 2-node cluster, if the other peer is not responding for
+     * pre-vote more than this limit, adjust quorum size.
+     * Enabled only when `auto_adjust_quorum_for_small_cluster_` is on.
+     */
+    static const int32 VOTE_LIMIT       = 10;
+
     peer( ptr<srv_config>& config,
           const context& ctx,
           timer_task<int32>::executor& hb_exec,

--- a/include/libnuraft/raft_params.hxx
+++ b/include/libnuraft/raft_params.hxx
@@ -86,6 +86,7 @@ struct raft_params {
         , auto_forwarding_(false)
         , use_bg_thread_for_urgent_commit_(true)
         , exclude_snp_receiver_from_quorum_(false)
+        , auto_adjust_quorum_for_small_cluster_(false)
         , locking_method_type_(dual_mutex)
         , return_method_(blocking)
         {}
@@ -454,6 +455,13 @@ public:
      * leader cannot make any progress.
      */
     bool exclude_snp_receiver_from_quorum_;
+
+    /**
+     * If `true` and the size of the cluster is 2, the quorum size
+     * will be adjusted to 1 automatically, once one of two nodes
+     * becomes offline.
+     */
+    bool auto_adjust_quorum_for_small_cluster_;
 
     /**
      * Choose the type of lock that will be used by user threads.

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -482,6 +482,7 @@ protected:
     struct pre_vote_status_t {
         pre_vote_status_t()
             : quorum_reject_count_(0)
+            , failure_count_(0)
             { reset(0); }
         void reset(ulong _term) {
             term_ = _term;
@@ -493,7 +494,16 @@ protected:
         std::atomic<int32> live_;
         std::atomic<int32> dead_;
         std::atomic<int32> abandoned_;
+
+        /**
+         * Number of pre-vote rejections by quorum.
+         */
         std::atomic<int32> quorum_reject_count_;
+
+        /**
+         * Number of pre-vote failures due to not-responding peers.
+         */
+        std::atomic<int32> failure_count_;
     };
 
 protected:

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -905,6 +905,7 @@ void raft_server::become_leader() {
     next_leader_candidate_ = -1;
     initialized_ = true;
     pre_vote_.quorum_reject_count_ = 0;
+    pre_vote_.failure_count_ = 0;
     data_fresh_ = true;
 
     request_append_entries();
@@ -1035,6 +1036,7 @@ void raft_server::become_follower() {
         initialized_ = true;
         uncommitted_config_.reset();
         pre_vote_.quorum_reject_count_ = 0;
+        pre_vote_.failure_count_ = 0;
 
         // Drain all pending callback functions.
         drop_all_pending_commit_elems();


### PR DESCRIPTION
* The quorum size of the 2-node cluster is 2, which means if any node
goes offline, the cluster becomes unavailable immediately.

* Added a configurable option: if we turn on this option, the quorum
size of the 2-node cluster is automatically adjusted to 1, if any
node becomes offline. The remaining node can do self-election and
also can commit incoming requests. The quorum size will be restored
using the default value once the offline node becomes online.

* It is not entirely safe, and dealing with log divergence is the
users' responsibility. Using the custom term counter to avoid
duplicate terms may be helpful.
