### PR TITLE
Change role to candidate on initiating pre-vote

### DIFF
--- a/src/handle_vote.cxx
+++ b/src/handle_vote.cxx
@@ -115,6 +115,7 @@ void raft_server::request_prevote() {
 
     hb_alive_ = false;
     leader_ = -1;
+    role_ = srv_role::candidate;
     pre_vote_.reset(state_->get_term());
     // Count for myself.
     pre_vote_.dead_++;


### PR DESCRIPTION
* If pre-vote is rejected and the server starts receiving heartbeat
again, the pre-vote rejection counter should be reset to 0. But
currently `become_follower` will not be called as role of the server
remains as `follower`.