### PR TITLE
Close snapshot context on timeout

### DIFF
--- a/examples/calculator/calc_state_machine.hxx
+++ b/examples/calculator/calc_state_machine.hxx
@@ -99,6 +99,11 @@ public:
         return ret;
     }
 
+    void commit_config(const ulong log_idx, ptr<cluster_config>& new_conf) {
+        // Nothing to do with configuration change. Just update committed index.
+        last_committed_idx_ = log_idx;
+    }
+
     void rollback(const ulong log_idx, buffer& data) {
         // Nothing to do with rollback,
         // as this example doesn't do anything on pre-commit.

--- a/examples/echo/echo_state_machine.hxx
+++ b/examples/echo/echo_state_machine.hxx
@@ -59,6 +59,11 @@ public:
         return nullptr;
     }
 
+    void commit_config(const ulong log_idx, ptr<cluster_config>& new_conf) {
+        // Nothing to do with configuration change. Just update committed index.
+        last_committed_idx_ = log_idx;
+    }
+
     void rollback(const ulong log_idx, buffer& data) {
         // Extract string from `data.
         buffer_serializer bs(data);

--- a/examples/in_memory_log_store.cxx
+++ b/examples/in_memory_log_store.cxx
@@ -230,7 +230,9 @@ bool inmem_log_store::compact(ulong last_log_index) {
     // WARNING:
     //   Even though nothing has been erased,
     //   we should set `start_idx_` to new index.
-    start_idx_ = last_log_index + 1;
+    if (start_idx_ <= last_log_index) {
+        start_idx_ = last_log_index + 1;
+    }
     return true;
 }
 

--- a/include/libnuraft/internal_timer.hxx
+++ b/include/libnuraft/internal_timer.hxx
@@ -49,10 +49,12 @@ struct timer_helper {
     }
 
     size_t get_duration_us() const {
+        std::lock_guard<std::mutex> l(lock_);
         return duration_us_;
     }
 
     void set_duration_us(size_t us) {
+        std::lock_guard<std::mutex> l(lock_);
         duration_us_ = us;
     }
 
@@ -120,7 +122,7 @@ struct timer_helper {
     std::chrono::time_point<std::chrono::system_clock> t_created_;
     size_t duration_us_;
     mutable bool first_event_fired_;
-    std::mutex lock_;
+    mutable std::mutex lock_;
 };
 
 }

--- a/include/libnuraft/peer.hxx
+++ b/include/libnuraft/peer.hxx
@@ -176,12 +176,13 @@ public:
         return pending_commit_flag_.compare_exchange_strong(t, false);
     }
 
-    void set_snapshot_in_sync(const ptr<snapshot>& s) {
+    void set_snapshot_in_sync(const ptr<snapshot>& s,
+                              ulong timeout_ms = 10 * 1000) {
         if (s == nilptr) {
             snp_sync_ctx_.reset();
         }
         else {
-            snp_sync_ctx_ = cs_new<snapshot_sync_ctx>(s);
+            snp_sync_ctx_ = cs_new<snapshot_sync_ctx>(s, timeout_ms);
         }
     }
 

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -53,6 +53,7 @@ class rpc_client;
 class req_msg;
 class resp_msg;
 class rpc_exception;
+class snapshot_sync_ctx;
 class state_machine;
 class state_mgr;
 struct context;
@@ -748,6 +749,9 @@ protected:
                                           ulong last_log_idx,
                                           ulong term,
                                           ulong commit_idx);
+    bool check_snapshot_timeout(ptr<peer> pp);
+    void destroy_user_snp_ctx(ptr<snapshot_sync_ctx> sync_ctx);
+    void clear_snapshot_sync_ctx(peer& pp);
     void commit(ulong target_idx);
     void snapshot_and_compact(ulong committed_idx);
     bool update_term(ulong term);

