### PR TITLE
Fix to potential pre-commit order inversion

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -668,6 +668,8 @@ protected:
     void handle_reconnect_resp(resp_msg& resp);
     void handle_custom_notification_resp(resp_msg& resp);
 
+    bool try_update_precommit_index(ulong desired, const size_t MAX_ATTEMPTS = 10);
+
     void handle_ext_resp(ptr<resp_msg>& resp, ptr<rpc_exception>& err);
     void handle_ext_resp_err(rpc_exception& err);
     void handle_join_leave_rpc_err(msg_type t_msg, ptr<peer> p);

--- a/src/handle_client_request.cxx
+++ b/src/handle_client_request.cxx
@@ -105,7 +105,7 @@ ptr<resp_msg> raft_server::handle_cli_req(req_msg& req) {
     if (num_entries) {
         log_store_->end_of_append_batch(last_idx - num_entries, num_entries);
     }
-    precommit_index_ = last_idx;
+    try_update_precommit_index(last_idx);
     resp_idx = log_store_->next_slot();
 
     // Finished appending logs and pre_commit of itself.

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -1429,9 +1429,7 @@ ulong raft_server::store_log_entry(ptr<log_entry>& entry, ulong index) {
 
         if ( role_ == srv_role::leader ) {
             // Need to progress precommit index for config.
-            if (precommit_index_ < log_index) {
-                precommit_index_ = log_index;
-            }
+            try_update_precommit_index(log_index);
         }
     }
 


### PR DESCRIPTION
* We should use compare-and-swap to avoid the situation that
a pre-commit index update is reverted by the race between threads.