### PR TITLE
Support global workers for commit and append

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,7 @@ set(RAFT_CORE
     ${ROOT_SRC}/cluster_config.cxx
     ${ROOT_SRC}/crc32.cxx
     ${ROOT_SRC}/error_code.cxx
+    ${ROOT_SRC}/global_mgr.cxx
     ${ROOT_SRC}/handle_append_entries.cxx
     ${ROOT_SRC}/handle_client_request.cxx
     ${ROOT_SRC}/handle_custom_notification.cxx

--- a/include/libnuraft/global_mgr.hxx
+++ b/include/libnuraft/global_mgr.hxx
@@ -1,0 +1,221 @@
+/************************************************************************
+Modifications Copyright 2017-present eBay Inc.
+
+Original Copyright:
+See URL: https://github.com/datatechnology/cornerstone
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+**************************************************************************/
+
+#pragma once
+
+#include "basic_types.hxx"
+#include "event_awaiter.h"
+#include "pp_util.hxx"
+#include "ptr.hxx"
+
+#include <atomic>
+#include <list>
+#include <mutex>
+#include <thread>
+#include <unordered_set>
+#include <vector>
+
+namespace nuraft {
+
+class raft_server;
+
+/**
+ * Configurations for the initialization of `nuraft_global_mgr`.
+ */
+struct nuraft_global_config {
+    nuraft_global_config()
+        : num_commit_threads_(1)
+        , num_append_threads_(1)
+        , max_scheduling_unit_ms_(20)
+        {}
+
+    /**
+     * The number of globally shared threads executing the
+     * commit of state machine.
+     */
+    size_t num_commit_threads_;
+
+    /**
+     * The number of globally shared threads executing replication.
+     */
+    size_t num_append_threads_;
+
+    /**
+     * If a commit of a Raft instance takes longer than this time,
+     * worker thread will pause the commit of the current instance
+     * and schedule the next instance, to avoid starvation issue.
+     */
+    size_t max_scheduling_unit_ms_;
+};
+
+static nuraft_global_config __DEFAULT_NURAFT_GLOBAL_CONFIG;
+
+// Singleton class.
+class nuraft_global_mgr {
+public:
+    /**
+     * Initialize the global instance.
+     *
+     * @return If succeeds, the initialized instance.
+     *         If already initialized, the existing instance.
+     */
+    static nuraft_global_mgr* init(const nuraft_global_config& config =
+                                       __DEFAULT_NURAFT_GLOBAL_CONFIG);
+
+    /**
+     * Shutdown the global instance and free all resources.
+     * All Raft instances should be shut down before calling this API.
+     */
+    static void shutdown();
+
+    /**
+     * Get the current global instance.
+     *
+     * @return The current global instance if initialized.
+     *         `nullptr` if not initialized.
+     */
+    static nuraft_global_mgr* get_instance();
+
+    /**
+     * This function is called by the constructor of `raft_server`.
+     *
+     * @param server Raft server instance.
+     */
+    void init_raft_server(raft_server* server);
+
+    /**
+     * This function is called by the destructor of `raft_server`.
+     *
+     * @param server Raft server instance.
+     */
+    void close_raft_server(raft_server* server);
+
+    /**
+     * Request `append_entries` for the given server.
+     *
+     * @param server Raft server instance to request `append_entries`.
+     */
+    void request_append(ptr<raft_server> server);
+
+    /**
+     * Request background commit execution for the given server.
+     *
+     * @param server Raft server instance to execute commit.
+     */
+    void request_commit(ptr<raft_server> server);
+
+private:
+    struct worker_handle {
+        worker_handle(size_t id = 0);
+        ~worker_handle();
+        void shutdown();
+
+        enum status {
+            SLEEPING = 0,
+            WORKING = 1,
+        };
+
+        size_t id_;
+        EventAwaiter ea_;
+        ptr<std::thread> thread_;
+        bool stopping_;
+        std::atomic<status> status_;
+    };
+
+    static std::mutex instance_lock_;
+    static std::atomic<nuraft_global_mgr*> instance_;
+
+    nuraft_global_mgr();
+
+    ~nuraft_global_mgr();
+
+    __nocopy__(nuraft_global_mgr);
+
+    /**
+     * Initialize thread pool with the given config.
+     */
+    void init_thread_pool();
+
+    /**
+     * Loop for commit worker threads.
+     */
+    void commit_worker_loop(ptr<worker_handle> handle);
+
+    /**
+     * Loop for append worker threads.
+     */
+    void append_worker_loop(ptr<worker_handle> handle);
+
+    /**
+     * Global config.
+     */
+    nuraft_global_config config_;
+
+    /**
+     * Counter for assigning thread ID.
+     */
+    std::atomic<size_t> thread_id_counter_;
+
+    /**
+     * Commit thread pool.
+     */
+    std::vector< ptr<worker_handle> > commit_workers_;
+
+    /**
+     * Commit thread pool.
+     */
+    std::vector< ptr<worker_handle> > append_workers_;
+
+    /**
+     * Commit requests.
+     * Duplicate requests from the same `raft_server` will not be allowed.
+     */
+    std::list< ptr<raft_server> > commit_queue_;
+
+    /**
+     * A set for efficient duplicate checking of `raft_server`.
+     * It will contain all `raft_server`s currently in `commit_queue_`.
+     */
+    std::unordered_set< ptr<raft_server> > commit_server_set_;
+
+    /**
+     * Lock for `commit_queue_` and `commit_server_set_`.
+     */
+    std::mutex commit_queue_lock_;
+
+    /**
+     * Append (replication) requests.
+     * Duplicate requests from the same `raft_server` will not be allowed.
+     */
+    std::list< ptr<raft_server> > append_queue_;
+
+    /**
+     * A set for efficient duplicate checking of `raft_server`.
+     * It will contain all `raft_server`s currently in `append_queue_`.
+     */
+    std::unordered_set< ptr<raft_server> > append_server_set_;
+
+    /**
+     * Lock for `append_queue_` and `append_server_set_`.
+     */
+    std::mutex append_queue_lock_;
+};
+
+} // namespace nuraft;
+

--- a/include/libnuraft/nuraft.hxx
+++ b/include/libnuraft/nuraft.hxx
@@ -31,6 +31,7 @@ limitations under the License.
 #include "delayed_task_scheduler.hxx"
 #include "delayed_task.hxx"
 #include "error_code.hxx"
+#include "global_mgr.hxx"
 #include "log_entry.hxx"
 #include "log_store.hxx"
 #include "logger.hxx"

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -55,7 +55,8 @@ class state_machine;
 class state_mgr;
 struct context;
 struct raft_params;
-class raft_server {
+class raft_server : public std::enable_shared_from_this<raft_server> {
+    friend class nuraft_global_mgr;
 public:
     struct init_options {
         init_options()
@@ -613,6 +614,7 @@ protected:
     void cancel_task(ptr<delayed_task>& task);
     bool check_leadership_validity();
     void update_rand_timeout();
+    void cancel_global_requests();
 
     bool is_regular_member(const ptr<peer>& p);
     int32 get_num_voting_members();
@@ -702,7 +704,10 @@ protected:
     ulong term_for_log(ulong log_idx);
 
     void commit_in_bg();
+    bool commit_in_bg_exec(size_t timeout_ms = 0);
+
     void append_entries_in_bg();
+    void append_entries_in_bg_exec();
 
     void commit_app_log(ulong idx_to_commit,
                         ptr<log_entry>& le,

--- a/src/global_mgr.cxx
+++ b/src/global_mgr.cxx
@@ -1,0 +1,340 @@
+/************************************************************************
+Modifications Copyright 2017-present eBay Inc.
+
+Original Copyright:
+See URL: https://github.com/datatechnology/cornerstone
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+**************************************************************************/
+
+#include "global_mgr.hxx"
+
+#include "logger.hxx"
+#include "raft_server.hxx"
+#include "tracer.hxx"
+
+namespace nuraft {
+
+std::atomic<nuraft_global_mgr*> nuraft_global_mgr::instance_(nullptr);
+std::mutex nuraft_global_mgr::instance_lock_;
+
+
+nuraft_global_mgr::worker_handle::worker_handle(size_t id)
+    : id_(id)
+    , thread_(nullptr)
+    , stopping_(false)
+    , status_(SLEEPING)
+{
+}
+
+nuraft_global_mgr::worker_handle::~worker_handle() {
+    shutdown();
+}
+
+void nuraft_global_mgr::worker_handle::shutdown() {
+    stopping_ = true;
+    if (thread_) {
+        if (thread_->joinable()) {
+            ea_.invoke();
+            thread_->join();
+        }
+        thread_.reset();
+    }
+}
+
+nuraft_global_mgr::nuraft_global_mgr()
+    : thread_id_counter_(0)
+    {}
+
+nuraft_global_mgr::~nuraft_global_mgr() {
+    for (auto& entry: append_workers_) {
+        ptr<worker_handle>& wh = entry;
+        wh->shutdown();
+    }
+    append_workers_.clear();
+
+    for (auto& entry: commit_workers_) {
+        ptr<worker_handle>& wh = entry;
+        wh->shutdown();
+    }
+    commit_workers_.clear();
+}
+
+nuraft_global_mgr* nuraft_global_mgr::init(const nuraft_global_config& config) {
+    nuraft_global_mgr* mgr = instance_.load();
+    if (!mgr) {
+        std::lock_guard<std::mutex> l(instance_lock_);
+        mgr = instance_.load();
+        if (!mgr) {
+            mgr = new nuraft_global_mgr();
+            instance_.store(mgr);
+            mgr->config_ = config;
+            mgr->init_thread_pool();
+        }
+    }
+    return mgr;
+}
+
+void nuraft_global_mgr::shutdown() {
+    std::lock_guard<std::mutex> l(instance_lock_);
+    nuraft_global_mgr* mgr = instance_.load();
+    if (mgr) {
+        delete mgr;
+        instance_.store(nullptr);
+    }
+}
+
+nuraft_global_mgr* nuraft_global_mgr::get_instance() {
+    return instance_.load();
+}
+
+void nuraft_global_mgr::init_thread_pool() {
+    for (size_t ii = 0; ii < config_.num_commit_threads_; ++ii) {
+        ptr<worker_handle> w_hdl =
+            cs_new<worker_handle>( thread_id_counter_.fetch_add(1) );
+        w_hdl->thread_ = cs_new<std::thread>( &nuraft_global_mgr::commit_worker_loop,
+                                              this,
+                                              w_hdl );
+        commit_workers_.push_back(w_hdl);
+    }
+
+    for (size_t ii = 0; ii < config_.num_append_threads_; ++ii) {
+        ptr<worker_handle> w_hdl =
+            cs_new<worker_handle>( thread_id_counter_.fetch_add(1) );
+        w_hdl->thread_ = cs_new<std::thread>( &nuraft_global_mgr::append_worker_loop,
+                                              this,
+                                              w_hdl );
+        append_workers_.push_back(w_hdl);
+    }
+}
+
+void nuraft_global_mgr::init_raft_server(raft_server* server) {
+    ptr<logger>& l_ = server->l_;
+    p_in("global manager detected, %zu commit workers, %zu append workers",
+         config_.num_commit_threads_,
+         config_.num_append_threads_);
+}
+
+void nuraft_global_mgr::close_raft_server(raft_server* server) {
+    // Cancel all requests for this raft server.
+    size_t num_aborted_append = 0;
+    {
+        std::lock_guard<std::mutex> l(append_queue_lock_);
+        auto entry = append_queue_.begin();
+        while (entry != append_queue_.end()) {
+            if (entry->get() == server) {
+                append_server_set_.erase(*entry);
+                entry = append_queue_.erase(entry);
+                num_aborted_append++;
+                break;
+            } else {
+                entry++;
+            }
+        }
+    }
+
+    size_t num_aborted_commit = 0;
+    {
+        std::lock_guard<std::mutex> l(commit_queue_lock_);
+        auto entry = commit_queue_.begin();
+        while (entry != commit_queue_.end()) {
+            if (entry->get() == server) {
+                commit_server_set_.erase(*entry);
+                entry = commit_queue_.erase(entry);
+                num_aborted_commit++;
+                break;
+            } else {
+                entry++;
+            }
+        }
+    }
+
+    ptr<logger>& l_ = server->l_;
+    p_in("global manager detected, %zu appends %zu commits are aborted",
+         num_aborted_append,
+         num_aborted_commit);
+}
+
+void nuraft_global_mgr::request_append(ptr<raft_server> server) {
+    {
+        std::lock_guard<std::mutex> l(append_queue_lock_);
+        // First search the set if the server is duplicate.
+        auto entry = append_server_set_.find(server);
+        if (entry != append_server_set_.end()) {
+            // `server` is already in the queue. Ignore it.
+            return;
+        }
+
+        // Put into queue.
+        append_queue_.push_back(server);
+        append_server_set_.insert(server);
+
+        ptr<logger>& l_ = server->l_;
+        p_tr("added append request to global queue, "
+             "server %p, queue length %zu",
+             server.get(),
+             append_queue_.size());
+    }
+
+    // Find a sleeping worker and invoke.
+    for (auto& entry: append_workers_) {
+        ptr<worker_handle>& wh = entry;
+        if (wh->status_ == worker_handle::SLEEPING) {
+            wh->ea_.invoke();
+            break;
+        }
+    }
+    // If all workers are working, nothing to do for now.
+}
+
+void nuraft_global_mgr::request_commit(ptr<raft_server> server) {
+    {
+        std::lock_guard<std::mutex> l(commit_queue_lock_);
+        // First search the set if the server is duplicate.
+        auto entry = commit_server_set_.find(server);
+        if (entry != commit_server_set_.end()) {
+            // `server` is already in the queue. Ignore it.
+            return;
+        }
+
+        // Put into queue.
+        commit_queue_.push_back(server);
+        commit_server_set_.insert(server);
+
+        ptr<logger>& l_ = server->l_;
+        p_tr("added commit request to global queue, "
+             "server %p, queue length %zu",
+             server.get(),
+             commit_queue_.size());
+    }
+
+    // Find a sleeping worker and invoke.
+    for (auto& entry: commit_workers_) {
+        ptr<worker_handle>& wh = entry;
+        if (wh->status_ == worker_handle::SLEEPING) {
+            wh->ea_.invoke();
+            break;
+        }
+    }
+    // If all workers are working, nothing to do for now.
+}
+
+void nuraft_global_mgr::commit_worker_loop(ptr<worker_handle> handle) {
+    std::string thread_name = "nuraft_g_c" + std::to_string(handle->id_);
+#ifdef __linux__
+    pthread_setname_np(pthread_self(), thread_name.c_str());
+#elif __APPLE__
+    pthread_setname_np(thread_name.c_str());
+#endif
+
+    bool skip_sleeping = false;
+    while (!handle->stopping_) {
+        if (!skip_sleeping) {
+            handle->status_ = worker_handle::SLEEPING;
+            // Wake up for every 1 second even without invoke, just in case.
+            handle->ea_.wait_ms(1000);
+            handle->ea_.reset();
+            handle->status_ = worker_handle::WORKING;
+        }
+        if (handle->stopping_) break;
+
+        skip_sleeping = false;
+        size_t queue_length = 0;
+        ptr<raft_server> target = nullptr;
+        {
+            std::lock_guard<std::mutex> l(commit_queue_lock_);
+            auto entry = commit_queue_.begin();
+            if (entry != commit_queue_.end()) {
+                target = *entry;
+                commit_server_set_.erase(target);
+                commit_queue_.pop_front();
+                queue_length = commit_queue_.size();
+                if (!commit_queue_.empty()) {
+                    // Other requests are waiting in the queue,
+                    // skip sleeping next time.
+                    skip_sleeping = true;
+                }
+            }
+        }
+        if (!target) continue;
+
+        if ( target->quick_commit_index_ <= target->sm_commit_index_ ||
+             target->log_store_->next_slot() - 1 <= target->sm_commit_index_ ) {
+            // State machine's commit index is large enough not to execute commit
+            // (see the comment in `commit_in_bg()`).
+            continue;
+        }
+
+        ptr<logger>& l_ = target->l_;
+        p_tr("executed commit by global worker, queue length %zu", queue_length);
+        bool finished_in_time =
+            target->commit_in_bg_exec(config_.max_scheduling_unit_ms_);
+        if (!finished_in_time) {
+            // Commit took too long time and aborted in the middle.
+            // Put this server to queue again.
+            p_tr("couldn't finish in time (%zu ms), re-push to queue",
+                 config_.max_scheduling_unit_ms_);
+            request_commit(target);
+            skip_sleeping = true;
+        }
+    }
+}
+
+void nuraft_global_mgr::append_worker_loop(ptr<worker_handle> handle) {
+    std::string thread_name = "nuraft_g_a" + std::to_string(handle->id_);
+#ifdef __linux__
+    pthread_setname_np(pthread_self(), thread_name.c_str());
+#elif __APPLE__
+    pthread_setname_np(thread_name.c_str());
+#endif
+
+    bool skip_sleeping = false;
+    while (!handle->stopping_) {
+        if (!skip_sleeping) {
+            handle->status_ = worker_handle::SLEEPING;
+            // Ditto, just in case.
+            handle->ea_.wait_ms(1000);
+            handle->ea_.reset();
+            handle->status_ = worker_handle::WORKING;
+        }
+        if (handle->stopping_) break;
+
+        skip_sleeping = false;
+        size_t queue_length = 0;
+        ptr<raft_server> target = nullptr;
+        {
+            std::lock_guard<std::mutex> l(append_queue_lock_);
+            auto entry = append_queue_.begin();
+            if (entry != append_queue_.end()) {
+                target = *entry;
+                append_server_set_.erase(target);
+                append_queue_.pop_front();
+                queue_length = append_queue_.size();
+                if (!append_queue_.empty()) {
+                    // Other requests are waiting in the queue,
+                    // skip sleeping next time.
+                    skip_sleeping = true;
+                }
+            }
+        }
+        if (!target) continue;
+
+        ptr<logger>& l_ = target->l_;
+        p_tr("executed append_entries by global worker, queue length %zu",
+             queue_length);
+        target->append_entries_in_bg_exec();
+    }
+}
+
+} // namespace nuraft;
+

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -50,11 +50,15 @@ void raft_server::append_entries_in_bg() {
         bg_append_ea_->reset();
         if (stopping_) break;
 
-        recur_lock(lock_);
-        request_append_entries();
+        append_entries_in_bg_exec();
     } while (!stopping_);
     append_bg_stopped_ = true;
     p_in("bg append_entries thread terminated");
+}
+
+void raft_server::append_entries_in_bg_exec() {
+    recur_lock(lock_);
+    request_append_entries();
 }
 
 void raft_server::request_append_entries() {

--- a/src/stat_mgr.cxx
+++ b/src/stat_mgr.cxx
@@ -26,13 +26,6 @@ namespace nuraft {
 std::atomic<stat_mgr*> stat_mgr::instance_(nullptr);
 std::mutex stat_mgr::instance_lock_;
 
-struct auto_destroyer {
-    ~auto_destroyer() {
-        stat_mgr::destroy();
-    }
-};
-static auto_destroyer auto_destroyer_;
-
 // === stat_elem ==============================================================
 
 stat_elem::stat_elem(Type _type, const std::string& _name)


### PR DESCRIPTION
* Each Raft instance creates at least two threads: one for commit and
the other one for append. If there is a use case that a process has
many Raft instances, it will produce lots of threads which end up with
resource efficiency problem.

* To address this issue, we introduce a global thread pool; there are
shared worker threads for commit and append, and a global manager
coordinates requests from multiple Raft instances and assigns them
to proper worker threads.