### PR TITLE
Fix rare race condition on commit cv

### DIFF
--- a/src/handle_commit.cxx
+++ b/src/handle_commit.cxx
@@ -106,8 +106,12 @@ void raft_server::commit_in_bg() {
                 sm_commit_index_ >= log_store_->next_slot() - 1 ) {
             std::unique_lock<std::mutex> lock(commit_cv_lock_);
 
+            auto wait_check = [this] () {
+                return (log_store_->next_slot() - 1 > sm_commit_index_ &&
+                        quick_commit_index_ > sm_commit_index_) || stopping_;
+            };
             p_tr("commit_cv_ sleep\n");
-            commit_cv_.wait(lock);
+            commit_cv_.wait(lock, wait_check);
 
             p_tr("commit_cv_ wake up\n");
             if (stopping_) {


### PR DESCRIPTION
Usage of condition variables without additional checks almost always leads to bugs. In this case, it may happen that `commit_cv` was notified before `commit_cv_lock_` was acquired. It can lead to a long wait until the next commit notification.