### PR TITLE
Add optional timeout to auto_forwarded requests

### DIFF
--- a/include/libnuraft/raft_params.hxx
+++ b/include/libnuraft/raft_params.hxx
@@ -90,6 +90,7 @@ struct raft_params {
         , auto_adjust_quorum_for_small_cluster_(false)
         , locking_method_type_(dual_mutex)
         , return_method_(blocking)
+        , auto_forwarding_req_timeout_(client_req_timeout_ * 3)
         {}
 
     /**
@@ -311,6 +312,18 @@ struct raft_params {
     }
 
     /**
+     * Set the auto-forwarding request timeout
+     *
+     * @param timeout_ms New timeout in millisecond.
+     * @return self
+     */
+    raft_params& with_auto_forwarding_req_timeout(int32 timeout_ms) {
+        auto_forwarding_req_timeout_ = timeout_ms;
+        return *this;
+    }
+
+
+    /**
      * Return heartbeat interval.
      * If given heartbeat interval is smaller than a specific value
      * based on election timeout, return it instead.
@@ -488,6 +501,12 @@ public:
      * To choose blocking call or asynchronous call.
      */
     return_method_type return_method_;
+
+    /**
+     * Wait ms for response after forwarding request to leader.
+     * must be larger than client_req_timeout_.
+     */
+    int32 auto_forwarding_req_timeout_;
 };
 
 }

--- a/include/libnuraft/raft_params.hxx
+++ b/include/libnuraft/raft_params.hxx
@@ -90,7 +90,7 @@ struct raft_params {
         , auto_adjust_quorum_for_small_cluster_(false)
         , locking_method_type_(dual_mutex)
         , return_method_(blocking)
-        , auto_forwarding_req_timeout_(client_req_timeout_ * 3)
+        , auto_forwarding_req_timeout_(0)
         {}
 
     /**

--- a/include/libnuraft/rpc_cli.hxx
+++ b/include/libnuraft/rpc_cli.hxx
@@ -40,9 +40,11 @@ class rpc_client {
     __interface_body__(rpc_client);
 
 public:
-    virtual void send(ptr<req_msg>& req, rpc_handler& when_done) = 0;
+    virtual void send(ptr<req_msg>& req, rpc_handler& when_done, uint64_t send_timeout_ms = 0) = 0;
 
     virtual uint64_t get_id() const = 0;
+
+    virtual bool is_abandoned() const = 0;
 };
 
 }

--- a/tests/unit/fake_network.cxx
+++ b/tests/unit/fake_network.cxx
@@ -298,7 +298,7 @@ FakeClient::FakeClient(FakeNetwork* mother,
 
 FakeClient::~FakeClient() {}
 
-void FakeClient::send(ptr<req_msg>& req, rpc_handler& when_done) {
+void FakeClient::send(ptr<req_msg>& req, rpc_handler& when_done, uint64_t /*send_timeout_ms*/) {
     SimpleLogger* ll = motherNet->getBase()->getLogger();
     _log_info(ll, "got request %s -> %s, %s",
               motherNet->getEndpoint().c_str(),
@@ -319,6 +319,10 @@ bool FakeClient::isDstOnline() {
 
 uint64_t FakeClient::get_id() const {
     return myId;
+}
+
+bool FakeClient::is_abandoned() const {
+    return false;
 }
 
 

--- a/tests/unit/fake_network.hxx
+++ b/tests/unit/fake_network.hxx
@@ -137,13 +137,15 @@ public:
 
     ~FakeClient();
 
-    void send(ptr<req_msg>& req, rpc_handler& when_done);
+    void send(ptr<req_msg>& req, rpc_handler& when_done, uint64_t send_timeout_ms = 0);
 
     void dropPackets();
 
     bool isDstOnline();
 
     uint64_t get_id() const;
+
+    bool is_abandoned() const;
 
 private:
     uint64_t myId;

--- a/tests/unit/raft_package_asio.hxx
+++ b/tests/unit/raft_package_asio.hxx
@@ -80,7 +80,8 @@ public:
     }
 
     void initServer(bool enable_ssl = false,
-                    bool use_global_asio = false) {
+                    bool use_global_asio = false,
+                    const raft_server::init_options & opt = raft_server::init_options()) {
         std::string log_file_name = "./srv" + std::to_string(myId) + ".log";
         myLogWrapper = cs_new<logger_wrapper>(log_file_name);
         myLog = myLogWrapper;
@@ -126,7 +127,7 @@ public:
         params.with_client_req_timeout(10000);
         context* ctx( new context( sMgr, sm, listener, myLog,
                                    rpc_cli_factory, scheduler, params ) );
-        raftServer = cs_new<raft_server>(ctx);
+        raftServer = cs_new<raft_server>(ctx, opt);
 
         // Listen.
         asioListener = listener;


### PR DESCRIPTION
Add `auto_forwarding_req_timeout_` setting which cancels forwarded request to the leader after the timeout. 