### PR TITLE
Make `raft_server_test` and `failure_test` deterministic

### DIFF
--- a/include/libnuraft/callback.hxx
+++ b/include/libnuraft/callback.hxx
@@ -150,6 +150,12 @@ public:
          * ctx: pointer to `ConnectionArgs`.
          */
         NewSessionFromLeader = 18,
+
+        /**
+         * Executed a log in the state machine.
+         * ctx: pointer to the log index.
+         */
+        StateMachineExecution = 19,
     };
 
     struct Param {


### PR DESCRIPTION
* Added a new callback command for state machine execution. Now
`raft_server_test` will not rely on the timer, but deterministically
proceed the test according to the callback signal.

* TODO: Synchronous executor is still based on timing.