### PR TITLE
Get rid of auto_destoyer

### DIFF
--- a/include/libnuraft/global_mgr.hxx
+++ b/include/libnuraft/global_mgr.hxx
@@ -68,9 +68,15 @@ struct nuraft_global_config {
 
 static nuraft_global_config __DEFAULT_NURAFT_GLOBAL_CONFIG;
 
-// Singleton class.
 class nuraft_global_mgr {
 public:
+    nuraft_global_mgr();
+
+    ~nuraft_global_mgr();
+
+    __nocopy__(nuraft_global_mgr);
+public:
+
     /**
      * Initialize the global instance.
      *
@@ -145,12 +151,6 @@ public:
 private:
     struct worker_handle;
 
-    nuraft_global_mgr();
-
-    ~nuraft_global_mgr();
-
-    __nocopy__(nuraft_global_mgr);
-
     /**
      * Initialize thread pool with the given config.
      */
@@ -165,16 +165,6 @@ private:
      * Loop for append worker threads.
      */
     void append_worker_loop(ptr<worker_handle> handle);
-
-    /**
-     * Lock for global manager instance.
-     */
-    static std::mutex instance_lock_;
-
-    /**
-     * Global manager instance.
-     */
-    static std::atomic<nuraft_global_mgr*> instance_;
 
     /**
      * Lock for global Asio service instance.

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -44,14 +44,6 @@ const int raft_server::default_snapshot_sync_block_size = 4 * 1024;
 
 raft_server::limits raft_server::raft_limits_;
 
-struct auto_destroyer {
-    ~auto_destroyer() {
-        stat_mgr::destroy();
-        nuraft_global_mgr::shutdown();
-    }
-};
-static auto_destroyer auto_destroyer_;
-
 raft_server::raft_server(context* ctx, const init_options& opt)
     : bg_append_ea_(nullptr)
     , initialized_(false)

--- a/src/stat_mgr.hxx
+++ b/src/stat_mgr.hxx
@@ -163,11 +163,7 @@ private:
 // Singleton class
 class stat_mgr {
 public:
-    static stat_mgr* init();
-
     static stat_mgr* get_instance();
-
-    static void destroy();
 
     stat_elem* get_stat(const std::string& stat_name);
 
@@ -180,9 +176,6 @@ public:
     void reset_all_stats();
 
 private:
-    static std::mutex instance_lock_;
-    static std::atomic<stat_mgr*> instance_;
-
     stat_mgr();
     ~stat_mgr();
 


### PR DESCRIPTION
* The destruction order of global static variables is non-deterministic.