### PR TITLE
Fix to bug in `get_peer_info`

### DIFF
--- a/include/libnuraft/peer.hxx
+++ b/include/libnuraft/peer.hxx
@@ -48,6 +48,7 @@ public:
         , rpc_backoff_( ctx.get_params()->rpc_failure_backoff_ )
         , max_hb_interval_( ctx.get_params()->max_hb_interval() )
         , next_log_idx_(0)
+        , last_accepted_log_idx_(0)
         , next_batch_size_hint_in_bytes_(0)
         , matched_idx_(0)
         , busy_flag_(false)
@@ -149,6 +150,14 @@ public:
 
     void set_next_log_idx(ulong idx) {
         next_log_idx_ = idx;
+    }
+
+    uint64_t get_last_accepted_log_idx() const {
+        return last_accepted_log_idx_;
+    }
+
+    void set_last_accepted_log_idx(uint64_t to) {
+        last_accepted_log_idx_ = to;
     }
 
     int64 get_next_batch_size_hint_in_bytes() const {
@@ -343,6 +352,11 @@ private:
      * Next log index of this server.
      */
     std::atomic<ulong> next_log_idx_;
+
+    /**
+     * The last log index accepted by this server.
+     */
+    std::atomic<uint64_t> last_accepted_log_idx_;
 
     /**
      * Hint of the next log batch size in bytes.

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -885,6 +885,7 @@ void raft_server::handle_append_entries_resp(resp_msg& resp) {
             p_tr("peer %d, prev matched idx: %ld, new matched idx: %ld",
                  p->get_id(), prev_matched_idx, new_matched_idx);
             p->set_matched_idx(new_matched_idx);
+            p->set_last_accepted_log_idx(new_matched_idx);
         }
         cb_func::Param param(id_, leader_, p->get_id());
         param.ctx = &new_matched_idx;

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -1524,7 +1524,7 @@ raft_server::peer_info raft_server::get_peer_info(int32 srv_id) const {
     peer_info ret;
     ptr<peer> pp = entry->second;
     ret.id_ = pp->get_id();
-    ret.last_log_idx_ = pp->get_next_log_idx() - 1;
+    ret.last_log_idx_ = pp->get_last_accepted_log_idx();
     ret.last_succ_resp_us_ = pp->get_resp_timer_us();
     return ret;
 }
@@ -1538,7 +1538,7 @@ std::vector<raft_server::peer_info> raft_server::get_peer_info_all() const {
         peer_info pi;
         ptr<peer> pp = entry.second;
         pi.id_ = pp->get_id();
-        pi.last_log_idx_ = pp->get_next_log_idx() - 1;
+        pi.last_log_idx_ = pp->get_last_accepted_log_idx();
         pi.last_succ_resp_us_ = pp->get_resp_timer_us();
         ret.push_back(pi);
     }


### PR DESCRIPTION
* `get_next_log_idx` may not be accurate if we want to get the last
log successfully sent to the peer.