### PR TITLE
Fix formating specifiers in logging

### DIFF
--- a/src/handle_vote.cxx
+++ b/src/handle_vote.cxx
@@ -89,9 +89,9 @@ void raft_server::request_prevote() {
         if (pre_vote_.live_ + pre_vote_.dead_ < quorum_size + 1) {
             // Pre-vote failed due to non-responding voters.
             pre_vote_.failure_count_++;
-            p_wn("total %zu nodes (including this node) responded for pre-vote "
-                 "(term %zu, live %zu, dead %zu), at least %zu nodes should "
-                 "respond. failure count %zu",
+            p_wn("total %d nodes (including this node) responded for pre-vote "
+                 "(term %zu, live %d, dead %d), at least %d nodes should "
+                 "respond. failure count %d",
                  pre_vote_.live_.load() + pre_vote_.dead_.load(),
                  pre_vote_.term_,
                  pre_vote_.live_.load(),


### PR DESCRIPTION
All values (`live_`, `dead_`, `quorum_size`, `failure_count_`) are signed (except `term_`) and seem like in debug mode it can lead to undefined behavior during logging:
```
total 1 nodes (including this node) responded for pre-vote (term 1, live 0, dead 1), at least 139633681760258 
nodes should respond. failure count 15                                                                                                                                                                                                         ```
