### PR TITLE
Add extended append_entries API

### DIFF
--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -34,6 +34,7 @@ limitations under the License.
 #include "internal_timer.hxx"
 #include "rpc_listener.hxx"
 #include "raft_server.hxx"
+#include "raft_server_handler.hxx"
 #include "strfmt.hxx"
 #include "tracer.hxx"
 
@@ -198,7 +199,10 @@ private:
 class rpc_session;
 typedef std::function<void(const ptr<rpc_session>&)> session_closed_callback;
 
-class rpc_session : public std::enable_shared_from_this<rpc_session> {
+class rpc_session
+    : public std::enable_shared_from_this<rpc_session>
+    , public raft_server_handler
+     {
 public:
     rpc_session( uint64_t id,
                  asio_service_impl* _impl,
@@ -545,7 +549,7 @@ private:
         }
 
         // === RAFT server processes the request here. ===
-        ptr<resp_msg> resp = handler_->process_req(*req);
+        ptr<resp_msg> resp = raft_server_handler::process_req(handler_.get(), *req);
         if (!resp) {
             p_wn("no response is returned from raft message handler");
             this->stop();

--- a/src/handle_commit.cxx
+++ b/src/handle_commit.cxx
@@ -359,8 +359,7 @@ void raft_server::commit_app_log(ulong idx_to_commit,
         ptr<commit_ret_elem>& elem = entry;
         if (elem->async_result_) {
             ptr<std::exception> err = nullptr;
-            elem->async_result_->set_result_code(cmd_result_code::OK);
-            elem->async_result_->set_result( elem->ret_value_, err );
+            elem->async_result_->set_result( elem->ret_value_, err, cmd_result_code::OK );
             elem->ret_value_.reset();
             elem->async_result_.reset();
         }

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -602,7 +602,8 @@ size_t raft_server::get_num_stale_peers() {
     return count;
 }
 
-ptr<resp_msg> raft_server::process_req(req_msg& req) {
+ptr<resp_msg> raft_server::process_req(req_msg& req,
+                                       const req_ext_params& ext_params) {
     cb_func::Param param(id_, leader_);
     param.ctx = &req;
     CbReturnCode rc = ctx_->cb_func_.call(cb_func::ProcessReq, &param);
@@ -629,7 +630,7 @@ ptr<resp_msg> raft_server::process_req(req_msg& req) {
 
     if ( req.get_type() == msg_type::client_request ) {
         // Client request doesn't need to go through below process.
-        return handle_cli_req_prelock(req);
+        return handle_cli_req_prelock(req, ext_params);
     }
 
     recur_lock(lock_);

--- a/src/raft_server_handler.hxx
+++ b/src/raft_server_handler.hxx
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "raft_server.hxx"
+
+namespace nuraft {
+
+/**
+ * Class to handle the internal feature of `raft_server`.
+ * Any internal class that wants to call `process_req` API should inherit this class.
+ * It should not be used externally.
+ */
+class raft_server_handler {
+protected:
+    /**
+     * Call `process_req` of the given raft server.
+     *
+     * @param srv `raft_server` instance.
+     * @param req Request.
+     * @param ext_params Extended parameters.
+     * @return ptr<resp_msg> Response.
+     */
+    static ptr<resp_msg> process_req(raft_server* srv,
+                                     req_msg& req,
+                                     const raft_server::req_ext_params& ext_params =
+                                         raft_server::req_ext_params()) {
+        return srv->process_req(req, ext_params);
+    }
+};
+
+}

--- a/tests/unit/fake_network.cxx
+++ b/tests/unit/fake_network.cxx
@@ -95,7 +95,7 @@ void FakeNetwork::listen(ptr<msg_handler>& _handler) {
 }
 
 ptr<resp_msg> FakeNetwork::gotMsg(ptr<req_msg>& msg) {
-    ptr<resp_msg> resp = handler->process_req(*msg);
+    ptr<resp_msg> resp = raft_server_handler::process_req(handler.get(), *msg);
     return resp;
 }
 

--- a/tests/unit/fake_network.hxx
+++ b/tests/unit/fake_network.hxx
@@ -19,6 +19,8 @@ limitations under the License.
 
 #include "nuraft.hxx"
 
+#include "raft_server_handler.hxx"
+
 #include <map>
 #include <unordered_map>
 
@@ -29,7 +31,8 @@ namespace nuraft {
 class FakeClient;
 class FakeNetworkBase;
 class FakeNetwork
-    : public rpc_client_factory
+    : public raft_server_handler
+    , public rpc_client_factory
     , public rpc_listener
     , public std::enable_shared_from_this<FakeNetwork>
 {


### PR DESCRIPTION
* With this API,

  - User can set an expected term. `append_entries` will succeed only
    if the current server's term matches, behaves similar to
    compare-and-swap operation.

  - User can set a callback function to know the log index and term
    of the log that is just appended.