### PR TITLE
Support global Asio worker pool

### DIFF
--- a/include/libnuraft/global_mgr.hxx
+++ b/include/libnuraft/global_mgr.hxx
@@ -19,6 +19,7 @@ limitations under the License.
 
 #pragma once
 
+#include "asio_service_options.hxx"
 #include "basic_types.hxx"
 #include "pp_util.hxx"
 #include "ptr.hxx"
@@ -32,6 +33,8 @@ limitations under the License.
 
 namespace nuraft {
 
+class asio_service;
+class logger;
 class raft_server;
 
 /**
@@ -92,6 +95,26 @@ public:
     static nuraft_global_mgr* get_instance();
 
     /**
+     * Initialize a global Asio service.
+     * Return the existing one if already initialized.
+     *
+     * @param asio_opt Asio service options.
+     * @param logger_inst Logger instance.
+     * @return Asio service instance.
+     */
+    static ptr<asio_service> init_asio_service(
+        const asio_service_options& asio_opt = asio_service_options(),
+        ptr<logger> logger_inst = nullptr);
+
+    /**
+     * Get the global Asio service instance.
+     *
+     * @return Asio service instance.
+     *         `nullptr` if not initialized.
+     */
+    static ptr<asio_service> get_asio_service();
+
+    /**
      * This function is called by the constructor of `raft_server`.
      *
      * @param server Raft server instance.
@@ -122,9 +145,6 @@ public:
 private:
     struct worker_handle;
 
-    static std::mutex instance_lock_;
-    static std::atomic<nuraft_global_mgr*> instance_;
-
     nuraft_global_mgr();
 
     ~nuraft_global_mgr();
@@ -145,6 +165,26 @@ private:
      * Loop for append worker threads.
      */
     void append_worker_loop(ptr<worker_handle> handle);
+
+    /**
+     * Lock for global manager instance.
+     */
+    static std::mutex instance_lock_;
+
+    /**
+     * Global manager instance.
+     */
+    static std::atomic<nuraft_global_mgr*> instance_;
+
+    /**
+     * Lock for global Asio service instance.
+     */
+    std::mutex asio_service_lock_;
+
+    /**
+     * Global Asio service instance.
+     */
+    ptr<asio_service> asio_service_;
 
     /**
      * Global config.

--- a/src/global_mgr.cxx
+++ b/src/global_mgr.cxx
@@ -65,7 +65,8 @@ struct nuraft_global_mgr::worker_handle {
 };
 
 nuraft_global_mgr::nuraft_global_mgr()
-    : thread_id_counter_(0)
+    : asio_service_(nullptr)
+    , thread_id_counter_(0)
     {}
 
 nuraft_global_mgr::~nuraft_global_mgr() {

--- a/tests/unit/raft_package_asio.hxx
+++ b/tests/unit/raft_package_asio.hxx
@@ -79,7 +79,8 @@ public:
         return false;
     }
 
-    void initServer(bool enable_ssl = false) {
+    void initServer(bool enable_ssl = false,
+                    bool use_global_asio = false) {
         std::string log_file_name = "./srv" + std::to_string(myId) + ".log";
         myLogWrapper = cs_new<logger_wrapper>(log_file_name);
         myLog = myLogWrapper;
@@ -106,7 +107,9 @@ public:
         asio_opt.invoke_req_cb_on_empty_meta_ = alwaysInvokeCb;
         asio_opt.invoke_resp_cb_on_empty_meta_ = alwaysInvokeCb;
 
-        asioSvc = cs_new<asio_service>(asio_opt, myLog);
+        asioSvc = use_global_asio
+                  ? nuraft_global_mgr::init_asio_service(asio_opt, myLog)
+                  : cs_new<asio_service>(asio_opt, myLog);
 
         int raft_port = 20000 + myId * 10;
         ptr<rpc_listener> listener


### PR DESCRIPTION
* In addition to append/commit workers, Asio workers also can be
shared among different Raft instances in the same process.