### PR TITLE
change to use PROJECT_SOURCE_DIR instead of CMAKE_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,7 +190,7 @@ set(ROOT_SRC ${PROJECT_SOURCE_DIR}/src)
 set(EXAMPLES_SRC ${PROJECT_SOURCE_DIR}/examples)
 
 # === Copy script files ===
-file(COPY ${CMAKE_SOURCE_DIR}/scripts/test/runtests.sh
+file(COPY ${PROJECT_SOURCE_DIR}/scripts/test/runtests.sh
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 # === Generate dummy self-signed cert and key for testing ===


### PR DESCRIPTION
update `CMakeLists.txt` (`CMAKE_SOURCE_DIR` to `PROJECT_SOURCE_DIR`).
failed to generate Makefile when using `add_subdirectory`.