### PR TITLE
Add an option for grace period

### DIFF
--- a/include/libnuraft/raft_params.hxx
+++ b/include/libnuraft/raft_params.hxx
@@ -92,6 +92,7 @@ struct raft_params {
         , locking_method_type_(dual_mutex)
         , return_method_(blocking)
         , auto_forwarding_req_timeout_(0)
+        , grace_period_of_lagging_state_machine_(0)
         {}
 
     /**
@@ -514,6 +515,18 @@ public:
      * If 0, there will be no timeout for auto forwarding.
      */
     int32 auto_forwarding_req_timeout_;
+
+    /**
+     * If non-zero, any server whose state machine's commit index is
+     * lagging behind the last committed log index will not
+     * initiate vote requests for the given amount of time
+     * in milliseconds.
+     *
+     * The purpose of this option is to avoid a server (whose state
+     * machine is still catching up with the committed logs and does
+     * not contain the latest data yet) being a leader.
+     */
+    int32 grace_period_of_lagging_state_machine_;
 };
 
 }

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -722,8 +722,8 @@ protected:
 
     bool check_cond_for_zp_election();
     void request_prevote();
-    void initiate_vote(bool ignore_priority = false);
-    void request_vote(bool ignore_priority);
+    void initiate_vote(bool force_vote = false);
+    void request_vote(bool force_vote);
     void request_append_entries();
     bool request_append_entries(ptr<peer> p);
     void handle_peer_resp(ptr<resp_msg>& resp, ptr<rpc_exception>& err);
@@ -911,6 +911,13 @@ protected:
      * Actual commit index of state machine.
      */
     std::atomic<ulong> sm_commit_index_;
+
+    /**
+     * If `grace_period_of_lagging_state_machine_` option is enabled,
+     * the server will not initiate vote if its state machine's commit
+     * index is less than this number.
+     */
+    std::atomic<ulong> lagging_sm_target_index_;
 
     /**
      * (Read-only)
@@ -1264,6 +1271,17 @@ protected:
      * for each heartbeat period.
      */
     timer_helper status_check_timer_;
+
+    /**
+     * Timer that will be used for tracking the time that
+     * this server is blocked from leader election.
+     */
+    timer_helper vote_init_timer_;
+
+    /**
+     * The term when `vote_init_timer_` was reset.
+     */
+    std::atomic<ulong> vote_init_timer_term_;
 };
 
 } // namespace nuraft;

