### PR TITLE
Fix to intermittent test failure of auto forwarding

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -753,6 +753,7 @@ protected:
                                ptr<rpc_client> rpc_cli,
                                ptr<resp_msg>& resp,
                                ptr<rpc_exception>& err);
+    void cleanup_auto_fwd_pkgs();
 
     void set_config(const ptr<cluster_config>& new_config);
     ptr<snapshot> get_last_snapshot() const;
@@ -1038,6 +1039,11 @@ protected:
      * Queue of request-response pairs for auto-forwarding (async mode only).
      */
     std::list<auto_fwd_req_resp> auto_fwd_reqs_;
+
+    /**
+     * Lock for auto-forwarding queue.
+     */
+    std::mutex auto_fwd_reqs_lock_;
 
     /**
      * Current role of this server.

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -463,6 +463,15 @@ void raft_server::shutdown() {
         bg_append_thread_.join();
     }
 
+    {
+        auto_lock(auto_fwd_reqs_lock_);
+        p_in("clean up auto-forwarding queue: %zu elems", auto_fwd_reqs_.size());
+        auto_fwd_reqs_.clear();
+    }
+
+    p_in("clean up auto-forwarding clients");
+    cleanup_auto_fwd_pkgs();
+
     p_in("raft_server shutdown completed.");
 }
 

--- a/tests/unit/asio_service_test.cxx
+++ b/tests/unit/asio_service_test.cxx
@@ -1317,6 +1317,7 @@ int auto_forwarding_test(bool async) {
         size_t ii;
     };
 
+    std::mutex handlers_lock;
     std::list< ptr< cmd_result< ptr<buffer> > > > handlers;
     auto send_msg = [&](TestSuite::ThreadArgs* t_args) -> int {
         MsgArgs* args = (MsgArgs*)t_args;
@@ -1325,6 +1326,8 @@ int auto_forwarding_test(bool async) {
         msg->put(test_msg);
         ptr< cmd_result< ptr<buffer> > > ret =
             s2.raftServer->append_entries( {msg} );
+
+        std::lock_guard<std::mutex> l(handlers_lock);
         handlers.push_back(ret);
         return 0;
     };


### PR DESCRIPTION
* Should use lock for list manipulation.

* Added explicit shutdown for things related to auto-forwarding.