### PR TITLE
Reset peer's log info once new connection is established

### DIFF
--- a/include/libnuraft/peer.hxx
+++ b/include/libnuraft/peer.hxx
@@ -232,7 +232,7 @@ public:
     void set_manual_free()      { manual_free_ = true; }
     bool is_manual_free()       { return manual_free_; }
 
-    void recreate_rpc(ptr<srv_config>& config,
+    bool recreate_rpc(ptr<srv_config>& config,
                       context& ctx);
 
     void reset_rpc_errs()   { rpc_errs_ = 0; }

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -693,7 +693,7 @@ protected:
     void reconfigure(const ptr<cluster_config>& new_config);
     void update_target_priority();
     void decay_target_priority();
-    void reconnect_client(peer& p);
+    bool reconnect_client(peer& p);
     void become_leader();
     void become_follower();
     void check_srv_to_leave_timeout();

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -161,9 +161,9 @@ bool raft_server::request_append_entries(ptr<peer> p) {
         }
     }
     if (need_to_reconnect) {
-        reconnect_client(*p);
+        bool reconnected = reconnect_client(*p);
         uint64_t p_next_log_idx = p->get_next_log_idx();
-        if (p_next_log_idx) {
+        if (reconnected && p_next_log_idx) {
             // NOTE:
             //   Discussions in https://github.com/eBay/NuRaft/issues/181
             //

--- a/src/handle_vote.cxx
+++ b/src/handle_vote.cxx
@@ -77,11 +77,7 @@ void raft_server::request_prevote() {
 
             if (recreate) {
                 p_in("reset RPC client for peer %d", s_config->get_id());
-                bool ok = pp->recreate_rpc(s_config, *ctx_);
-                if (ok) {
-                    pp->set_free();
-                    pp->set_manual_free();
-                }
+                pp->recreate_rpc(s_config, *ctx_);
             }
         }
     }

--- a/src/handle_vote.cxx
+++ b/src/handle_vote.cxx
@@ -77,9 +77,11 @@ void raft_server::request_prevote() {
 
             if (recreate) {
                 p_in("reset RPC client for peer %d", s_config->get_id());
-                pp->recreate_rpc(s_config, *ctx_);
-                pp->set_free();
-                pp->set_manual_free();
+                bool ok = pp->recreate_rpc(s_config, *ctx_);
+                if (ok) {
+                    pp->set_free();
+                    pp->set_manual_free();
+                }
             }
         }
     }

--- a/src/peer.cxx
+++ b/src/peer.cxx
@@ -180,16 +180,16 @@ void peer::handle_rpc_result( ptr<peer> myself,
     }
 }
 
-void peer::recreate_rpc(ptr<srv_config>& config,
+bool peer::recreate_rpc(ptr<srv_config>& config,
                         context& ctx)
 {
-    if (abandoned_) return;
+    if (abandoned_) return false;
 
     ptr<rpc_client_factory> factory = nullptr;
     {   std::lock_guard<std::mutex> l(ctx.ctx_lock_);
         factory = ctx.rpc_cli_factory_;
     }
-    if (!factory) return;
+    if (!factory) return false;
 
     std::lock_guard<std::mutex> l(rpc_protector_);
 
@@ -209,10 +209,12 @@ void peer::recreate_rpc(ptr<srv_config>& config,
         //   A reconnection attempt should be treated as an activity,
         //   hence reset timer.
         reset_active_timer();
+        return true;
 
     } else {
         p_tr("skip reconnect this time");
     }
+    return false;
 }
 
 void peer::shutdown() {

--- a/src/peer.cxx
+++ b/src/peer.cxx
@@ -209,6 +209,9 @@ bool peer::recreate_rpc(ptr<srv_config>& config,
         //   A reconnection attempt should be treated as an activity,
         //   hence reset timer.
         reset_active_timer();
+
+        set_free();
+        set_manual_free();
         return true;
 
     } else {

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -893,12 +893,7 @@ bool raft_server::reconnect_client(peer& p) {
     if (s_config) {
         p_db( "reset RPC client for peer %d",
               p.get_id() );
-        bool ok = p.recreate_rpc(s_config, *ctx_);
-        if (ok) {
-            p.set_free();
-            p.set_manual_free();
-        }
-        return ok;
+        return p.recreate_rpc(s_config, *ctx_);
     }
     return false;
 }

--- a/tests/unit/failure_test.cxx
+++ b/tests/unit/failure_test.cxx
@@ -142,10 +142,9 @@ int simple_conflict_test() {
     // Now S2 replicate messages.
     // S1 has conflict, so that it should discard its local logs.
     s2.dbgLog(" --- S2 starts to replicate ---");
-    s2.fNet->execReqResp();
-    s2.fNet->execReqResp();
-    s2.fNet->execReqResp();
-    s2.fNet->execReqResp();
+    for (size_t ii = 0; ii < 10; ++ii) {
+        s2.fNet->execReqResp();
+    }
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Check if all messages are committed.

--- a/tests/unit/raft_server_test.cxx
+++ b/tests/unit/raft_server_test.cxx
@@ -1799,6 +1799,8 @@ int snapshot_basic_test() {
 
     // Trigger heartbeat to S3, it will initiate snapshot transmission.
     s1.fTimer->invoke(timer_task_type::heartbeat_timer);
+    s1.fNet->execReqResp();
+
     // Send the entire snapshot.
     do {
         s1.fNet->execReqResp();


### PR DESCRIPTION
* To support offline data change (including snapshot installation),
peer's log info should be reset if the previous connection is gone.
Otherwise, there will be a data mismatch and the leader will attempt
to send logs based on incorrect info.

* The reset peer info will be recovered during the first
`append_entries` communication between the leader and the peer.