### PR TITLE
Do not call `remote_endpoint()` on failed connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ How to Build
 
 * Ubuntu
 ```sh
-$ sudo apt-get install cmake
-$ sudo apt-get install openssl libssl-dev
+$ sudo apt-get install cmake openssl libssl-dev libz-dev
 ```
 
 * OSX


### PR DESCRIPTION
* Calling `remote_endpoint()` with invalid socket will cause an
unintended exception, which results in triggering self-defense
logic by exception handler.