### PR TITLE
Fix to bug on auto adjusting quorum size

### DIFF
--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -112,7 +112,7 @@ bool raft_server::request_append_entries(ptr<peer> p) {
             ctx_->set_params(clone);
 
         } else if ( num_not_responding_peers == 0 &&
-                    cur_quorum_size == 0 ) {
+                    params->custom_commit_quorum_size_ == 1 ) {
             // Recovered.
             p_wn("2-node cluster's follower is responding now, "
                  "restore quorum with default value");


### PR DESCRIPTION
* If 2-node cluster's leader is sending snapshot, and if
`exclude_snp_receiver_from_quorum_` option is on, this case should be
handled separately.