--- a/include/libnuraft/state_machine.hxx
+++ b/include/libnuraft/state_machine.hxx
@@ -29,6 +29,7 @@ limitations under the License.
 
 namespace nuraft {
 
+class cluster_config;
 class snapshot;
 class state_machine {
     __interface_body__(state_machine);
@@ -70,6 +71,15 @@ public:
      */
     virtual ptr<buffer> commit_ext(const ext_op_params& params)
     {   return commit(params.log_idx, *params.data);    }
+
+    /**
+     * (Optional)
+     * Handler on the commit of a configuration change.
+     *
+     * @param log_idx Raft log number of the configuration change.
+     * @param new_conf New cluster configuration.
+     */
+    virtual void commit_config(const ulong log_idx, ptr<cluster_config>& new_conf) { }
 
     /**
      * Pre-commit the given Raft log.

--- a/src/handle_snapshot_sync.cxx
+++ b/src/handle_snapshot_sync.cxx
@@ -497,6 +497,7 @@ bool raft_server::handle_snapshot_sync_req(snapshot_sync_req& req) {
             precommit_index_ = req.get_snapshot().get_last_log_idx();
             sm_commit_index_ = req.get_snapshot().get_last_log_idx();
             quick_commit_index_ = req.get_snapshot().get_last_log_idx();
+            lagging_sm_target_index_ = req.get_snapshot().get_last_log_idx();
 
             ctx_->state_mgr_->save_state(*state_);
 

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -114,12 +114,14 @@ raft_server::raft_server(context* ctx, const init_options& opt)
     apply_and_log_current_params();
     update_rand_timeout();
     precommit_index_ = log_store_->next_slot() - 1;
+    lagging_sm_target_index_ = log_store_->next_slot() - 1;
 
     if (!state_) {
         state_ = cs_new<srv_state>();
         state_->set_term(0);
         state_->set_voted_for(-1);
     }
+    vote_init_timer_term_ = state_->get_term();
 
     print_msg.clear();
 
@@ -283,6 +285,8 @@ void raft_server::start_server(bool skip_initial_election_timeout)
         restart_election_timer();
     }
     priority_change_timer_.reset();
+    vote_init_timer_.set_duration_ms(params->grace_period_of_lagging_state_machine_);
+    vote_init_timer_.reset();
     p_db("server %d started", id_);
 }
 
@@ -347,7 +351,8 @@ void raft_server::apply_and_log_current_params() {
           "custom commit quorum size %d, "
           "custom election quorum size %d, "
           "snapshot receiver %s, "
-          "leadership transfer wait time %d",
+          "leadership transfer wait time %d, "
+          "grace period of lagging state machine %d",
           params->election_timeout_lower_bound_,
           params->election_timeout_upper_bound_,
           params->heart_beat_interval_,
@@ -364,7 +369,8 @@ void raft_server::apply_and_log_current_params() {
           params->custom_commit_quorum_size_,
           params->custom_election_quorum_size_,
           params->exclude_snp_receiver_from_quorum_ ? "EXCLUDED" : "INCLUDED",
-          params->leadership_transfer_min_wait_time_ );
+          params->leadership_transfer_min_wait_time_,
+          params->grace_period_of_lagging_state_machine_ );
 
     status_check_timer_.set_duration_ms(params->heart_beat_interval_);
     status_check_timer_.reset();

--- a/tests/unit/asio_service_test.cxx
+++ b/tests/unit/asio_service_test.cxx
@@ -1399,6 +1399,171 @@ int auto_forwarding_test(bool async) {
     return 0;
 }
 
+int enforced_state_machine_catchup_test() {
+    reset_log_files();
+
+    std::string s1_addr = "localhost:20010";
+    std::string s2_addr = "localhost:20020";
+    std::string s3_addr = "localhost:20030";
+
+    RaftAsioPkg s1(1, s1_addr);
+    RaftAsioPkg s2(2, s2_addr);
+    RaftAsioPkg s3(3, s3_addr);
+    std::vector<RaftAsioPkg*> pkgs = {&s1, &s2, &s3};
+
+    _msg("launching asio-raft servers\n");
+    CHK_Z( launch_servers(pkgs, false) );
+
+    _msg("organizing raft group\n");
+    CHK_Z( make_group(pkgs) );
+
+    CHK_TRUE( s1.raftServer->is_leader() );
+    CHK_EQ(1, s1.raftServer->get_leader());
+    CHK_EQ(1, s2.raftServer->get_leader());
+    CHK_EQ(1, s3.raftServer->get_leader());
+    TestSuite::sleep_sec(1, "wait for Raft group ready");
+
+    for (size_t ii=0; ii<100; ++ii) {
+        std::string msg_str = std::to_string(ii);
+        ptr<buffer> msg = buffer::alloc(sizeof(uint32_t) + msg_str.size());
+        buffer_serializer bs(msg);
+        bs.put_str(msg_str);
+        s1.raftServer->append_entries( {msg} );
+    }
+    TestSuite::sleep_sec(1, "wait for replication");
+
+    // Adjust the priority of S2 to zero, to block it becoming a leader.
+    s1.raftServer->set_priority(2, 0);
+    TestSuite::sleep_sec(1, "set S2's priority to zero");
+
+    // Stop S3, delete data.
+    uint64_t last_committed_idx = s3.raftServer->get_committed_log_idx();
+    s3.raftServer->shutdown();
+    s3.stopAsio();
+    s3.getTestSm()->truncateData(last_committed_idx - 5);
+
+    // Stop S1.
+    s1.raftServer->shutdown();
+    s1.stopAsio();
+    TestSuite::sleep_sec(1, "stop S1 and S3");
+
+    // Restart S3 with grace period option.
+    raft_params new_params = s1.raftServer->get_current_params();
+    new_params.grace_period_of_lagging_state_machine_ = 1000; // 1 second.
+    s3.restartServer(&new_params);
+    TestSuite::sleep_ms(500, "restarting S3");
+
+    // Before the grace period, there should be no leader.
+    CHK_FALSE( s2.raftServer->is_leader() );
+    CHK_FALSE( s3.raftServer->is_leader() );
+
+    // After the grace period, S3 should be the leader.
+    TestSuite::sleep_sec(1, "grace period");
+    CHK_TRUE( s3.raftServer->is_leader() );
+    CHK_EQ(3, s2.raftServer->get_leader());
+
+    // Stop both S2 and S3 and then restart them.
+    s2.raftServer->shutdown();
+    s2.stopAsio();
+    s3.raftServer->shutdown();
+    s3.stopAsio();
+    TestSuite::sleep_sec(1, "stop S2 and S3");
+
+    s2.restartServer();
+    s3.restartServer(&new_params);
+    TestSuite::sleep_ms(500, "restarting S2 and S3");
+
+    // Even before the grace period, S3 should be the leader.
+    CHK_TRUE( s3.raftServer->is_leader() );
+    CHK_EQ(3, s2.raftServer->get_leader());
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+    TestSuite::sleep_sec(1, "shutting down");
+
+    SimpleLogger::shutdown();
+    return 0;
+}
+
+int enforced_state_machine_catchup_with_term_inc_test() {
+    reset_log_files();
+
+    std::string s1_addr = "localhost:20010";
+    std::string s2_addr = "localhost:20020";
+    std::string s3_addr = "localhost:20030";
+
+    RaftAsioPkg s1(1, s1_addr);
+    RaftAsioPkg s2(2, s2_addr);
+    RaftAsioPkg s3(3, s3_addr);
+    std::vector<RaftAsioPkg*> pkgs = {&s1, &s2, &s3};
+
+    _msg("launching asio-raft servers\n");
+    CHK_Z( launch_servers(pkgs, false) );
+
+    _msg("organizing raft group\n");
+    CHK_Z( make_group(pkgs) );
+
+    CHK_TRUE( s1.raftServer->is_leader() );
+    CHK_EQ(1, s1.raftServer->get_leader());
+    CHK_EQ(1, s2.raftServer->get_leader());
+    CHK_EQ(1, s3.raftServer->get_leader());
+    TestSuite::sleep_sec(1, "wait for Raft group ready");
+
+    for (size_t ii=0; ii<100; ++ii) {
+        std::string msg_str = std::to_string(ii);
+        ptr<buffer> msg = buffer::alloc(sizeof(uint32_t) + msg_str.size());
+        buffer_serializer bs(msg);
+        bs.put_str(msg_str);
+        s1.raftServer->append_entries( {msg} );
+    }
+    TestSuite::sleep_sec(1, "wait for replication");
+
+    // Adjust the priority of S2 to zero, to block it becoming a leader.
+    s1.raftServer->set_priority(2, 0);
+    TestSuite::sleep_sec(1, "set S2's priority to zero");
+
+    // Stop S3, delete data.
+    uint64_t last_committed_idx = s3.raftServer->get_committed_log_idx();
+    s3.raftServer->shutdown();
+    s3.stopAsio();
+    s3.getTestSm()->truncateData(last_committed_idx - 5);
+    TestSuite::sleep_ms(500, "stop S3");
+
+    // A few leader changes to increase the term.
+    s1.raftServer->yield_leadership(false, 2);
+    TestSuite::sleep_sec(1, "leader change: S1 -> S2");
+    s2.raftServer->yield_leadership(false, 1);
+    TestSuite::sleep_sec(1, "leader change: S2 -> S1");
+
+    // Stop S1.
+    s1.raftServer->shutdown();
+    s1.stopAsio();
+    TestSuite::sleep_sec(1, "stop S1");
+
+    // Restart S3 with grace period option.
+    raft_params new_params = s1.raftServer->get_current_params();
+    new_params.grace_period_of_lagging_state_machine_ = 1000; // 1 second.
+    s3.restartServer(&new_params);
+    TestSuite::sleep_ms(500, "restarting S3");
+
+    // Before the grace period, there should be no leader.
+    CHK_FALSE( s2.raftServer->is_leader() );
+    CHK_FALSE( s3.raftServer->is_leader() );
+
+    // Even after the grace period, S3 can't be the leader due to term.
+    TestSuite::sleep_ms(1500, "grace period");
+    CHK_FALSE( s3.raftServer->is_leader() );
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+    TestSuite::sleep_sec(1, "shutting down");
+
+    SimpleLogger::shutdown();
+    return 0;
+}
+
 }  // namespace asio_service_test;
 using namespace asio_service_test;
 
@@ -1456,6 +1621,12 @@ int main(int argc, char** argv) {
     ts.doTest( "auto forwarding test",
                auto_forwarding_test,
                TestRange<bool>( {false, true} ) );
+
+    ts.doTest( "enforced state machine catch-up test",
+               enforced_state_machine_catchup_test );
+
+    ts.doTest( "enforced state machine catch-up with term increment test",
+               enforced_state_machine_catchup_with_term_inc_test );
 
 #ifdef ENABLE_RAFT_STATS
     _msg("raft stats: ENABLED\n");

--- a/tests/unit/raft_functional_common.hxx
+++ b/tests/unit/raft_functional_common.hxx
@@ -41,6 +41,7 @@ class TestSm : public state_machine {
 public:
     TestSm(SimpleLogger* logger = nullptr)
         : customBatchSize(0)
+        , lastCommittedConfigIdx(0)
         , myLog(logger)
     {
         (void)myLog;
@@ -56,6 +57,10 @@ public:
         buffer_serializer bs(ret);
         bs.put_u64(log_idx);
         return ret;
+    }
+
+    void commit_config(const ulong log_idx, ptr<cluster_config>& new_conf) {
+        lastCommittedConfigIdx = log_idx;
     }
 
     ptr<buffer> pre_commit(const ulong log_idx, buffer& data) {
@@ -198,7 +203,7 @@ public:
         std::lock_guard<std::mutex> ll(dataLock);
         auto entry = commits.rbegin();
         if (entry == commits.rend()) return 0;
-        return entry->first;
+        return std::max(entry->first, lastCommittedConfigIdx.load());
     }
 
     void create_snapshot(snapshot& s,
@@ -289,18 +294,22 @@ public:
         return 0;
     }
 
-    ulong getLastCommittedIdx() const {
-        std::lock_guard<std::mutex> ll(dataLock);
-        auto entry = commits.rbegin();
-        if (entry == commits.rend()) return 0;
-        return entry->first;
-    }
-
     ptr<buffer> getData(ulong log_idx) const {
         std::lock_guard<std::mutex> ll(dataLock);
         auto entry = commits.find(log_idx);
         if (entry == commits.end()) return nullptr;
         return entry->second;
+    }
+
+    void truncateData(ulong log_idx_upto) {
+        auto entry = preCommits.lower_bound(log_idx_upto);
+        preCommits.erase(entry, preCommits.end());
+        auto entry2 = commits.lower_bound(log_idx_upto);
+        commits.erase(entry2, commits.end());
+
+        if (lastCommittedConfigIdx > log_idx_upto) {
+            lastCommittedConfigIdx = log_idx_upto;
+        }
     }
 
 private:
@@ -313,6 +322,8 @@ private:
     mutable std::mutex lastSnapshotLock;
 
     std::atomic<uint64_t> customBatchSize;
+
+    std::atomic<uint64_t> lastCommittedConfigIdx;
 
     SimpleLogger* myLog;
 };

--- a/tests/unit/raft_server_test.cxx
+++ b/tests/unit/raft_server_test.cxx
@@ -144,7 +144,7 @@ int make_group_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Test message should be the same.
-    uint64_t last_idx = s1.getTestSm()->getLastCommittedIdx();
+    uint64_t last_idx = s1.getTestSm()->last_commit_index();
     CHK_GT(last_idx, 0);
     ptr<buffer> buf = s1.getTestSm()->getData(last_idx);
     CHK_NONNULL( buf.get() );
@@ -1732,7 +1732,7 @@ int follower_reconnect_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Test message should be the same.
-    uint64_t last_idx = s1.getTestSm()->getLastCommittedIdx();
+    uint64_t last_idx = s1.getTestSm()->last_commit_index();
     CHK_GT(last_idx, 0);
     ptr<buffer> buf = s1.getTestSm()->getData(last_idx);
     CHK_NONNULL( buf.get() );


### PR DESCRIPTION
* This option is used for avoiding a server being a leader, when
the server's state machine is lagging behind the last committed index.