### PR TITLE
Make fake network transfer order deterministic

### DIFF
--- a/tests/unit/fake_network.cxx
+++ b/tests/unit/fake_network.cxx
@@ -103,7 +103,7 @@ bool FakeNetwork::execReqResp(const std::string& endpoint) {
     if (endpoint.empty()) {
         // Do the same thing to all.
 
-        std::unordered_map< std::string, ptr<FakeClient> > clients_clone;
+        std::map< std::string, ptr<FakeClient> > clients_clone;
 
         // WARNING:
         //   As a result of processing req or resp, client re-connection

--- a/tests/unit/fake_network.hxx
+++ b/tests/unit/fake_network.hxx
@@ -100,7 +100,10 @@ private:
     std::string myEndpoint;
     ptr<FakeNetworkBase> base;
     ptr<msg_handler> handler;
-    std::unordered_map< std::string, ptr<FakeClient> > clients;
+    // NOTE: We don't use `unordered_map` as the order of traversal
+    //       will be different according to platforms. We should make
+    //       the test deterministic.
+    std::map< std::string, ptr<FakeClient> > clients;
     std::mutex clientsLock;
     std::list< ptr<FakeClient> > staleClients;
     bool online;


### PR DESCRIPTION
* If we use `unordered_map`, its traversal order won't be deterministic
and depending on platforms the test executable is running. We should
make the test deterministic.