### PR TITLE
Auto-forwarding now waits for a result when using blocking mode before returning

### DIFF
--- a/include/libnuraft/async.hxx
+++ b/include/libnuraft/async.hxx
@@ -268,6 +268,16 @@ public:
         return empty_result_;
     }
 
+    /**
+     * Blocks until set_result is called.
+     *
+     * @return void.
+     */
+    void wait() {
+        std::unique_lock<std::mutex> lock(lock_);
+        cv_.wait(lock);
+    }
+
 private:
     T empty_result_;
     T result_;

--- a/include/libnuraft/async.hxx
+++ b/include/libnuraft/async.hxx
@@ -268,16 +268,6 @@ public:
         return empty_result_;
     }
 
-    /**
-     * Blocks until set_result is called.
-     *
-     * @return void.
-     */
-    void wait() {
-        std::unique_lock<std::mutex> lock(lock_);
-        cv_.wait(lock);
-    }
-
 private:
     T empty_result_;
     T result_;

--- a/src/handle_user_cmd.cxx
+++ b/src/handle_user_cmd.cxx
@@ -186,6 +186,12 @@ ptr< cmd_result< ptr<buffer> > > raft_server::send_msg_to_leader(ptr<req_msg>& r
         presult->set_result(resp_ctx, perr);
     };
     rpc_cli->send(req, handler);
+
+    ptr<raft_params> params = ctx_->get_params();
+    if (params->return_method_ == raft_params::blocking) {
+        presult->wait();
+    }
+
     return presult;
 // LCOV_EXCL_STOP
 }

--- a/src/handle_user_cmd.cxx
+++ b/src/handle_user_cmd.cxx
@@ -189,7 +189,7 @@ ptr< cmd_result< ptr<buffer> > > raft_server::send_msg_to_leader(ptr<req_msg>& r
 
     ptr<raft_params> params = ctx_->get_params();
     if (params->return_method_ == raft_params::blocking) {
-        presult->wait();
+        presult->get();
     }
 
     return presult;


### PR DESCRIPTION
I've added the wait method to the cmd_result class because calling get won't work due to how the presult variable is instantiated. 
https://github.com/eBay/NuRaft/blob/17aab8d633b0187dc4a5d862aa75faf3ef91f5cd/src/handle_user_cmd.cxx#L168-L170
When presult is made, it calls a constructor that sets has_result_ to true. Then, if get() was used it would see that has_result_ is true and return immediately and not wait for the set_result call. Therefore, the explicit wait method will guarantee the current thread to wait until a call to set_result happens.