### PR TITLE
Allow only one global worker to do commit of a Raft server

### DIFF
--- a/include/libnuraft/global_mgr.hxx
+++ b/include/libnuraft/global_mgr.hxx
@@ -41,7 +41,7 @@ struct nuraft_global_config {
     nuraft_global_config()
         : num_commit_threads_(1)
         , num_append_threads_(1)
-        , max_scheduling_unit_ms_(20)
+        , max_scheduling_unit_ms_(200)
         {}
 
     /**

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -1088,6 +1088,11 @@ protected:
     std::mutex commit_cv_lock_;
 
     /**
+     * Lock to allow only one thread for commit.
+     */
+    std::mutex commit_lock_;
+
+    /**
      * Lock for auto forwarding.
      */
     std::mutex rpc_clients_lock_;


### PR DESCRIPTION
* Racing between workers may cause verbose warnings, although it is
functionally correct by help of CAS.