### PR TITLE
Adjust quorum size for lagging follower as well

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -622,6 +622,7 @@ protected:
     int32 get_quorum_for_commit();
     int32 get_leadership_expiry();
     size_t get_not_responding_peers();
+    size_t get_num_stale_peers();
 
     ptr<resp_msg> handle_append_entries(req_msg& req);
     ptr<resp_msg> handle_prevote_req(req_msg& req);

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -548,6 +548,21 @@ size_t raft_server::get_not_responding_peers() {
     return num_not_resp_nodes;
 }
 
+size_t raft_server::get_num_stale_peers() {
+    // Check the number of peers lagging more than `stale_log_gap_`.
+    if (leader_ != id_) return 0;
+
+    size_t count = 0;
+    for (auto& entry: peers_) {
+        ptr<peer>& pp = entry.second;
+        if ( get_last_log_idx() > pp->get_matched_idx() +
+                                  ctx_->get_params()->stale_log_gap_ ) {
+            count++;
+        }
+    }
+    return count;
+}
+
 ptr<resp_msg> raft_server::process_req(req_msg& req) {
     cb_func::Param param(id_, leader_);
     param.ctx = &req;


### PR DESCRIPTION
* In a 2-node cluster, the lagging follower may result in blocking 
the commit of the leader, which affects the availability. We should 
be able to adjust the quorum size for that case as well.