### PR TITLE
Get rid of event_awaiter.h from raft_server.hxx

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 
 #include "async.hxx"
 #include "callback.hxx"
-#include "event_awaiter.h"
 #include "internal_timer.hxx"
 #include "log_store.hxx"
 #include "snapshot_sync_req.hxx"
@@ -630,27 +629,7 @@ protected:
     /**
      * A set of components required for auto-forwarding.
      */
-    struct auto_fwd_pkg {
-        /**
-         * Available RPC clients.
-         */
-        std::list<ptr<rpc_client>> rpc_client_idle_;
-
-        /**
-         * RPC clients in use.
-         */
-        std::unordered_set<ptr<rpc_client>> rpc_client_in_use_;
-
-        /**
-         * Mutex.
-         */
-        std::mutex lock_;
-
-        /**
-         * Event awaiter.
-         */
-        EventAwaiter ea_;
-    };
+    struct auto_fwd_pkg;
 
 protected:
     void apply_and_log_current_params();

--- a/src/handle_user_cmd.cxx
+++ b/src/handle_user_cmd.cxx
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "cluster_config.hxx"
 #include "context.hxx"
+#include "event_awaiter.h"
 #include "rpc_cli_factory.hxx"
 #include "tracer.hxx"
 
@@ -29,6 +30,28 @@ limitations under the License.
 #include <sstream>
 
 namespace nuraft {
+
+struct raft_server::auto_fwd_pkg {
+    /**
+     * Available RPC clients.
+     */
+    std::list<ptr<rpc_client>> rpc_client_idle_;
+
+    /**
+     * RPC clients in use.
+     */
+    std::unordered_set<ptr<rpc_client>> rpc_client_in_use_;
+
+    /**
+     * Mutex.
+     */
+    std::mutex lock_;
+
+    /**
+     * Event awaiter.
+     */
+    EventAwaiter ea_;
+};
 
 ptr< cmd_result< ptr<buffer> > > raft_server::add_srv(const srv_config& srv)
 {


### PR DESCRIPTION
* We should not expose the internal header to the public.