### PR TITLE
[eBay][NuRaft][LOG] Correct error prompt

### DIFF
--- a/src/handle_snapshot_sync.cxx
+++ b/src/handle_snapshot_sync.cxx
@@ -468,7 +468,7 @@ bool raft_server::handle_snapshot_sync_req(snapshot_sync_req& req) {
             // LCOV_EXCL_STOP
         }
 
-        p_in( "sucessfully receive a snapshot (idx %zu term %zu) from leader",
+        p_in( "successfully receive a snapshot (idx %zu term %zu) from leader",
               req.get_snapshot().get_last_log_idx(),
               req.get_snapshot().get_last_log_term() );
         if (log_store_->compact(req.get_snapshot().get_last_log_idx())) {


### PR DESCRIPTION
```
my id: 2, voting_member
num peers: 0 [raft_server.cxx:242, raft_server()]
2020-12-11T14:59:07.571_325+08:00 [c2c9] [INFO] global manager does not exist. will use local thread for commit and append [raft_server.cxx:253, raft_server()]
2020-12-11T14:59:07.571_405+08:00 [c2c9] [INFO] wait for HB, for 50 + [200, 400] ms [raft_server.cxx:280, raft_server()]
2020-12-11T14:59:07.571_527+08:00 [aeb7] [INFO] bg append_entries thread initiated [handle_append_entries.cxx:47, append_entries_in_bg()]
2020-12-11T14:59:07.642_937+08:00 [decf] [INFO] receive a incoming rpc connection [asio_service.cxx:759, handle_accept()]
2020-12-11T14:59:07.643_010+08:00 [decf] [INFO] session 1 got connection from 10.203.46.164:7672 (as a server) [asio_service.cxx:244, prepare_handshake()]
2020-12-11T14:59:07.643_232+08:00 [bc08] [WARN] [LOG XX] req log idx: 10, req log term: 0, my last log idx: 0, my log (10) term: 0 [handle_append_entries.cxx:528, handle_append_entries()]
2020-12-11T14:59:07.643_239+08:00 [bc08] [WARN] deny, req term 7, my term 7, req log idx 10, my log idx 0 [handle_append_entries.cxx:535, handle_append_entries()]
2020-12-11T14:59:07.643_407+08:00 [75ec] [INFO] save snapshot (idx 15, term 7) offset 0x0, first obj last obj [handle_snapshot_sync.cxx:412, handle_snapshot_sync_req()]
2020-12-11T14:59:07.643_427+08:00 [75ec] [INFO] sucessfully receive a snapshot (idx 15 term 7) from leader [handle_snapshot_sync.cxx:473, handle_snapshot_sync_req()]
2020-12-11T14:59:07.643_433+08:00 [75ec] [INFO] successfully compact the log store, will now ask the statemachine to apply the snapshot [handle_snapshot_sync.cxx:481, handle_snapshot_sync_req()]
2020-12-11T14:59:07.643_442+08:00 [75ec] [INFO] new config log idx 11, prev log idx 10, cur config log idx 0, prev log idx 0 [handle_commit.cxx:530, reconfigure()]
2020-12-11T14:59:07.643_514+08:00 [75ec] [INFO] server 1 is added to cluster [handle_commit.cxx:605, reconfigure()]
2020-12-11T14:59:07.643_551+08:00 [75ec] [INFO] server 3 is added to cluster [handle_commit.cxx:605, reconfigure()]
2020-12-11T14:59:07.643_553+08:00 [75ec] [INFO] add peer 1, ip:port, voting member
```


2020-12-11T14:59:07.643_427+08:00 [75ec] [INFO] `sucessfully` receive a snapshot (idx 15 term 7) from leader [handle_snapshot_sync.cxx:473, handle_snapshot_sync_req()]

change sucessfully to successfully