### PR TITLE
Support leadership transfer

### DIFF
--- a/include/libnuraft/raft_params.hxx
+++ b/include/libnuraft/raft_params.hxx
@@ -82,6 +82,7 @@ struct raft_params {
         , custom_commit_quorum_size_(0)
         , custom_election_quorum_size_(0)
         , leadership_expiry_(0)
+        , leadership_transfer_min_wait_time_(0)
         , allow_temporary_zero_priority_leader_(true)
         , auto_forwarding_(false)
         , use_bg_thread_for_urgent_commit_(true)
@@ -422,6 +423,21 @@ public:
      * (the same as the original Raft logic).
      */
     int32 leadership_expiry_;
+
+    /**
+     * Minimum wait time required for transferring the leadership
+     * in millisecond. If this value is non-zero, and the below
+     * conditions are met together,
+     *   - the elapsed time since this server became a leader
+     *     is longer than this number, and
+     *   - the current leader's priority is not the highest one, and
+     *   - all peers are responding, and
+     *   - the log gaps of all peers are smaller than `stale_log_gap_`, and
+     *   - `allow_leadership_transfer` of the state machine returns true,
+     * then the current leader will transfer its leadership to the peer
+     * with the highest priority.
+     */
+    int32 leadership_transfer_min_wait_time_;
 
     /**
      * If true, zero-priority member can initiate vote

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -613,11 +613,12 @@ protected:
     };
 
 protected:
-    void log_current_params();
+    void apply_and_log_current_params();
     void cancel_schedulers();
     void schedule_task(ptr<delayed_task>& task, int32 milliseconds);
     void cancel_task(ptr<delayed_task>& task);
     bool check_leadership_validity();
+    void check_leadership_transfer();
     void update_rand_timeout();
     void cancel_global_requests();
 
@@ -743,6 +744,8 @@ protected:
                                              ptr<resp_msg> resp);
 
     void remove_peer_from_peers(const ptr<peer>& pp);
+
+    void check_overall_status();
 
 protected:
     static const int default_snapshot_sync_block_size;
@@ -1148,6 +1151,17 @@ protected:
      * Lock for `last_snapshot_`.
      */
     mutable std::mutex last_snapshot_lock_;
+
+    /**
+     * Timer that will be reset on becoming a leader.
+     */
+    timer_helper leadership_transfer_timer_;
+
+    /**
+     * Timer that will be used for status checking
+     * for each heartbeat period.
+     */
+    timer_helper status_check_timer_;
 };
 
 } // namespace nuraft;

--- a/include/libnuraft/state_machine.hxx
+++ b/include/libnuraft/state_machine.hxx
@@ -287,6 +287,17 @@ public:
      *         `false` if does not want to create snapshot.
      */
     virtual bool chk_create_snapshot() { return true; }
+
+    /**
+     * Decide to transfer leadership.
+     * Once the other conditions are met, Raft core will invoke
+     * this function to ask if it is allowed to transfer the
+     * leadership to other member.
+     *
+     * @return `true` if wants to transfer leadership.
+     *         `false` if not.
+     */
+    virtual bool allow_leadership_transfer() { return true; }
 };
 
 }

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -945,10 +945,15 @@ void raft_server::handle_append_entries_resp(resp_msg& resp) {
     // such as the response was sent out long time ago
     // and the role was updated by UpdateTerm call
     // Try to match up the logs for this peer
-    if (role_ == srv_role::leader && need_to_catchup) {
-        p_db("reqeust append entries need to catchup, p %d\n",
-             (int)p->get_id());
-        request_append_entries(p);
+    if (role_ == srv_role::leader) {
+        if (need_to_catchup) {
+            p_db("reqeust append entries need to catchup, p %d\n",
+                 (int)p->get_id());
+            request_append_entries(p);
+        }
+        if (status_check_timer_.timeout_and_reset()) {
+            check_overall_status();
+        }
     }
 }
 


### PR DESCRIPTION
* Added a configurable option that if there is a server in the same
group with higher priority, the leader will transfer its leadership
to the server if all other peers are healthy.