### PR TITLE
Clearing busy flag should be protected by lock

### DIFF
--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -925,8 +925,8 @@ public:
 
         ptr<asio_rpc_client> self = this->shared_from_this();
         while (!socket().is_open()) { // Dummy one-time loop
-            p_db( "socket to %s:%s is not opened yet",
-                  host_.c_str(), port_.c_str() );
+            p_db( "socket %p to %s:%s is not opened yet",
+                  this, host_.c_str(), port_.c_str() );
 
             // WARNING:
             //   Only one thread can establish connection at a time.
@@ -1109,15 +1109,15 @@ private:
         if (to == true) {
             bool exp = false;
             if (!socket_busy_.compare_exchange_strong(exp, true)) {
-                p_ft("socket is already in use, race happened on connection to %s:%s",
-                     host_.c_str(), port_.c_str());
+                p_ft("socket %p is already in use, race happened on connection to %s:%s",
+                     this, host_.c_str(), port_.c_str());
                 assert(0);
             }
         } else {
             bool exp = true;
             if (!socket_busy_.compare_exchange_strong(exp, false)) {
-                p_ft("socket is already idle, race happened on connection to %s:%s",
-                     host_.c_str(), port_.c_str());
+                p_ft("socket %p is already idle, race happened on connection to %s:%s",
+                     this, host_.c_str(), port_.c_str());
                 assert(0);
             }
         }
@@ -1147,8 +1147,8 @@ private:
                    asio::ip::tcp::resolver::iterator itor)
     {
         if (!err) {
-            p_in( "connected to %s:%s (as a client)",
-                  host_.c_str(), port_.c_str() );
+            p_in( "%p connected to %s:%s (as a client)",
+                  this, host_.c_str(), port_.c_str() );
             if (ssl_enabled_) {
 #ifdef SSL_LIBRARY_NOT_FOUND
                 assert(0); // Should not reach here.

--- a/src/peer.cxx
+++ b/src/peer.cxx
@@ -200,7 +200,7 @@ void peer::recreate_rpc(ptr<srv_config>& config,
         reconn_backoff_.set_duration_ms(new_duration_ms);
 
         rpc_ = factory->create_client(config->get_endpoint());
-        p_tr("reconnect peer %zu", config_->get_id());
+        p_in("%p reconnect peer %zu", rpc_.get(), config_->get_id());
 
     } else {
         p_tr("skip reconnect this time");

--- a/src/peer.cxx
+++ b/src/peer.cxx
@@ -46,6 +46,13 @@ void peer::send_req( ptr<peer> myself,
     ptr<rpc_result> pending = cs_new<rpc_result>(handler);
     ptr<rpc_client> rpc_local = nullptr;
     {   std::lock_guard<std::mutex> l(rpc_protector_);
+        if (!rpc_) {
+            // Nothing will be sent, immediately free it
+            // to serve next operation.
+            p_tr("rpc local is null");
+            set_free();
+            return;
+        }
         rpc_local = rpc_;
     }
     rpc_handler h = (rpc_handler)std::bind
@@ -59,12 +66,6 @@ void peer::send_req( ptr<peer> myself,
                       std::placeholders::_2 );
     if (rpc_local) {
         rpc_local->send(req, h);
-
-    } else {
-        // Nothing has been sent, immediately free it
-        // to serve next operation.
-        p_tr("rpc local is null");
-        set_free();
     }
 }
 
@@ -123,10 +124,12 @@ void peer::handle_rpc_result( ptr<peer> myself,
                       given_rpc_id );
                 return;
             }
-        }
-
-        if ( msg_types_to_free.find(req->get_type()) != msg_types_to_free.end() ) {
-            set_free();
+            // WARNING:
+            //   `set_free()` should be protected by `rpc_protector_`, otherwise
+            //   it may free the peer even though new RPC client is already created.
+            if ( msg_types_to_free.find(req->get_type()) != msg_types_to_free.end() ) {
+                set_free();
+            }
         }
 
         reset_active_timer();
@@ -200,7 +203,12 @@ void peer::recreate_rpc(ptr<srv_config>& config,
         reconn_backoff_.set_duration_ms(new_duration_ms);
 
         rpc_ = factory->create_client(config->get_endpoint());
-        p_in("%p reconnect peer %zu", rpc_.get(), config_->get_id());
+        p_tr("%p reconnect peer %zu", rpc_.get(), config_->get_id());
+
+        // WARNING:
+        //   A reconnection attempt should be treated as an activity,
+        //   hence reset timer.
+        reset_active_timer();
 
     } else {
         p_tr("skip reconnect this time");


### PR DESCRIPTION
* `handle_rpc_result` can be invoked asynchronously without Raft `lock_`,
hence `set_free()` should be called under `rpc_protector_`. Otherwise,
it may free the flag even though a new RPC client is created, which
results in race condition.