### PR TITLE
commit_ret_elems_ performance improvement and enclose basic types with namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode/
+build
 debug/
 Debug/
 .vs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ if (BOOST_INCLUDE_PATH AND BOOST_LIBRARY_PATH)
 
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_BOOST_ASIO")
 
-    set(ASIO_INCLUDE_DIR ${BOOST_INCLUDE_PATH})
+    set(ASIO_INCLUDE_DIR ${BOOST_INCLUDE_PATH}/boost)
     set(LIBBOOST_SYSTEM "${BOOST_LIBRARY_PATH}/libboost_system.a")
 
 else ()
@@ -60,6 +60,10 @@ endif ()
 
 # === Includes ===
 include_directories(BEFORE ./)
+if (BOOST_INCLUDE_PATH)
+    message(STATUS "Boost include path: " ${BOOST_INCLUDE_PATH})
+    include_directories(BEFORE ${BOOST_INCLUDE_PATH})
+endif ()
 include_directories(BEFORE ${ASIO_INCLUDE_DIR})
 include_directories(BEFORE ${PROJECT_SOURCE_DIR}/include)
 include_directories(BEFORE ${PROJECT_SOURCE_DIR}/include/libnuraft)

--- a/include/libnuraft/basic_types.hxx
+++ b/include/libnuraft/basic_types.hxx
@@ -23,6 +23,8 @@ limitations under the License.
 
 #include <cstdint>
 
+namespace nuraft {
+
 typedef uint64_t ulong;
 typedef int64_t int64;
 typedef void* any_ptr;
@@ -30,5 +32,7 @@ typedef unsigned char byte;
 typedef uint16_t ushort;
 typedef uint32_t uint;
 typedef int32_t int32;
+
+}
 
 #endif // _BASIC_TYPES_HXX_

--- a/include/libnuraft/launcher.hxx
+++ b/include/libnuraft/launcher.hxx
@@ -37,6 +37,7 @@ public:
      * @param port_number Port number.
      * @param asio_options ASIO options.
      * @param params Raft parameters.
+     * @param raft_callback Callback function for hooking the operation.
      * @return Raft server instance.
      *         `nullptr` on any errors.
      */
@@ -45,7 +46,8 @@ public:
                           ptr<logger> lg,
                           int port_number,
                           const asio_service::options& asio_options,
-                          const raft_params& params);
+                          const raft_params& params,
+                          cb_func::func_type raft_callback = nullptr);
 
     /**
      * Shutdown Raft server and ASIO service.

--- a/include/libnuraft/raft_params.hxx
+++ b/include/libnuraft/raft_params.hxx
@@ -89,6 +89,7 @@ struct raft_params {
         , auto_adjust_quorum_for_small_cluster_(false)
         , locking_method_type_(dual_mutex)
         , return_method_(blocking)
+        , skip_initial_election_timeout_(false)
         {}
 
     /**
@@ -472,6 +473,17 @@ public:
      * To choose blocking call or asynchronous call.
      */
     return_method_type return_method_;
+
+    /**
+     * If `true`, the election timer will not be initiated
+     * automatically, so that this node will never trigger
+     * leader election until it gets the first heartbeat
+     * from any valid leader.
+     *
+     * Purpose: to avoid becoming leader when there is only one
+     *          node in the cluster.
+     */
+    bool skip_initial_election_timeout_;
 };
 
 }

--- a/src/handle_client_request.cxx
+++ b/src/handle_client_request.cxx
@@ -121,13 +121,16 @@ ptr<resp_msg> raft_server::handle_cli_req(req_msg& req) {
         elem->idx_ = last_idx;
         elem->result_code_ = cmd_result_code::TIMEOUT;
 
-        {   auto_lock(commit_ret_elems_lock_);
-            auto entry = commit_ret_elems_.find(last_idx);
-            if (entry != commit_ret_elems_.end()) {
-                // Commit thread was faster than this.
-                elem = entry->second;
-            } else {
-                commit_ret_elems_.insert( std::make_pair(last_idx, elem) );
+        {
+            {
+                auto_lock(commit_ret_elems_lock_);
+                auto entry = commit_ret_elems_.find(last_idx);
+                if (entry != commit_ret_elems_.end()) {
+                    // Commit thread was faster than this.
+                    elem = entry->second;
+                } else {
+                    commit_ret_elems_.insert( std::make_pair(last_idx, elem) );
+                }
             }
 
             switch (ctx_->get_params()->return_method_) {

--- a/src/launcher.cxx
+++ b/src/launcher.cxx
@@ -41,6 +41,9 @@ ptr<raft_server> raft_launcher::init(ptr<state_machine> sm,
     ptr<delayed_task_scheduler> scheduler = asio_svc_;
     ptr<rpc_client_factory> rpc_cli_factory = asio_svc_;
 
+    raft_server::init_options opt;
+    opt.skip_initial_election_timeout_ = params_given.skip_initial_election_timeout_;
+
     context* ctx = new context( smgr,
                                 sm,
                                 asio_listener_,
@@ -48,7 +51,7 @@ ptr<raft_server> raft_launcher::init(ptr<state_machine> sm,
                                 rpc_cli_factory,
                                 scheduler,
                                 params_given );
-    raft_instance_ = cs_new<raft_server>(ctx);
+    raft_instance_ = cs_new<raft_server>(ctx, opt);
     asio_listener_->listen( raft_instance_ );
     return raft_instance_;
 }

--- a/src/launcher.cxx
+++ b/src/launcher.cxx
@@ -32,7 +32,8 @@ ptr<raft_server> raft_launcher::init(ptr<state_machine> sm,
                                      ptr<logger> lg,
                                      int port_number,
                                      const asio_service::options& asio_options,
-                                     const raft_params& params_given)
+                                     const raft_params& params_given,
+                                     cb_func::func_type raft_callback)
 {
     asio_svc_ = cs_new<asio_service>(asio_options, lg);
     asio_listener_ = asio_svc_->create_rpc_listener(port_number, lg);
@@ -51,6 +52,9 @@ ptr<raft_server> raft_launcher::init(ptr<state_machine> sm,
                                 rpc_cli_factory,
                                 scheduler,
                                 params_given );
+    if (raft_callback) {
+        ctx->set_cb_func(raft_callback);
+    }
     raft_instance_ = cs_new<raft_server>(ctx, opt);
     asio_listener_->listen( raft_instance_ );
     return raft_instance_;


### PR DESCRIPTION
I've made the following changes:
- improve performance by reducing commit_ret_elems_lock_ scope
- improve performance by using find() instead of loop for getting entry from commit_ret_elems_
- enclose typedefs with namespace in basic_type.hxx to avoid name collision with other projects
- add skip_initial_election_timeout_ option to raft_params
- support setting raft callback in raft_launcher::init()