### PR TITLE
fix segfault when logger is set to nullptr

### DIFF
--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -1008,7 +1008,7 @@ ulong raft_server::get_expected_committed_log_idx() {
                std::greater<ulong>() );
 
     size_t quorum_idx = get_quorum_for_commit();
-    if (l_->get_level() >= 6) {
+    if (l_ && l_->get_level() >= 6) {
         std::string tmp_str;
         for (ulong m_idx: matched_indexes) {
             tmp_str += std::to_string(m_idx) + " ";


### PR DESCRIPTION
In the middle of making a plugin for Apache Traffic Server, found a bug where setting the logger to nullptr causes a segfault when adding servers.

```
[Switching to Thread 0x7ffff627b700 (LWP 276059)]
nuraft::raft_server::get_expected_committed_log_idx (this=0x5555555c03d0) at /home/duke/Git/NuRaft/src/handle_append_entries.cxx:982
982	    if (l_->get_level() >= 6) {
(gdb) bt
#0  nuraft::raft_server::get_expected_committed_log_idx (this=0x5555555c03d0) at /home/duke/Git/NuRaft/src/handle_append_entries.cxx:982
#1  0x00007ffff7ebc74c in nuraft::raft_server::handle_append_entries_resp (this=0x5555555c03d0, resp=...) at /home/duke/Git/NuRaft/src/handle_append_entries.cxx:848
#2  0x00007ffff7f20940 in nuraft::raft_server::handle_peer_resp (this=0x5555555c03d0, resp=std::shared_ptr<nuraft::resp_msg> (use count 2, weak count 0) = {...}, 
    err=std::shared_ptr<nuraft::rpc_exception> (empty) = {...}) at /home/duke/Git/NuRaft/src/raft_server.cxx:783
#3  0x00007ffff7f2cc54 in std::__invoke_impl<void, void (nuraft::raft_server::*&)(std::shared_ptr<nuraft::resp_msg>&, std::shared_ptr<nuraft::rpc_exception>&), nuraft::raft_server*&, std::shared_ptr<nuraft::resp_msg>&, std::shared_ptr<nuraft::rpc_exception>&> (__f=
    @0x7fffd80010d0: (void (nuraft::raft_server::*)(nuraft::raft_server * const, std::shared_ptr<nuraft::resp_msg> &, std::shared_ptr<nuraft::rpc_exception> &)) 0x7ffff7f1fe56 <nuraft::raft_server::handle_peer_resp(std::shared_ptr<nuraft::resp_msg>&, std::shared_ptr<nuraft::rpc_exception>&)>, __t=@0x7fffd80010e0: 0x5555555c03d0)
    at /usr/include/c++/9/bits/invoke.h:73
#4  0x00007ffff7f2c404 in std::__invoke<void (nuraft::raft_server::*&)(std::shared_ptr<nuraft::resp_msg>&, std::shared_ptr<nuraft::rpc_exception>&), nuraft::raft_server*&, std::shared_ptr<nuraft::resp_msg>&, std::shared_ptr<nuraft::rpc_exception>&> (__fn=
    @0x7fffd80010d0: (void (nuraft::raft_server::*)(nuraft::raft_server * const, std::shared_ptr<nuraft::resp_msg> &, std::shared_ptr<nuraft::rpc_exception> &)) 0x7ffff7f1fe56 <nuraft::raft_server::handle_peer_resp(std::shared_ptr<nuraft::resp_msg>&, std::shared_ptr<nuraft::rpc_exception>&)>) at /usr/include/c++/9/bits/invoke.h:95
#5  0x00007ffff7f2b9e1 in std::_Bind<void (nuraft::raft_server::*(nuraft::raft_server*, std::_Placeholder<1>, std::_Placeholder<2>))(std::shared_ptr<nuraft::resp_msg>&, std::shared_ptr<nuraft::rpc_exception>&)>::__call<void, std::shared_ptr<nuraft::resp_msg>&, std::shared_ptr<nuraft::rpc_exception>&, 0ul, 1ul, 2ul>(std::tuple<std::shared_ptr<nuraft::resp_msg>&, std::shared_ptr<nuraft::rpc_exception>&>&&, std::_Index_tuple<0ul, 1ul, 2ul>) (this=0x7fffd80010d0, __args=...)
    at /usr/include/c++/9/functional:400
#6  0x00007ffff7f2a98d in std::_Bind<void (nuraft::raft_server::*(nuraft::raft_server*, std::_Placeholder<1>, std::_Placeholder<2>))(std::shared_ptr<nuraft::resp_msg>&, std::shared_ptr<nuraft::rpc_exception>&)>::operator()<std::shared_ptr<nuraft::resp_msg>&, std::shared_ptr<nuraft::rpc_exception>&, void>(std::shared_ptr<nuraft::resp_msg>&, std::shared_ptr<nuraft::rpc_exception>&) (this=0x7fffd80010d0) at /usr/include/c++/9/functional:484
#7  0x00007ffff7f293b4 in std::_Function_handler<void (std::shared_ptr<nuraft::resp_msg>&, std::shared_ptr<nuraft::rpc_exception>&), std::_Bind<void (nuraft::raft_server::*(nuraft::raft_server*, std::_Placeholder<1>, std::_Placeholder<2>))(std::shared_ptr<nuraft::resp_msg>&, std::shared_ptr<nuraft::rpc_exception>&)> >::_M_invoke(std::_Any_data const&, std::shared_ptr<nuraft::resp_msg>&, std::shared_ptr<nuraft::rpc_exception>&) (__functor=..., 
    __args#0=std::shared_ptr<nuraft::resp_msg> (use count 2, weak count 0) = {...}, __args#1=std::shared_ptr<nuraft::rpc_exception> (empty) = {...})
    at /usr/include/c++/9/bits/std_function.h:300
#8  0x00007ffff7e585bd in std::function<void (std::shared_ptr<nuraft::resp_msg>&, std::shared_ptr<nuraft::rpc_exception>&)>::operator()(std::shared_ptr<nuraft::resp_msg>&, std::shared_ptr<nuraft::rpc_exception>&) const (this=0x7fffd8001028, __args#0=std::shared_ptr<nuraft::resp_msg> (use count 2, weak count 0) = {...}, 
    __args#1=std::shared_ptr<nuraft::rpc_exception> (empty) = {...}) at /usr/include/c++/9/bits/std_function.h:688
#9  0x00007ffff7f154cc in nuraft::cmd_result<std::shared_ptr<nuraft::resp_msg>, std::shared_ptr<nuraft::rpc_exception> >::set_result (this=0x7fffd8000ff0, 
    result=std::shared_ptr<nuraft::resp_msg> (use count 2, weak count 0) = {...}, err=std::shared_ptr<nuraft::rpc_exception> (empty) = {...})
    at /home/duke/Git/NuRaft/include/libnuraft/async.hxx:163
#10 0x00007ffff7f1400e in nuraft::peer::handle_rpc_result (this=0x7fffe8001420, myself=std::shared_ptr<nuraft::peer> (use count 5, weak count 0) = {...}, 
    my_rpc_client=std::shared_ptr<nuraft::rpc_client> (use count 5, weak count 1) = {...}, req=std::shared_ptr<nuraft::req_msg> (use count 2, weak count 0) = {...}, 
    pending_result=std::shared_ptr<nuraft::cmd_result<std::shared_ptr<nuraft::resp_msg>, std::shared_ptr<nuraft::rpc_exception> >> (use count 1, weak count 0) = {...}, resp=std::shared_ptr<nuraft::resp_msg> (use count 2, weak count 0) = {...}, err=std::shared_ptr<nuraft::rpc_exception> (empty) = {...})
    at /home/duke/Git/NuRaft/src/peer.cxx:139
#11 0x00007ffff7f1820a in std::__invoke_impl<void, void (nuraft::peer::*&)(std::shared_ptr<nuraft::peer>, std::shared_ptr<nuraft::rpc_client>, std::shared_ptr<nuraft::req_msg>&, std::shared_ptr<nuraft::cmd_result<std::shared_ptr<nuraft::resp_msg>, std::shared_ptr<nuraft::rpc_exception> > >&, std::shared_ptr<nuraft::resp_msg>&, std::shared_ptr<nuraft::rpc_exception>&), nuraft::peer*&, std::shared_ptr<nuraft::peer>&, std::shared_ptr<nuraft::rpc_client>&, std::shared_ptr<nuraft::req_msg>&, std::shared_ptr<nuraft::cmd_result<std::shared_ptr<nuraft::resp_msg>, std::shared_ptr<nuraft::rpc_exception> > >&, std::shared_ptr<nuraft::resp_msg>&, std::shared_ptr<nuraft::rpc_exception>&> (__f=
    @0x7fffd4000d20: (void (nuraft::peer::*)(nuraft::peer * const, std::shared_ptr<nuraft::peer>, std::shared_ptr<nuraft::rpc_client>, std::shared_ptr<nuraft::req_msg> &, std::shared_ptr<nuraft::cmd_result<std::shared_ptr<nuraft::resp_msg>, std::shared_ptr<nuraft::rpc_exception> > > &, std::shared_ptr<nuraft::resp_msg> &, std::shared_ptr<nuraft::rpc_exception> &)) 0x7ffff7f1391c <nuraft::peer::handle_rpc_result(std::shared_ptr<nuraft::peer>, std::shared_ptr<nuraft::rpc_client>, std::shared_ptr<nuraft::req_msg>&, std::shared_ptr<nuraft::cmd_result<std::shared_ptr<nuraft::resp_msg>, std::shared_ptr<nuraft::rpc_exception> > >&, std::shared_ptr<nuraft::resp_msg>&, std::shared_ptr<nuraft::rpc_exception>&)>, __t=@0x7fffd4000d70: 0x7fffe8001420) at /usr/include/c++/9/bits/invoke.h:73
#12 0x00007ffff7f176c1 in std::__invoke<void (nuraft::peer::*&)(std::shared_ptr<nuraft::peer>, std::shared_ptr<nuraft::rpc_client>, std::shared_ptr<nuraft::req_msg>&, std::shared_ptr<nuraft::cmd_result<std::shared_ptr<nuraft::resp_msg>, std::shared_ptr<nuraft::rpc_exception> > >&, std::shared_ptr<nuraft::resp_msg>&, std::shared_ptr<nuraft::rpc_exception>&), nuraft::peer*&, std::shared_ptr<nuraft::peer>&, std::shared_ptr<nuraft::rpc_client>&, std::shared_ptr<nuraft::req_msg>&, std::shared_ptr<nuraft::cmd_result<std::shared_ptr<nuraft::resp_msg>, std::shared_ptr<nuraft::rpc_exception> > >&, std::shared_ptr<nuraft::resp_msg>&, std::shared_ptr<nuraft::rpc_exception>&> (__fn=
    @0x7fffd4000d20: (void (nuraft::peer::*)(nuraft::peer * const, std::shared_ptr<nuraft::peer>, std::shared_ptr<nuraft::rpc_client>, std::shared_ptr<nuraft::req_msg> &, std::shared_ptr<nuraft::cmd_result<std::shared_ptr<nuraft::resp_msg>, std::shared_ptr<nuraft::rpc_exception> > > &, std::shared_ptr<nuraft::resp_msg> &, std::shared_ptr<nuraft::rpc_exception> &)) 0x7ffff7f1391c <nuraft::peer::handle_rpc_result(std::shared_ptr<nuraft::peer>, std::shared_ptr<nuraft::rpc_client>, std::shared_ptr<nuraft::req_msg>&, std::shared_ptr<nuraft::cmd_result<std::shared_ptr<nuraft::resp_msg>, std::shared_ptr<nuraft::rpc_exception> > >&, std::shared_ptr<nuraft::resp_msg>&, std::shared_ptr<nuraft::rpc_exception>&)>) at /usr/include/c++/9/bits/invoke.h:95
#13 0x00007ffff7f16c54 in std::_Bind<void (nuraft::peer::*(nuraft::peer*, std::shared_ptr<nuraft::peer>, std::shared_ptr<nuraft::rpc_client>, std::shared_ptr<nuraft::req_msg>, std::shared_ptr<nuraft::cmd_result<std::shared_ptr<nuraft::resp_msg>, std::shared_ptr<nuraft::rpc_exception> > >, std::_Placeholder<1>, std::_Placeholder<2>))(std::shared_ptr<nuraft::peer>, std::shared_ptr<nuraft::rpc_client>, std::shared_ptr<nuraft::req_msg>&, std::shared_ptr<nuraft::cmd_result<std::shared_ptr<nuraft::resp_msg>, std::shared_ptr<nuraft::rpc_exception> > >&, std::shared_ptr<nuraft::resp_msg>&, std::shared_ptr<nuraft::rpc_exception>&)>::__call<void, std::shared_ptr<nuraft::resp_msg>&, std::shared_ptr<nuraft::rpc_exception>&, 0ul, 1ul, 2ul, 3ul, 4ul, 5ul, 6ul>(std::tuple<std::shared_ptr<nuraft::resp_msg>&, std::shared_ptr<nuraft::rpc_exception>&>&&, std::_Index_tuple<0ul, 1ul, 2ul, 3ul, 4ul, 5ul, 6ul>) (this=0x7fffd4000d20, __args=...) at /usr/include/c++/9/functional:400
```