### PR TITLE
Accept pre-vote if `catching_up_` flag is on

### DIFF
--- a/src/handle_vote.cxx
+++ b/src/handle_vote.cxx
@@ -377,7 +377,15 @@ ptr<resp_msg> raft_server::handle_prevote_req(req_msg& req) {
             req.get_src(),
             next_idx_for_resp ) );
 
-    if (!hb_alive_) {
+    // NOTE:
+    //   While `catching_up_` flag is on, this server does not get
+    //   normal append_entries request so that `hb_alive_` may not
+    //   be cleared properly. Hence, it should accept any pre-vote
+    //   requests.
+    if (catching_up_) {
+        p_in("this server is catching up, always accept pre-vote");
+    }
+    if (!hb_alive_ || catching_up_) {
         p_in("pre-vote decision: O (grant)");
         resp->accept(log_store_->next_slot());
     } else {


### PR DESCRIPTION
* While a server is catching up the leader, its `hb_alive_` flag will
not be updated properly, hence it will reject all pre-vote requests
which may block the leader election.