### PR TITLE
Fix potential data races

### DIFF
--- a/examples/logger.cc
+++ b/examples/logger.cc
@@ -1089,7 +1089,10 @@ void SimpleLogger::put(int level,
             while (ll->needToFlush()) std::this_thread::yield();
         }
     }
-    ll->write(cur_len, msg);
+    {
+        std::unique_lock<std::mutex> write_lock(flushingLogs, std::try_to_lock);
+        ll->write(cur_len, msg);
+    }
 
     if (level > curDispLevel) return;
 

--- a/examples/logger.cc
+++ b/examples/logger.cc
@@ -1090,7 +1090,7 @@ void SimpleLogger::put(int level,
         }
     }
     {
-        std::unique_lock<std::mutex> write_lock(flushingLogs, std::try_to_lock);
+        std::unique_lock<std::mutex> write_lock(flushingLogs);
         ll->write(cur_len, msg);
     }
 


### PR DESCRIPTION
I got a data race report with TSan

<details>
  <summary>see logs</summary>

```
WARNING: ThreadSanitizer: data race (pid=83692)
  Read of size 8 at 0x7f7f307dd018 by thread T1 (mutexes: write M38, write M207):
    #0 memcpy <null> (calc_server+0x434697)
    #1 std::basic_streambuf<char, std::char_traits<char> >::xsputn(char const*, long) <null> (libstdc++.so.6+0x123477)
    #2 SimpleLogger::flushAll() /home/zyh/NuRaft/examples/logger.cc:1235:5 (calc_server+0x4d8f90)
    #3 SimpleLoggerMgr::flushAllLoggers(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/zyh/NuRaft/examples/logger.cc:636:17 (calc_server+0x4d8f90)
    #4 SimpleLoggerMgr::flushAllLoggers() /home/zyh/NuRaft/examples/logger.h:369:30 (calc_server+0x4e0014)
    #5 SimpleLoggerMgr::flushWorker() /home/zyh/NuRaft/examples/logger.cc:495:14 (calc_server+0x4e0014)
    #6 void std::__invoke_impl<void, void (*)()>(std::__invoke_other, void (*&&)()) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/invoke.h:60:14 (calc_server+0x4ed6df)
    #7 std::__invoke_result<void (*)()>::type std::__invoke<void (*)()>(void (*&&)()) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/invoke.h:95:14 (calc_server+0x4ed6df)
    #8 decltype(std::__invoke(_S_declval<0ul>())) std::thread::_Invoker<std::tuple<void (*)()> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/thread:234:13 (calc_server+0x4ed6df)
    #9 std::thread::_Invoker<std::tuple<void (*)()> >::operator()() /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/thread:243:11 (calc_server+0x4ed6df)
    #10 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)()> > >::_M_run() /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/thread:186:13 (calc_server+0x4ed6df)
    #11 <null> <null> (libstdc++.so.6+0xbd6de)

  Previous write of size 8 at 0x7f7f307dd018 by main thread:
    #0 memcpy <null> (calc_server+0x434697)
    #1 SimpleLogger::LogElem::write(unsigned long, char*) /home/zyh/NuRaft/examples/logger.cc:748:9 (calc_server+0x4e54eb)
    #2 SimpleLogger::put(int, char const*, char const*, unsigned long, char const*, ...) /home/zyh/NuRaft/examples/logger.cc:1094:13 (calc_server+0x4e54eb)
    #3 logger_wrapper::put_details(int, char const*, char const*, unsigned long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/zyh/NuRaft/examples/logger_wrapper.hxx:58:22 (calc_server+0x4cd007)
    #4 nuraft::asio_rpc_listener::asio_rpc_listener(nuraft::asio_service_impl*, asio::io_context&, asio::ssl::context&, unsigned short, bool, std::shared_ptr<nuraft::logger>&) /home/zyh/NuRaft/src/asio_service.cxx:705:9 (calc_server+0x5e1668)
    #5 void __gnu_cxx::new_allocator<nuraft::asio_rpc_listener>::construct<nuraft::asio_rpc_listener, nuraft::asio_service_impl*&, asio::io_context&, asio::ssl::context&, unsigned short&, bool&, std::shared_ptr<nuraft::logger>&>(nuraft::asio_rpc_listener*, nuraft::asio_service_impl*&, asio::io_context&, asio::ssl::context&, unsigned short&, bool&, std::shared_ptr<nuraft::logger>&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/ext/new_allocator.h:136:23 (calc_server+0x5e0c56)
    #6 void std::allocator_traits<std::allocator<nuraft::asio_rpc_listener> >::construct<nuraft::asio_rpc_listener, nuraft::asio_service_impl*&, asio::io_context&, asio::ssl::context&, unsigned short&, bool&, std::shared_ptr<nuraft::logger>&>(std::allocator<nuraft::asio_rpc_listener>&, nuraft::asio_rpc_listener*, nuraft::asio_service_impl*&, asio::io_context&, asio::ssl::context&, unsigned short&, bool&, std::shared_ptr<nuraft::logger>&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/alloc_traits.h:475:8 (calc_server+0x5e0c56)
    #7 std::_Sp_counted_ptr_inplace<nuraft::asio_rpc_listener, std::allocator<nuraft::asio_rpc_listener>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<nuraft::asio_service_impl*&, asio::io_context&, asio::ssl::context&, unsigned short&, bool&, std::shared_ptr<nuraft::logger>&>(std::allocator<nuraft::asio_rpc_listener>, nuraft::asio_service_impl*&, asio::io_context&, asio::ssl::context&, unsigned short&, bool&, std::shared_ptr<nuraft::logger>&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/shared_ptr_base.h:526:4 (calc_server+0x5e0c56)
    #8 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<nuraft::asio_rpc_listener, std::allocator<nuraft::asio_rpc_listener>, nuraft::asio_service_impl*&, asio::io_context&, asio::ssl::context&, unsigned short&, bool&, std::shared_ptr<nuraft::logger>&>(std::_Sp_make_shared_tag, nuraft::asio_rpc_listener*, std::allocator<nuraft::asio_rpc_listener> const&, nuraft::asio_service_impl*&, asio::io_context&, asio::ssl::context&, unsigned short&, bool&, std::shared_ptr<nuraft::logger>&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/shared_ptr_base.h:637:18 (calc_server+0x5e0c56)
    #9 std::__shared_ptr<nuraft::asio_rpc_listener, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<nuraft::asio_rpc_listener>, nuraft::asio_service_impl*&, asio::io_context&, asio::ssl::context&, unsigned short&, bool&, std::shared_ptr<nuraft::logger>&>(std::_Sp_make_shared_tag, std::allocator<nuraft::asio_rpc_listener> const&, nuraft::asio_service_impl*&, asio::io_context&, asio::ssl::context&, unsigned short&, bool&, std::shared_ptr<nuraft::logger>&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/shared_ptr_base.h:1294:14 (calc_server+0x5e0c56)
    #10 std::shared_ptr<nuraft::asio_rpc_listener>::shared_ptr<std::allocator<nuraft::asio_rpc_listener>, nuraft::asio_service_impl*&, asio::io_context&, asio::ssl::context&, unsigned short&, bool&, std::shared_ptr<nuraft::logger>&>(std::_Sp_make_shared_tag, std::allocator<nuraft::asio_rpc_listener> const&, nuraft::asio_service_impl*&, asio::io_context&, asio::ssl::context&, unsigned short&, bool&, std::shared_ptr<nuraft::logger>&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/shared_ptr.h:344:4 (calc_server+0x580c66)
    #11 std::shared_ptr<nuraft::asio_rpc_listener> std::allocate_shared<nuraft::asio_rpc_listener, std::allocator<nuraft::asio_rpc_listener>, nuraft::asio_service_impl*&, asio::io_context&, asio::ssl::context&, unsigned short&, bool&, std::shared_ptr<nuraft::logger>&>(std::allocator<nuraft::asio_rpc_listener> const&, nuraft::asio_service_impl*&, asio::io_context&, asio::ssl::context&, unsigned short&, bool&, std::shared_ptr<nuraft::logger>&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/shared_ptr.h:690:14 (calc_server+0x580c66)
    #12 std::shared_ptr<nuraft::asio_rpc_listener> std::make_shared<nuraft::asio_rpc_listener, nuraft::asio_service_impl*&, asio::io_context&, asio::ssl::context&, unsigned short&, bool&, std::shared_ptr<nuraft::logger>&>(nuraft::asio_service_impl*&, asio::io_context&, asio::ssl::context&, unsigned short&, bool&, std::shared_ptr<nuraft::logger>&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/shared_ptr.h:706:14 (calc_server+0x580c66)
    #13 std::shared_ptr<nuraft::asio_rpc_listener> nuraft::cs_new<nuraft::asio_rpc_listener, nuraft::asio_service_impl*&, asio::io_context&, asio::ssl::context&, unsigned short&, bool&, std::shared_ptr<nuraft::logger>&>(nuraft::asio_service_impl*&, asio::io_context&, asio::ssl::context&, unsigned short&, bool&, std::shared_ptr<nuraft::logger>&) /home/zyh/NuRaft/include/libnuraft/ptr.hxx:36:12 (calc_server+0x580c66)
    #14 nuraft::asio_service::create_rpc_listener(unsigned short, std::shared_ptr<nuraft::logger>&) /home/zyh/NuRaft/src/asio_service.cxx:1786:16 (calc_server+0x580c66)
    #15 nuraft::raft_launcher::init(std::shared_ptr<nuraft::state_machine>, std::shared_ptr<nuraft::state_mgr>, std::shared_ptr<nuraft::logger>, int, nuraft::asio_service_options const&, nuraft::raft_params const&, nuraft::raft_server::init_options const&) /home/zyh/NuRaft/src/launcher.cxx:39:33 (calc_server+0x5247f9)
    #16 calc_server::init_raft(std::shared_ptr<nuraft::state_machine>) /home/zyh/NuRaft/examples/example_common.hxx:192:44 (calc_server+0x4bfdc8)
    #17 main /home/zyh/NuRaft/examples/calculator/calc_server.cxx:213:5 (calc_server+0x4c888a)

  Location is heap block of size 4210688 at 0x7f7f307dc000 allocated by main thread:
    #0 operator new(unsigned long) <null> (calc_server+0x4b8f4b)
    #1 __gnu_cxx::new_allocator<SimpleLogger::LogElem>::allocate(unsigned long, void const*) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/ext/new_allocator.h:111:27 (calc_server+0x4e7a31)
    #2 std::allocator_traits<std::allocator<SimpleLogger::LogElem> >::allocate(std::allocator<SimpleLogger::LogElem>&, unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/alloc_traits.h:436:20 (calc_server+0x4e7a31)
    #3 std::_Vector_base<SimpleLogger::LogElem, std::allocator<SimpleLogger::LogElem> >::_M_allocate(unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/stl_vector.h:172:20 (calc_server+0x4e7a31)
    #4 std::_Vector_base<SimpleLogger::LogElem, std::allocator<SimpleLogger::LogElem> >::_M_create_storage(unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/stl_vector.h:187:33 (calc_server+0x4e7a31)
    #5 std::_Vector_base<SimpleLogger::LogElem, std::allocator<SimpleLogger::LogElem> >::_Vector_base(unsigned long, std::allocator<SimpleLogger::LogElem> const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/stl_vector.h:138:9 (calc_server+0x4e7a31)
    #6 std::vector<SimpleLogger::LogElem, std::allocator<SimpleLogger::LogElem> >::vector(unsigned long, std::allocator<SimpleLogger::LogElem> const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/stl_vector.h:284:9 (calc_server+0x4e7a31)
    #7 SimpleLogger::SimpleLogger(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned long, unsigned long, unsigned int) /home/zyh/NuRaft/examples/logger.cc:787:7 (calc_server+0x4e7a31)
    #8 logger_wrapper::logger_wrapper(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int) /home/zyh/NuRaft/examples/logger_wrapper.hxx:31:23 (calc_server+0x4cc877)
    #9 void __gnu_cxx::new_allocator<logger_wrapper>::construct<logger_wrapper, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(logger_wrapper*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/ext/new_allocator.h:136:23 (calc_server+0x4bef8c)
    #10 void std::allocator_traits<std::allocator<logger_wrapper> >::construct<logger_wrapper, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(std::allocator<logger_wrapper>&, logger_wrapper*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/alloc_traits.h:475:8 (calc_server+0x4bef8c)
    #11 std::_Sp_counted_ptr_inplace<logger_wrapper, std::allocator<logger_wrapper>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(std::allocator<logger_wrapper>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/shared_ptr_base.h:526:4 (calc_server+0x4bef8c)
    #12 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<logger_wrapper, std::allocator<logger_wrapper>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(std::_Sp_make_shared_tag, logger_wrapper*, std::allocator<logger_wrapper> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/shared_ptr_base.h:637:18 (calc_server+0x4bef8c)
    #13 std::__shared_ptr<logger_wrapper, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<logger_wrapper>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(std::_Sp_make_shared_tag, std::allocator<logger_wrapper> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/shared_ptr_base.h:1294:14 (calc_server+0x4bef8c)
    #14 std::shared_ptr<logger_wrapper>::shared_ptr<std::allocator<logger_wrapper>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(std::_Sp_make_shared_tag, std::allocator<logger_wrapper> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/shared_ptr.h:344:4 (calc_server+0x4bef8c)
    #15 std::shared_ptr<logger_wrapper> std::allocate_shared<logger_wrapper, std::allocator<logger_wrapper>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(std::allocator<logger_wrapper> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/shared_ptr.h:690:14 (calc_server+0x4bef8c)
    #16 std::shared_ptr<logger_wrapper> std::make_shared<logger_wrapper, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/shared_ptr.h:706:14 (calc_server+0x4bef8c)
    #17 std::shared_ptr<logger_wrapper> nuraft::cs_new<logger_wrapper, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /home/zyh/NuRaft/include/libnuraft/ptr.hxx:36:12 (calc_server+0x4bef8c)
    #18 calc_server::init_raft(std::shared_ptr<nuraft::state_machine>) /home/zyh/NuRaft/examples/example_common.hxx:155:36 (calc_server+0x4bef8c)
    #19 main /home/zyh/NuRaft/examples/calculator/calc_server.cxx:213:5 (calc_server+0x4c888a)

  Mutex M38 (0x7b6400000500) created at:
    #0 pthread_mutex_lock <null> (calc_server+0x4486c6)
    #1 __gthread_mutex_lock(pthread_mutex_t*) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/x86_64-linux-gnu/c++/7.5.0/bits/gthr-default.h:748:12 (calc_server+0x4e5d76)
    #2 std::mutex::lock() /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/std_mutex.h:103:17 (calc_server+0x4e5d76)
    #3 std::unique_lock<std::mutex>::lock() /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/std_mutex.h:267:17 (calc_server+0x4e5d76)
    #4 std::unique_lock<std::mutex>::unique_lock(std::mutex&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/std_mutex.h:197:2 (calc_server+0x4e5d76)
    #5 SimpleLoggerMgr::addLogger(SimpleLogger*) /home/zyh/NuRaft/examples/logger.cc:641:34 (calc_server+0x4e5d76)
    #6 SimpleLogger::start() /home/zyh/NuRaft/examples/logger.cc:961:10 (calc_server+0x4eb940)
    #7 logger_wrapper::logger_wrapper(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int) /home/zyh/NuRaft/examples/logger_wrapper.hxx:35:18 (calc_server+0x4cc993)
    #8 void __gnu_cxx::new_allocator<logger_wrapper>::construct<logger_wrapper, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(logger_wrapper*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/ext/new_allocator.h:136:23 (calc_server+0x4bef8c)
    #9 void std::allocator_traits<std::allocator<logger_wrapper> >::construct<logger_wrapper, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(std::allocator<logger_wrapper>&, logger_wrapper*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/alloc_traits.h:475:8 (calc_server+0x4bef8c)
    #10 std::_Sp_counted_ptr_inplace<logger_wrapper, std::allocator<logger_wrapper>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(std::allocator<logger_wrapper>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/shared_ptr_base.h:526:4 (calc_server+0x4bef8c)
    #11 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<logger_wrapper, std::allocator<logger_wrapper>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(std::_Sp_make_shared_tag, logger_wrapper*, std::allocator<logger_wrapper> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/shared_ptr_base.h:637:18 (calc_server+0x4bef8c)
    #12 std::__shared_ptr<logger_wrapper, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<logger_wrapper>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(std::_Sp_make_shared_tag, std::allocator<logger_wrapper> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/shared_ptr_base.h:1294:14 (calc_server+0x4bef8c)
    #13 std::shared_ptr<logger_wrapper>::shared_ptr<std::allocator<logger_wrapper>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(std::_Sp_make_shared_tag, std::allocator<logger_wrapper> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/shared_ptr.h:344:4 (calc_server+0x4bef8c)
    #14 std::shared_ptr<logger_wrapper> std::allocate_shared<logger_wrapper, std::allocator<logger_wrapper>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(std::allocator<logger_wrapper> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/shared_ptr.h:690:14 (calc_server+0x4bef8c)
    #15 std::shared_ptr<logger_wrapper> std::make_shared<logger_wrapper, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/shared_ptr.h:706:14 (calc_server+0x4bef8c)
    #16 std::shared_ptr<logger_wrapper> nuraft::cs_new<logger_wrapper, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /home/zyh/NuRaft/include/libnuraft/ptr.hxx:36:12 (calc_server+0x4bef8c)
    #17 calc_server::init_raft(std::shared_ptr<nuraft::state_machine>) /home/zyh/NuRaft/examples/example_common.hxx:155:36 (calc_server+0x4bef8c)
    #18 main /home/zyh/NuRaft/examples/calculator/calc_server.cxx:213:5 (calc_server+0x4c888a)

  Mutex M207 (0x7b58000002a0) created at:
    #0 pthread_mutex_trylock <null> (calc_server+0x42bd86)
    #1 __gthread_mutex_trylock(pthread_mutex_t*) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/x86_64-linux-gnu/c++/7.5.0/bits/gthr-default.h:757:12 (calc_server+0x4ebbb7)
    #2 std::mutex::try_lock() /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/std_mutex.h:114:15 (calc_server+0x4ebbb7)
    #3 std::unique_lock<std::mutex>::unique_lock(std::mutex&, std::try_to_lock_t) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/std_mutex.h:206:62 (calc_server+0x4ebbb7)
    #4 SimpleLogger::flush(unsigned long) /home/zyh/NuRaft/examples/logger.cc:1196:34 (calc_server+0x4ebbb7)
    #5 SimpleLogger::flushAll() /home/zyh/NuRaft/examples/logger.cc:1235:5 (calc_server+0x4d8f90)
    #6 SimpleLoggerMgr::flushAllLoggers(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/zyh/NuRaft/examples/logger.cc:636:17 (calc_server+0x4d8f90)
    #7 SimpleLoggerMgr::flushAllLoggers() /home/zyh/NuRaft/examples/logger.h:369:30 (calc_server+0x4e0014)
    #8 SimpleLoggerMgr::flushWorker() /home/zyh/NuRaft/examples/logger.cc:495:14 (calc_server+0x4e0014)
    #9 void std::__invoke_impl<void, void (*)()>(std::__invoke_other, void (*&&)()) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/invoke.h:60:14 (calc_server+0x4ed6df)
    #10 std::__invoke_result<void (*)()>::type std::__invoke<void (*)()>(void (*&&)()) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/invoke.h:95:14 (calc_server+0x4ed6df)
    #11 decltype(std::__invoke(_S_declval<0ul>())) std::thread::_Invoker<std::tuple<void (*)()> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/thread:234:13 (calc_server+0x4ed6df)
    #12 std::thread::_Invoker<std::tuple<void (*)()> >::operator()() /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/thread:243:11 (calc_server+0x4ed6df)
    #13 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)()> > >::_M_run() /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/thread:186:13 (calc_server+0x4ed6df)
    #14 <null> <null> (libstdc++.so.6+0xbd6de)

  Thread T1 (tid=83700, running) created by main thread at:
    #0 pthread_create <null> (calc_server+0x42a46b)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) <null> (libstdc++.so.6+0xbd994)
    #2 SimpleLoggerMgr::init() /home/zyh/NuRaft/examples/logger.cc:161:23 (calc_server+0x4d7989)
    #3 SimpleLoggerMgr::get() /home/zyh/NuRaft/examples/logger.cc:170:22 (calc_server+0x4e9f7a)
    #4 SimpleLogger::setCrashDumpPath(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) /home/zyh/NuRaft/examples/logger.cc:806:28 (calc_server+0x4e9f7a)
    #5 logger_wrapper::logger_wrapper(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int) /home/zyh/NuRaft/examples/logger_wrapper.hxx:34:9 (calc_server+0x4cc934)
    #6 void __gnu_cxx::new_allocator<logger_wrapper>::construct<logger_wrapper, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(logger_wrapper*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/ext/new_allocator.h:136:23 (calc_server+0x4bef8c)
    #7 void std::allocator_traits<std::allocator<logger_wrapper> >::construct<logger_wrapper, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(std::allocator<logger_wrapper>&, logger_wrapper*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/alloc_traits.h:475:8 (calc_server+0x4bef8c)
    #8 std::_Sp_counted_ptr_inplace<logger_wrapper, std::allocator<logger_wrapper>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(std::allocator<logger_wrapper>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/shared_ptr_base.h:526:4 (calc_server+0x4bef8c)
    #9 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<logger_wrapper, std::allocator<logger_wrapper>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(std::_Sp_make_shared_tag, logger_wrapper*, std::allocator<logger_wrapper> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/shared_ptr_base.h:637:18 (calc_server+0x4bef8c)
    #10 std::__shared_ptr<logger_wrapper, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<logger_wrapper>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(std::_Sp_make_shared_tag, std::allocator<logger_wrapper> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/shared_ptr_base.h:1294:14 (calc_server+0x4bef8c)
    #11 std::shared_ptr<logger_wrapper>::shared_ptr<std::allocator<logger_wrapper>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(std::_Sp_make_shared_tag, std::allocator<logger_wrapper> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/shared_ptr.h:344:4 (calc_server+0x4bef8c)
    #12 std::shared_ptr<logger_wrapper> std::allocate_shared<logger_wrapper, std::allocator<logger_wrapper>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(std::allocator<logger_wrapper> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/shared_ptr.h:690:14 (calc_server+0x4bef8c)
    #13 std::shared_ptr<logger_wrapper> std::make_shared<logger_wrapper, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/bits/shared_ptr.h:706:14 (calc_server+0x4bef8c)
    #14 std::shared_ptr<logger_wrapper> nuraft::cs_new<logger_wrapper, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int&&) /home/zyh/NuRaft/include/libnuraft/ptr.hxx:36:12 (calc_server+0x4bef8c)
    #15 calc_server::init_raft(std::shared_ptr<nuraft::state_machine>) /home/zyh/NuRaft/examples/example_common.hxx:155:36 (calc_server+0x4bef8c)
    #16 main /home/zyh/NuRaft/examples/calculator/calc_server.cxx:213:5 (calc_server+0x4c888a)

SUMMARY: ThreadSanitizer: data race (/home/zyh/NuRaft/build/examples/calc_server+0x434697) in memcpy
==================
```

</details>

This PR can fix it, but needs more tests.