### PR TITLE
Fix to order inversion between commit and user threads

### DIFF
--- a/include/libnuraft/debugging_options.hxx
+++ b/include/libnuraft/debugging_options.hxx
@@ -1,12 +1,15 @@
 #pragma once
 
 #include <atomic>
+#include <cstdlib>
+#include <cstddef>
 
 namespace nuraft {
 
 struct debugging_options {
     debugging_options()
         : disable_reconn_backoff_(false)
+        , handle_cli_req_sleep_us_(0)
         {}
 
     static debugging_options& get_instance() {
@@ -20,6 +23,12 @@ struct debugging_options {
      * request to follower.
      */
     std::atomic<bool> disable_reconn_backoff_;
+
+    /**
+     * If non-zero, the thread will sleep the given amount of time
+     * inside `handle_cli_req` function.
+     */
+    std::atomic<size_t> handle_cli_req_sleep_us_;
 };
 
 }

--- a/src/peer.cxx
+++ b/src/peer.cxx
@@ -195,7 +195,8 @@ bool peer::recreate_rpc(ptr<srv_config>& config,
     std::lock_guard<std::mutex> l(rpc_protector_);
 
     bool backoff_timer_disabled =
-        debugging_options::get_instance().disable_reconn_backoff_;
+        debugging_options::get_instance()
+        .disable_reconn_backoff_.load(std::memory_order_relaxed);
     if (backoff_timer_disabled) {
         p_tr("reconnection back-off timer is disabled");
     }

--- a/tests/unit/asio_service_test.cxx
+++ b/tests/unit/asio_service_test.cxx
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 **************************************************************************/
 
+#include "debugging_options.hxx"
 #include "raft_package_asio.hxx"
 
 #include "event_awaiter.h"
@@ -779,28 +780,98 @@ int async_append_handler_test() {
     }
 
     // Append messages asynchronously.
+    const size_t NUM = 10;
     std::list< ptr< cmd_result< ptr<buffer> > > > handlers;
-    for (size_t ii=0; ii<10; ++ii) {
+    std::list<ulong> idx_list;
+    for (size_t ii=0; ii<NUM; ++ii) {
         std::string test_msg = "test" + std::to_string(ii);
         ptr<buffer> msg = buffer::alloc(test_msg.size() + 1);
         msg->put(test_msg);
         ptr< cmd_result< ptr<buffer> > > ret =
             s1.raftServer->append_entries( {msg} );
-        handlers.push_back(ret);
-    }
-    TestSuite::sleep_sec(1, "replication");
 
-    // Now all async handlers should have result.
-    std::list<ulong> idx_list;
-    for (auto& entry: handlers) {
-        ptr< cmd_result< ptr<buffer> > > result = entry;
         cmd_result< ptr<buffer> >::handler_type my_handler =
             std::bind( async_handler,
                        &idx_list,
                        std::placeholders::_1,
                        std::placeholders::_2 );
-        result->when_ready( my_handler );
+        ret->when_ready( my_handler );
+
+        handlers.push_back(ret);
     }
+    TestSuite::sleep_sec(1, "replication");
+
+    // Now all async handlers should have result.
+    CHK_EQ(NUM, idx_list.size());
+
+    // State machine should be identical.
+    CHK_OK( s2.getTestSm()->isSame( *s1.getTestSm() ) );
+    CHK_OK( s3.getTestSm()->isSame( *s1.getTestSm() ) );
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+    TestSuite::sleep_sec(1, "shutting down");
+
+    SimpleLogger::shutdown();
+    return 0;
+}
+
+int async_append_handler_with_order_inversion_test() {
+    reset_log_files();
+
+    std::string s1_addr = "tcp://127.0.0.1:20010";
+    std::string s2_addr = "tcp://127.0.0.1:20020";
+    std::string s3_addr = "tcp://127.0.0.1:20030";
+
+    RaftAsioPkg s1(1, s1_addr);
+    RaftAsioPkg s2(2, s2_addr);
+    RaftAsioPkg s3(3, s3_addr);
+    std::vector<RaftAsioPkg*> pkgs = {&s1, &s2, &s3};
+
+    _msg("launching asio-raft servers\n");
+    CHK_Z( launch_servers(pkgs, false) );
+
+    _msg("organizing raft group\n");
+    CHK_Z( make_group(pkgs) );
+
+    // Set async.
+    for (auto& entry: pkgs) {
+        RaftAsioPkg* pp = entry;
+        raft_params param = pp->raftServer->get_current_params();
+        param.return_method_ = raft_params::async_handler;
+        pp->raftServer->update_params(param);
+    }
+
+    // Set debugging parameter to inject sleep so as to mimic the thread
+    // execution order inversion.
+    debugging_options::get_instance().handle_cli_req_sleep_us_ =
+        RaftAsioPkg::HEARTBEAT_MS * 1500;
+
+    TestSuite::GcFunc gcf([](){ // Auto rollback.
+        debugging_options::get_instance().handle_cli_req_sleep_us_ = 0;
+    });
+
+    std::atomic<bool> handler_invoked(false);
+    {
+        std::string test_msg = "test" + std::to_string(1234);
+        ptr<buffer> msg = buffer::alloc(test_msg.size() + 1);
+        msg->put(test_msg);
+        ptr< cmd_result< ptr<buffer> > > ret =
+            s1.raftServer->append_entries({msg});
+        ret->when_ready( [&handler_invoked]
+                         ( cmd_result< ptr<buffer> >& result,
+                           ptr<std::exception>& err ) -> int {
+            CHK_NONNULL(result.get());
+            handler_invoked = true;
+            return 0;
+        });
+        CHK_TRUE(ret->get_accepted());
+    }
+    TestSuite::sleep_sec(1, "wait for handler");
+
+    // The handler should have been invoked.
+    CHK_TRUE(handler_invoked);
 
     // State machine should be identical.
     CHK_OK( s2.getTestSm()->isSame( *s1.getTestSm() ) );
@@ -1714,6 +1785,9 @@ int main(int argc, char** argv) {
 
     ts.doTest( "async append handler test",
                async_append_handler_test );
+
+    ts.doTest( "async append handler with order inversion test",
+               async_append_handler_with_order_inversion_test );
 
     ts.doTest( "auto quorum size test",
                auto_quorum_size_test );


### PR DESCRIPTION
* If the commit thread executes the state machine operation before the
user thread (in the middle of `append_entries`) installs the commit
element, the user's callback function can be missed.

* Commit thread should make sure that if order inversion is detected,
it should let user thread invoke the callback, by generating the
corresponding commit element initialized with the state machine result.