--- a/include/libnuraft/snapshot_sync_ctx.hxx
+++ b/include/libnuraft/snapshot_sync_ctx.hxx
@@ -29,13 +29,14 @@ class snapshot;
 struct snapshot_sync_ctx {
 public:
     snapshot_sync_ctx(const ptr<snapshot>& s,
+                      ulong timeout_ms,
                       ulong offset = 0L)
         : snapshot_(s)
         , offset_(offset)
         , user_snp_ctx_(nullptr)
     {
         // 10 seconds by default.
-        timer_.set_duration_sec(10);
+        timer_.set_duration_ms(timeout_ms);
     }
 
     __nocopy__(snapshot_sync_ctx);

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -268,6 +268,7 @@ bool raft_server::request_append_entries(ptr<peer> p) {
     }
 
     p_db("Server %d is busy, skip the request", p->get_id());
+    check_snapshot_timeout(p);
 
     int32 last_ts_ms = p->get_ls_timer_us() / 1000;
     if ( last_ts_ms > params->heart_beat_interval_ ) {

--- a/src/handle_join_leave.cxx
+++ b/src/handle_join_leave.cxx
@@ -568,12 +568,7 @@ void raft_server::handle_join_leave_rpc_err(msg_type t_msg, ptr<peer> p) {
 }
 
 void raft_server::reset_srv_to_join() {
-    ptr<snapshot_sync_ctx> sync_ctx = srv_to_join_->get_snapshot_sync_ctx();
-    if (sync_ctx) {
-        // If user context exists for snapshot, should free it.
-        void*& user_ctx = sync_ctx->get_user_snp_ctx();
-        state_machine_->free_user_snp_ctx(user_ctx);
-    }
+    clear_snapshot_sync_ctx(*srv_to_join_);
     srv_to_join_->shutdown();
     srv_to_join_.reset();
 }

--- a/src/handle_timeout.cxx
+++ b/src/handle_timeout.cxx
@@ -345,11 +345,7 @@ void raft_server::cancel_schedulers() {
         p->shutdown();
 
         // Free user context of snapshot if exists.
-        ptr<snapshot_sync_ctx> sync_ctx = p->get_snapshot_sync_ctx();
-        if (sync_ctx) {
-            void*& user_ctx = sync_ctx->get_user_snp_ctx();
-            state_machine_->free_user_snp_ctx(user_ctx);
-        }
+        clear_snapshot_sync_ctx(*p);
     }
     scheduler_.reset();
 }

--- a/src/handle_timeout.cxx
+++ b/src/handle_timeout.cxx
@@ -74,6 +74,28 @@ void raft_server::handle_hb_timeout(int32 srv_id) {
          srv_to_join_ &&
          srv_to_join_->get_id() == srv_id ) {
         p_in("retrying snapshot read for server %d", srv_id);
+        if (srv_to_join_->need_to_reconnect()) {
+            p_in("rpc client for %d needs reconnection", srv_id);
+
+            ptr<raft_params> params = ctx_->get_params();
+            uint64_t resp_timer_ms = srv_to_join_->get_resp_timer_us() / 1000;
+            if ( resp_timer_ms >= (uint64_t)params->heart_beat_interval_ *
+                                  raft_server::raft_limits_.response_limit_ ) {
+                p_in("response timeout: %lu ms, will not retry", resp_timer_ms);
+                clear_snapshot_sync_ctx(*srv_to_join_);
+                return;
+            }
+
+            ptr<srv_config> s_config =
+                srv_config::deserialize( *srv_to_join_->get_config().serialize() );
+            bool succ = srv_to_join_->recreate_rpc(s_config, *ctx_);
+            if (!succ) {
+                // Reconnection failed.
+                p_wn("reconnection failed, will not retry");
+                clear_snapshot_sync_ctx(*srv_to_join_);
+                return;
+            }
+        }
         sync_log_to_new_srv(0);
         return;
     }

--- a/src/peer.cxx
+++ b/src/peer.cxx
@@ -184,13 +184,19 @@ void peer::handle_rpc_result( ptr<peer> myself,
 bool peer::recreate_rpc(ptr<srv_config>& config,
                         context& ctx)
 {
-    if (abandoned_) return false;
+    if (abandoned_) {
+        p_tr("peer %d is abandoned", config->get_id());
+        return false;
+    }
 
     ptr<rpc_client_factory> factory = nullptr;
     {   std::lock_guard<std::mutex> l(ctx.ctx_lock_);
         factory = ctx.rpc_cli_factory_;
     }
-    if (!factory) return false;
+    if (!factory) {
+        p_tr("client factory is empty");
+        return false;
+    }
 
     std::lock_guard<std::mutex> l(rpc_protector_);
 

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -729,6 +729,8 @@ void raft_server::handle_peer_resp(ptr<resp_msg>& resp, ptr<rpc_exception>& err)
         if (pp) {
             pp->inc_rpc_errs();
             rpc_errs = pp->get_rpc_errs();
+
+            check_snapshot_timeout(pp);
         }
 
         if (rpc_errs < raft_server::raft_limits_.warning_limit_) {
@@ -939,12 +941,7 @@ void raft_server::become_leader() {
         ptr<snapshot> nil_snp;
         for (peer_itor it = peers_.begin(); it != peers_.end(); ++it) {
             ptr<peer> pp = it->second;
-            ptr<snapshot_sync_ctx> sync_ctx = pp->get_snapshot_sync_ctx();
-            if (sync_ctx) {
-                void*& user_ctx = sync_ctx->get_user_snp_ctx();
-                state_machine_->free_user_snp_ctx(user_ctx);
-                pp->set_snapshot_in_sync(nil_snp);
-            }
+            clear_snapshot_sync_ctx(*pp);
             // Reset RPC client for all peers.
             // NOTE: Now we don't reset client, as we already did it
             //       during pre-vote phase.
@@ -1365,6 +1362,20 @@ void raft_server::handle_ext_resp_err(rpc_exception& err) {
     ptr<req_msg> req = err.req();
     p_in( "receive an rpc error response from peer server, %s %d",
           err.what(), req->get_type() );
+
+    if ( req->get_type() == msg_type::install_snapshot_request ) {
+        if (srv_to_join_ && srv_to_join_->get_id() == req->get_dst()) {
+            bool timed_out = check_snapshot_timeout(srv_to_join_);
+            if (!timed_out) {
+                // Enable temp HB to retry snapshot.
+                p_wn("sending snapshot to joining server %d failed, "
+                     "retry with temp heartbeat", srv_to_join_->get_id());
+                srv_to_join_snp_retry_required_ = true;
+                enable_hb_for_peer(*srv_to_join_);
+            }
+        }
+    }
+
     if ( req->get_type() != msg_type::sync_log_request     &&
          req->get_type() != msg_type::join_cluster_request &&
          req->get_type() != msg_type::leave_cluster_request ) {

--- a/tests/unit/asio_service_test.cxx
+++ b/tests/unit/asio_service_test.cxx
@@ -1750,6 +1750,221 @@ int snapshot_read_failure_for_lagging_server_test(size_t num_failures) {
     return 0;
 }
 
+int snapshot_context_timeout_normal_test() {
+    reset_log_files();
+
+    std::string s1_addr = "localhost:20010";
+    std::string s2_addr = "localhost:20020";
+    std::string s3_addr = "localhost:20030";
+
+    RaftAsioPkg s1(1, s1_addr);
+    RaftAsioPkg s2(2, s2_addr);
+    RaftAsioPkg s3(3, s3_addr);
+    std::vector<RaftAsioPkg*> pkgs = {&s1, &s2, &s3};
+
+    _msg("launching asio-raft servers\n");
+    CHK_Z( launch_servers(pkgs, false) );
+
+    _msg("organizing raft group\n");
+    CHK_Z( make_group(pkgs) );
+
+    CHK_TRUE( s1.raftServer->is_leader() );
+    CHK_EQ(1, s1.raftServer->get_leader());
+    CHK_EQ(1, s2.raftServer->get_leader());
+    CHK_EQ(1, s3.raftServer->get_leader());
+    TestSuite::sleep_sec(1, "wait for Raft group ready");
+
+    // Stop S3.
+    s3.raftServer->shutdown();
+    s3.stopAsio();
+    TestSuite::sleep_sec(1, "stop S3");
+
+    // Replication.
+    for (size_t ii=0; ii<100; ++ii) {
+        std::string msg_str = std::to_string(ii);
+        ptr<buffer> msg = buffer::alloc(sizeof(uint32_t) + msg_str.size());
+        buffer_serializer bs(msg);
+        bs.put_str(msg_str);
+        s1.raftServer->append_entries( {msg} );
+    }
+    TestSuite::sleep_sec(1, "wait for replication");
+
+    // Set snapshot delay for S3 and restart.
+    s3.getTestSm()->setSnpDelay(100);
+    s3.restartServer();
+    TestSuite::sleep_sec(1, "restarting S3");
+
+    // User snapshot ctx should exist.
+    CHK_EQ(1, s1.getTestSm()->getNumOpenedUserCtxs());
+
+    // Stop S3 again, and wait.
+    s3.raftServer->shutdown();
+    s3.stopAsio();
+    TestSuite::sleep_ms(RaftAsioPkg::HEARTBEAT_MS * 25, "stop S3");
+
+    // User snapshot ctx should be empty.
+    CHK_Z(s1.getTestSm()->getNumOpenedUserCtxs());
+
+    // Clear snapshot delay for S3 and restart.
+    s3.getTestSm()->setSnpDelay(0);
+    s3.restartServer();
+    TestSuite::sleep_sec(1, "restarting S3");
+
+    // State machine should be identical.
+    CHK_OK( s2.getTestSm()->isSame( *s1.getTestSm() ) );
+    CHK_OK( s3.getTestSm()->isSame( *s1.getTestSm() ) );
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+    TestSuite::sleep_sec(1, "shutting down");
+
+    SimpleLogger::shutdown();
+    return 0;
+}
+
+int snapshot_context_timeout_join_test() {
+    reset_log_files();
+
+    std::string s1_addr = "localhost:20010";
+    std::string s2_addr = "localhost:20020";
+    std::string s3_addr = "localhost:20030";
+
+    RaftAsioPkg s1(1, s1_addr);
+    RaftAsioPkg s2(2, s2_addr);
+    RaftAsioPkg s3(3, s3_addr);
+    std::vector<RaftAsioPkg*> pkgs = {&s1, &s2, &s3};
+
+    _msg("launching asio-raft servers\n");
+    CHK_Z( launch_servers(pkgs, false) );
+
+    _msg("organizing raft group\n");
+    CHK_Z( make_group( {&s1, &s2} ) );
+
+    CHK_TRUE( s1.raftServer->is_leader() );
+    CHK_EQ(1, s1.raftServer->get_leader());
+    CHK_EQ(1, s2.raftServer->get_leader());
+    TestSuite::sleep_sec(1, "wait for Raft group ready");
+
+    // Replication.
+    for (size_t ii=0; ii<100; ++ii) {
+        std::string msg_str = std::to_string(ii);
+        ptr<buffer> msg = buffer::alloc(sizeof(uint32_t) + msg_str.size());
+        buffer_serializer bs(msg);
+        bs.put_str(msg_str);
+        s1.raftServer->append_entries( {msg} );
+    }
+    TestSuite::sleep_sec(1, "wait for replication");
+
+    raft_params params = s1.raftServer->get_current_params();
+    params.log_sync_stop_gap_ = 10;
+    s1.raftServer->update_params(params);
+
+    // Set snapshot delay for S3 and add it to the group.
+    s3.getTestSm()->setSnpDelay(100);
+    s1.raftServer->add_srv( *s3.getTestMgr()->get_srv_config() );
+    TestSuite::sleep_sec(1, "adding S3");
+
+    // User snapshot ctx should exist.
+    CHK_EQ(1, s1.getTestSm()->getNumOpenedUserCtxs());
+
+    // Stop S3, and wait.
+    s3.raftServer->shutdown();
+    s3.stopAsio();
+    TestSuite::sleep_ms(RaftAsioPkg::HEARTBEAT_MS * 25, "stop S3");
+
+    // User snapshot ctx should be empty.
+    CHK_Z(s1.getTestSm()->getNumOpenedUserCtxs());
+
+    // Clear snapshot delay for S3 and restart.
+    s3.getTestSm()->setSnpDelay(0);
+    s3.restartServer();
+    TestSuite::sleep_sec(1, "restarting S3");
+    TestSuite::sleep_sec(2, "wait for previous adding server to be expired");
+
+    // Re-attempt adding S3.
+    s1.raftServer->add_srv( *s3.getTestMgr()->get_srv_config() );
+    TestSuite::sleep_sec(1, "adding S3");
+
+    // State machine should be identical.
+    CHK_OK( s2.getTestSm()->isSame( *s1.getTestSm() ) );
+    CHK_OK( s3.getTestSm()->isSame( *s1.getTestSm() ) );
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+    TestSuite::sleep_sec(1, "shutting down");
+
+    SimpleLogger::shutdown();
+    return 0;
+}
+
+int snapshot_context_timeout_removed_server_test() {
+    reset_log_files();
+
+    std::string s1_addr = "localhost:20010";
+    std::string s2_addr = "localhost:20020";
+    std::string s3_addr = "localhost:20030";
+
+    RaftAsioPkg s1(1, s1_addr);
+    RaftAsioPkg s2(2, s2_addr);
+    RaftAsioPkg s3(3, s3_addr);
+    std::vector<RaftAsioPkg*> pkgs = {&s1, &s2, &s3};
+
+    _msg("launching asio-raft servers\n");
+    CHK_Z( launch_servers(pkgs, false) );
+
+    _msg("organizing raft group\n");
+    CHK_Z( make_group(pkgs) );
+
+    CHK_TRUE( s1.raftServer->is_leader() );
+    CHK_EQ(1, s1.raftServer->get_leader());
+    CHK_EQ(1, s2.raftServer->get_leader());
+    CHK_EQ(1, s3.raftServer->get_leader());
+    TestSuite::sleep_sec(1, "wait for Raft group ready");
+
+    // Stop S3.
+    s3.raftServer->shutdown();
+    s3.stopAsio();
+    TestSuite::sleep_sec(1, "stop S3");
+
+    // Replication.
+    for (size_t ii=0; ii<100; ++ii) {
+        std::string msg_str = std::to_string(ii);
+        ptr<buffer> msg = buffer::alloc(sizeof(uint32_t) + msg_str.size());
+        buffer_serializer bs(msg);
+        bs.put_str(msg_str);
+        s1.raftServer->append_entries( {msg} );
+    }
+    TestSuite::sleep_sec(1, "wait for replication");
+
+    // Set snapshot delay for S3 and restart.
+    s3.getTestSm()->setSnpDelay(100);
+    s3.restartServer();
+    TestSuite::sleep_sec(1, "restarting S3");
+
+    // User snapshot ctx should exist.
+    CHK_EQ(1, s1.getTestSm()->getNumOpenedUserCtxs());
+
+    // Now remove S3 from the group while it is still receiving snapshot.
+    s1.raftServer->remove_srv(3);
+    TestSuite::sleep_sec(1, "removing S3");
+
+    // S3 shouldn't exist in the group.
+    CHK_NULL( s1.raftServer->get_srv_config(3).get() );
+
+    // User snapshot ctx should be empty.
+    CHK_Z(s1.getTestSm()->getNumOpenedUserCtxs());
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+    TestSuite::sleep_sec(1, "shutting down");
+
+    SimpleLogger::shutdown();
+    return 0;
+}
+
 }  // namespace asio_service_test;
 using namespace asio_service_test;
 
@@ -1824,6 +2039,15 @@ int main(int argc, char** argv) {
     ts.doTest( "snapshot read failure for lagging server test",
                snapshot_read_failure_for_lagging_server_test,
                TestRange<size_t>( {1, 5} ) );
+
+    ts.doTest( "snapshot context timeout normal test",
+               snapshot_context_timeout_normal_test );
+
+    ts.doTest( "snapshot context timeout join test",
+               snapshot_context_timeout_join_test );
+
+    ts.doTest( "snapshot context timeout removed server test",
+               snapshot_context_timeout_removed_server_test );
 
 #ifdef ENABLE_RAFT_STATS
     _msg("raft stats: ENABLED\n");

--- a/tests/unit/raft_functional_common.hxx
+++ b/tests/unit/raft_functional_common.hxx
@@ -26,6 +26,7 @@ limitations under the License.
 #include <cassert>
 #include <list>
 #include <map>
+#include <set>
 #include <sstream>
 
 #define INT_UNUSED      int ATTR_UNUSED
@@ -43,6 +44,7 @@ public:
         : customBatchSize(0)
         , lastCommittedConfigIdx(0)
         , targetSnpReadFailures(0)
+        , snpDelayMs(0)
         , myLog(logger)
     {
         (void)myLog;
@@ -85,6 +87,10 @@ public:
                               bool is_first_obj,
                               bool is_last_obj)
     {
+        if (snpDelayMs) {
+            TestSuite::sleep_ms(snpDelayMs);
+        }
+
         if (obj_id == 0) {
             // Special object containing metadata.
             // Request next object.
@@ -130,16 +136,17 @@ public:
                              ptr<buffer>& data_out,
                              bool& is_last_obj)
     {
-        if (targetSnpReadFailures > 0) {
-            targetSnpReadFailures--;
-            return -1;
-        }
-
         if (!user_snp_ctx) {
             // Create a dummy context with a magic number.
             int ctx = 0xabcdef;
             user_snp_ctx = malloc( sizeof(ctx) );
             memcpy(user_snp_ctx, &ctx, sizeof(ctx));
+            openedUserCtxs.insert(user_snp_ctx);
+        }
+
+        if (targetSnpReadFailures > 0) {
+            targetSnpReadFailures--;
+            return -1;
         }
 
         if (obj_id == 0) {
@@ -198,6 +205,11 @@ public:
         // Check magic number.
         assert(ctx == 0xabcdef);
         free(user_snp_ctx);
+        openedUserCtxs.erase(user_snp_ctx);
+    }
+
+    size_t getNumOpenedUserCtxs() const {
+        return openedUserCtxs.size();
     }
 
     ptr<snapshot> last_snapshot() {
@@ -322,6 +334,10 @@ public:
         targetSnpReadFailures = num_failures;
     }
 
+    void setSnpDelay(size_t delay_ms) {
+        snpDelayMs = delay_ms;
+    }
+
 private:
     std::map<uint64_t, ptr<buffer>> preCommits;
     std::map<uint64_t, ptr<buffer>> commits;
@@ -336,6 +352,10 @@ private:
     std::atomic<uint64_t> lastCommittedConfigIdx;
 
     std::atomic<int> targetSnpReadFailures;
+
+    std::atomic<size_t> snpDelayMs;
+
+    std::set<void*> openedUserCtxs;
 
     SimpleLogger* myLog;
 };
@@ -398,9 +418,7 @@ private:
 
 static VOID_UNUSED reset_log_files() {
     std::stringstream ss;
-    for (size_t ii=1; ii<=10; ++ii) {
-        ss << "srv" + std::to_string(ii) + ".log* ";
-    }
+    ss << "srv*.log ";
 
 #if defined(__linux__) || defined(__APPLE__)
     std::string cmd = "rm -f base.log " + ss.str() + "2> /dev/null";


### PR DESCRIPTION
* When snapshot receiver (follower) is not responding long time, the
snapshot and its user context should be closed after configured
timeout.

* The same timeout should be applied to below cases:
  - When the snapshot receiver is removed from the group.
  - When a new joining server is not responding.