### PR TITLE
Add a new option for full consensus mode

### DIFF
--- a/include/libnuraft/raft_params.hxx
+++ b/include/libnuraft/raft_params.hxx
@@ -94,6 +94,7 @@ struct raft_params {
         , auto_forwarding_req_timeout_(0)
         , grace_period_of_lagging_state_machine_(0)
         , use_bg_thread_for_snapshot_io_(false)
+        , use_full_consensus_while_healthy_(false)
         {}
 
     /**
@@ -536,6 +537,17 @@ public:
      * Asynchronous IO will reduce the overall latency of the leader's operations.
      */
     bool use_bg_thread_for_snapshot_io_;
+
+    /**
+     * (Experimental)
+     * If `true`, it will commit a log upon the agreement of all members
+     * while they are all healthy. In other words, with this option,
+     * all members have the log at the moment the leader commits the log.
+     *
+     * If there is more than one unhealthy (not responding for a while)
+     * member, it will follow the regular quorum-based consensus.
+     */
+    bool use_full_consensus_while_healthy_;
 };
 
 }

--- a/tests/unit/asio_service_test.cxx
+++ b/tests/unit/asio_service_test.cxx
@@ -2179,6 +2179,94 @@ int pause_state_machine_execution_test(bool use_global_mgr) {
     return 0;
 }
 
+int full_consensus_test() {
+    reset_log_files();
+
+    std::string s1_addr = "tcp://127.0.0.1:20010";
+    std::string s2_addr = "tcp://127.0.0.1:20020";
+    std::string s3_addr = "tcp://127.0.0.1:20030";
+
+    RaftAsioPkg s1(1, s1_addr);
+    RaftAsioPkg s2(2, s2_addr);
+    RaftAsioPkg s3(3, s3_addr);
+    std::vector<RaftAsioPkg*> pkgs = {&s1, &s2, &s3};
+
+    _msg("launching asio-raft servers\n");
+    CHK_Z( launch_servers(pkgs, false) );
+
+    _msg("organizing raft group\n");
+    CHK_Z( make_group(pkgs) );
+
+    // Set async & full consensus mode.
+    for (auto& entry: pkgs) {
+        RaftAsioPkg* pp = entry;
+        raft_params param = pp->raftServer->get_current_params();
+        param.return_method_ = raft_params::async_handler;
+        param.use_full_consensus_while_healthy_ = true;
+        pp->raftServer->update_params(param);
+    }
+
+    // Stop S3.
+    s3.raftServer->shutdown();
+    s3.stopAsio();
+    TestSuite::sleep_ms(RaftAsioPkg::HEARTBEAT_MS * 5, "stop S3");
+
+    // Remember the commit index.
+    uint64_t commit_idx = s1.raftServer->get_committed_log_idx();
+
+    // Append messages asynchronously.
+    const size_t NUM = 10;
+    std::list< ptr< cmd_result< ptr<buffer> > > > handlers;
+    std::list<ulong> idx_list;
+    std::mutex idx_list_lock;
+    auto do_async_append = [&]() {
+        handlers.clear();
+        idx_list.clear();
+        for (size_t ii=0; ii<NUM; ++ii) {
+            std::string test_msg = "test" + std::to_string(ii);
+            ptr<buffer> msg = buffer::alloc(test_msg.size() + 1);
+            msg->put(test_msg);
+            ptr< cmd_result< ptr<buffer> > > ret =
+                s1.raftServer->append_entries( {msg} );
+
+            cmd_result< ptr<buffer> >::handler_type my_handler =
+                std::bind( async_handler,
+                        &idx_list,
+                        &idx_list_lock,
+                        std::placeholders::_1,
+                        std::placeholders::_2 );
+            ret->when_ready( my_handler );
+
+            handlers.push_back(ret);
+        }
+    };
+    do_async_append();
+
+    TestSuite::sleep_ms(RaftAsioPkg::HEARTBEAT_MS * 5, "wait for replication");
+
+    // No request should have been committed.
+    CHK_EQ(commit_idx, s1.raftServer->get_committed_log_idx());
+
+    // Wait more so that the leader can tolerate not responding peer.
+    TestSuite::sleep_ms(RaftAsioPkg::HEARTBEAT_MS * 15, "wait for not responding peer");
+    uint64_t new_commit_idx = s1.raftServer->get_committed_log_idx();
+    CHK_GT(new_commit_idx, commit_idx);
+
+    // More replication.
+    do_async_append();
+    TestSuite::sleep_ms(RaftAsioPkg::HEARTBEAT_MS * 5, "wait for replication");
+    // They should be committed immediately.
+    CHK_GT(s1.raftServer->get_committed_log_idx(), new_commit_idx);
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+    TestSuite::sleep_sec(1, "shutting down");
+
+    SimpleLogger::shutdown();
+    return 0;
+}
+
 }  // namespace asio_service_test;
 using namespace asio_service_test;
 
@@ -2271,6 +2359,9 @@ int main(int argc, char** argv) {
     ts.doTest( "pause state machine execution test",
                pause_state_machine_execution_test,
                TestRange<bool>( {false, true} ) );
+
+    ts.doTest( "full consensus test",
+               full_consensus_test );
 
 #ifdef ENABLE_RAFT_STATS
     _msg("raft stats: ENABLED\n");


### PR DESCRIPTION
* If this mode is on, and all members in the cluster are healthy, the
leader will commit the incoming request only after getting the consensus
from all members. It guarantees that all member have the data at the
moment that the log is committed.

* If any unhealthy (not responding) member exists, the regular quorum
based consensus will be used.