### PR TITLE
Add lifecycle callback functions for worker threads.

### DIFF
--- a/include/libnuraft/asio_service_options.hxx
+++ b/include/libnuraft/asio_service_options.hxx
@@ -65,6 +65,8 @@ struct asio_service_meta_cb_params {
 struct asio_service_options {
     asio_service_options()
         : thread_pool_size_(0)
+        , worker_start_(nullptr)
+        , worker_stop_(nullptr)
         , enable_ssl_(false)
         , skip_verification_(false)
         , write_req_meta_(nullptr)
@@ -79,6 +81,12 @@ struct asio_service_options {
     // Number of ASIO worker threads.
     // If zero, it will be automatically set to number of cores.
     size_t thread_pool_size_;
+
+    // Lifecycle callback function on worker thread start.
+    std::function< void(uint32_t) > worker_start_;
+
+    // Lifecycle callback function on worker thread stop.
+    std::function< void(uint32_t) > worker_stop_;
 
     // If `true`, enable SSL/TLS secure connection.
     bool enable_ssl_;


### PR DESCRIPTION
Added lifecycle callback functions for worker-thread start and stop.  The idea behind this PR is the following:
MonstorDB uses user-space update-copy-update (rcu) libraries to manage frequently-read-but-rarely-updated data structures. The library requires each participating thread to call a "register" function before its first use of the library and a "unregister" function before the termination of the thread's main function.  Currently, MonstorDB uses a thread-local boolean flag to track the thread's first use, and relies on another thread-local variable's destructor to call the "unregister" function.  It seems to work at the moment, but theoretically it depends on the order of thread-local variable's destruction order and may break in future in a very subtle way.  I'm planning to fix that by explicitly calling "register" and "unregister" functions inside each thread's main function (for threads using the rcu library only).  Currently, the "pre_commit" callback functions may use the rcu library.  Therefore, I added the two hooks on the worker thread's main function. 