### PR TITLE
Fix to bug on the restart of joining server

### DIFF
--- a/src/handle_commit.cxx
+++ b/src/handle_commit.cxx
@@ -357,9 +357,10 @@ void raft_server::commit_conf(ulong idx_to_commit,
     p_in( "config at index %llu is committed, prev config log idx %llu",
           new_conf->get_log_idx(), cur_conf->get_log_idx() );
 
-    ctx_->state_mgr_->save_config(*new_conf);
     config_changing_ = false;
     if (cur_conf->get_log_idx() < new_conf->get_log_idx()) {
+        // WARNING: Should not overwrite newer config with older one.
+        ctx_->state_mgr_->save_config(*new_conf);
         reconfigure(new_conf);
     } else {
         p_in( "skipped config %lu, latest config %lu",

--- a/tests/unit/raft_package_fake.hxx
+++ b/tests/unit/raft_package_fake.hxx
@@ -161,6 +161,7 @@ public:
 // ===== Helper functions waiting for the execution of state machine ====
 // NOTE: A single thread at a time (not MT-safe).
 static std::atomic<bool> commit_done(false);
+static std::list<int> removed_servers;
 static std::vector<RaftPkg*> pkgs_to_watch;
 static std::mutex pkgs_to_watch_lock;
 static EventAwaiter ea_wait_for_commit;
@@ -216,6 +217,10 @@ static cb_func::ReturnCode ATTR_UNUSED cb_default(
             if (commit_done.compare_exchange_strong(exp, true)) {
                 ea_wait_for_commit.invoke();
             }
+        }
+    } else if (type == cb_func::Type::RemovedFromCluster) {
+        if (param) {
+            removed_servers.push_back(param->myId);
         }
     }
     return cb_func::ReturnCode::Ok;


### PR DESCRIPTION
* The config received during join request should be durable via the
state manager.

* During the replaying of logs, the newer config should not be
overwritten by the older config.