### PR TITLE
Fixed bug where accept flag wasn't propagated correctly when using auto-forwarding

### DIFF
--- a/src/handle_user_cmd.cxx
+++ b/src/handle_user_cmd.cxx
@@ -179,6 +179,7 @@ ptr< cmd_result< ptr<buffer> > > raft_server::send_msg_to_leader(ptr<req_msg>& r
         } else {
             if (resp->get_accepted()) {
                 resp_ctx = resp->get_ctx();
+                presult->accept();
             }
         }
 


### PR DESCRIPTION
In reference to issue #131. Compiles and passes all unit tests.

Thanks,
James.