### PR TITLE
Use last accepted index for staleness checking

### DIFF
--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -596,7 +596,7 @@ size_t raft_server::get_num_stale_peers() {
     size_t count = 0;
     for (auto& entry: peers_) {
         ptr<peer>& pp = entry.second;
-        if ( get_last_log_idx() > pp->get_matched_idx() +
+        if ( get_last_log_idx() > pp->get_last_accepted_log_idx() +
                                   ctx_->get_params()->stale_log_gap_ ) {
             count++;
         }


### PR DESCRIPTION
* If we use matched index, it can be reset to 0 on reconnection so
that the peer can be treated as "stale" incorrectly.