### PR TITLE
Disable reconnection back-off timer for deterministic tests

### DIFF
--- a/include/libnuraft/debugging_options.hxx
+++ b/include/libnuraft/debugging_options.hxx
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <atomic>
+
+namespace nuraft {
+
+struct debugging_options {
+    debugging_options()
+        : disable_reconn_backoff_(false)
+        {}
+
+    static debugging_options& get_instance() {
+        static debugging_options opt;
+        return opt;
+    }
+
+    /**
+     * If `true`, reconnection back-off timer will be disabled,
+     * and there will be frequent reconnection attempts for every
+     * request to follower.
+     */
+    std::atomic<bool> disable_reconn_backoff_;
+};
+
+}

--- a/tests/unit/failure_test.cxx
+++ b/tests/unit/failure_test.cxx
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 **************************************************************************/
 
+#include "debugging_options.hxx"
 #include "fake_network.hxx"
 #include "raft_package_fake.hxx"
 
@@ -596,6 +597,9 @@ int main(int argc, char** argv) {
     TestSuite ts(argc, argv);
 
     ts.options.printTestMessage = true;
+
+    // Disable reconnection timer for deterministic test.
+    debugging_options::get_instance().disable_reconn_backoff_ = true;
 
     ts.doTest( "simple conflict test",
                simple_conflict_test );

--- a/tests/unit/raft_server_test.cxx
+++ b/tests/unit/raft_server_test.cxx
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 **************************************************************************/
 
+#include "debugging_options.hxx"
 #include "fake_network.hxx"
 #include "raft_package_fake.hxx"
 
@@ -2358,6 +2359,9 @@ int main(int argc, char** argv) {
     TestSuite ts(argc, argv);
 
     ts.options.printTestMessage = true;
+
+    // Disable reconnection timer for deterministic test.
+    debugging_options::get_instance().disable_reconn_backoff_ = true;
 
     ts.doTest( "make group test",
                make_group_test );


### PR DESCRIPTION
* For deterministic tests based on mock network layer (raft_server_test
and failure_test), we should disable back-off timer as it makes test
depend on the timing.