### PR TITLE
Support parallel log appending as an experimental feature

### DIFF
--- a/include/libnuraft/internal_timer.hxx
+++ b/include/libnuraft/internal_timer.hxx
@@ -21,6 +21,8 @@ limitations under the License.
 #include <mutex>
 #include <thread>
 
+#include <sys/time.h>
+
 namespace nuraft {
 
 struct timer_helper {
@@ -117,6 +119,14 @@ struct timer_helper {
             return true;
         }
         return false;
+    }
+
+    static uint64_t get_timeofday_us() {
+        struct timeval tv;
+        gettimeofday(&tv, nullptr);
+        uint64_t ret = tv.tv_sec * 1000000UL;
+        ret += tv.tv_usec;
+        return ret;
     }
 
     std::chrono::time_point<std::chrono::system_clock> t_created_;

--- a/include/libnuraft/log_store.hxx
+++ b/include/libnuraft/log_store.hxx
@@ -173,6 +173,15 @@ public:
      * @return `true` on success.
      */
     virtual bool flush() = 0;
+
+    /**
+     * (Experimental)
+     * This API is used only when `raft_params::parallel_log_appending_` flag is set.
+     * Please refer to the comment of the flag.
+     *
+     * @return The last durable log index.
+     */
+    virtual ulong last_durable_index() { return next_slot() - 1; }
 };
 
 }

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -18,6 +18,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 **************************************************************************/
 
+#include "pp_util.hxx"
+#include "raft_params.hxx"
 #include "raft_server.hxx"
 
 #include "cluster_config.hxx"
@@ -71,7 +73,8 @@ void raft_server::request_append_entries() {
     // We should call it here.
     if ( peers_.size() == 0 ||
          get_quorum_for_commit() == 0 ) {
-        commit(precommit_index_.load());
+        uint64_t leader_index = get_current_leader_index();
+        commit(leader_index);
         return;
     }
 
@@ -737,6 +740,24 @@ ptr<resp_msg> raft_server::handle_append_entries(req_msg& req)
         // End of batch.
         log_store_->end_of_append_batch( req.get_last_log_idx() + 1,
                                          req.log_entries().size() );
+
+        ptr<raft_params> params = ctx_->get_params();
+        if (params->parallel_log_appending_) {
+            uint64_t last_durable_index = log_store_->last_durable_index();
+            while ( last_durable_index <
+                    req.get_last_log_idx() + req.log_entries().size() ) {
+                // Some logs are not durable yet, wait here and block the thread.
+                p_tr( "durable idnex %lu, sleep and wait for log appending completion",
+                      last_durable_index );
+                ea_follower_log_append_->wait_ms(params->heart_beat_interval_);
+
+                // --- `notify_log_append_completion` API will wake it up. ---
+
+                ea_follower_log_append_->reset();
+                last_durable_index = log_store_->last_durable_index();
+                p_tr( "wake up, durable index %lu", last_durable_index );
+            }
+        }
     }
 
     leader_ = req.get_src();
@@ -1009,15 +1030,29 @@ void raft_server::handle_append_entries_resp(resp_msg& resp) {
     }
 }
 
+uint64_t raft_server::get_current_leader_index() {
+    uint64_t leader_index = precommit_index_;
+    ptr<raft_params> params = ctx_->get_params();
+    if (params->parallel_log_appending_) {
+        // For parallel appending, take the smaller one.
+        uint64_t durable_index = log_store_->last_durable_index();
+        p_tr("last durable index %lu, precommit index %lu",
+             durable_index, precommit_index_.load());
+        leader_index = std::min(precommit_index_.load(), durable_index);
+    }
+    return leader_index;
+}
+
 ulong raft_server::get_expected_committed_log_idx() {
     std::vector<ulong> matched_indexes;
     state_machine::adjust_commit_index_params aci_params;
     matched_indexes.reserve(16);
     aci_params.peer_index_map_.reserve(16);
 
-    // Leader itself.
-    matched_indexes.push_back( precommit_index_ );
-    aci_params.peer_index_map_[id_] = precommit_index_;
+    // Put the index of leader itself.
+    uint64_t leader_index = get_current_leader_index();
+    matched_indexes.push_back( leader_index );
+    aci_params.peer_index_map_[id_] = leader_index;
 
     for (auto& entry: peers_) {
         ptr<peer>& p = entry.second;
@@ -1072,6 +1107,47 @@ ulong raft_server::get_expected_committed_log_idx() {
               aci_params.expected_commit_index_, adjusted_commit_index );
     }
     return adjusted_commit_index;
+}
+
+void raft_server::notify_log_append_completion(bool ok) {
+    p_tr("got log append completion notification: %s", ok ? "OK" : "FAILED");
+
+    if (role_ == srv_role::leader) {
+        recur_lock(lock_);
+        if (!ok) {
+            // If log appending fails, leader should resign immediately.
+            p_er("log appending failed, resign immediately");
+            leader_ = -1;
+            become_follower();
+
+            // Clear this flag to avoid pre-vote rejection.
+            hb_alive_ = false;
+            return;
+        }
+
+        // Leader: commit the log and send append_entries request, if needed.
+        uint64_t prev_committed_index = quick_commit_index_.load();
+        uint64_t committed_index = get_expected_committed_log_idx();
+        commit( committed_index );
+
+        if (quick_commit_index_ > prev_committed_index) {
+            // Commit index has been changed as a result of log appending.
+            // Send replication messages.
+            request_append_entries_for_all();
+        }
+    } else {
+        if (!ok) {
+            // If log appending fails for follower, there is no way to proceed it.
+            // We should stop the server immediately.
+            recur_lock(lock_);
+            p_ft("log appending failed, stop this server");
+            ctx_->state_mgr_->system_exit(N21_log_flush_failed);
+            return;
+        }
+
+        // Follower: wake up the waiting thread.
+        ea_follower_log_append_->invoke();
+    }
 }
 
 } // namespace nuraft;

--- a/src/handle_client_request.cxx
+++ b/src/handle_client_request.cxx
@@ -55,6 +55,13 @@ ptr<resp_msg> raft_server::handle_cli_req_prelock(req_msg& req,
     }
 
     // Urgent commit, so that the commit will not depend on hb.
+    request_append_entries_for_all();
+
+    return resp;
+}
+
+void raft_server::request_append_entries_for_all() {
+    ptr<raft_params> params = ctx_->get_params();
     if (params->use_bg_thread_for_urgent_commit_) {
         // Let background generate request (some delay may happen).
         nuraft_global_mgr* mgr = nuraft_global_mgr::get_instance();
@@ -70,7 +77,6 @@ ptr<resp_msg> raft_server::handle_cli_req_prelock(req_msg& req,
         recur_lock(lock_);
         request_append_entries();
     }
-    return resp;
 }
 
 ptr<resp_msg> raft_server::handle_cli_req(req_msg& req,

--- a/tests/unit/asio_service_test.cxx
+++ b/tests/unit/asio_service_test.cxx
@@ -2357,6 +2357,95 @@ int custom_commit_condition_test() {
     return 0;
 }
 
+int parallel_log_append_test() {
+    reset_log_files();
+
+    std::string s1_addr = "tcp://127.0.0.1:20010";
+    std::string s2_addr = "tcp://127.0.0.1:20020";
+    std::string s3_addr = "tcp://127.0.0.1:20030";
+
+    RaftAsioPkg s1(1, s1_addr);
+    RaftAsioPkg s2(2, s2_addr);
+    RaftAsioPkg s3(3, s3_addr);
+    std::vector<RaftAsioPkg*> pkgs = {&s1, &s2, &s3};
+
+    _msg("launching asio-raft servers\n");
+    CHK_Z( launch_servers(pkgs, false) );
+
+    _msg("organizing raft group\n");
+    CHK_Z( make_group(pkgs) );
+
+    // Set disk delay (2s for S1, 10ms for S2 and S3).
+    s1.getTestMgr()->set_disk_delay(s1.raftServer.get(), 2000);
+    s2.getTestMgr()->set_disk_delay(s2.raftServer.get(), 10);
+    s3.getTestMgr()->set_disk_delay(s3.raftServer.get(), 10);
+
+    // Set async mode.
+    for (auto& entry: pkgs) {
+        RaftAsioPkg* pp = entry;
+        raft_params param = pp->raftServer->get_current_params();
+        param.return_method_ = raft_params::async_handler;
+        param.parallel_log_appending_ = true;
+        pp->raftServer->update_params(param);
+    }
+
+    // Append messages asynchronously.
+    const size_t NUM = 10;
+    std::list< ptr< cmd_result< ptr<buffer> > > > handlers;
+    std::list<ulong> idx_list;
+    std::mutex idx_list_lock;
+    auto do_async_append = [&]() {
+        handlers.clear();
+        idx_list.clear();
+        for (size_t ii=0; ii<NUM; ++ii) {
+            std::string test_msg = "test" + std::to_string(ii);
+            ptr<buffer> msg = buffer::alloc(test_msg.size() + 1);
+            msg->put(test_msg);
+            ptr< cmd_result< ptr<buffer> > > ret =
+                s1.raftServer->append_entries( {msg} );
+
+            cmd_result< ptr<buffer> >::handler_type my_handler =
+                std::bind( async_handler,
+                           &idx_list,
+                           &idx_list_lock,
+                           std::placeholders::_1,
+                           std::placeholders::_2 );
+            ret->when_ready( my_handler );
+
+            handlers.push_back(ret);
+        }
+    };
+    do_async_append();
+
+    TestSuite::sleep_sec(1, "wait for replication");
+
+    // Still durable index is smaller than the last index.
+    CHK_SM( s1.getTestMgr()->load_log_store()->last_durable_index(),
+            s1.getTestMgr()->load_log_store()->next_slot() - 1 );
+
+    // All servers should have the same log index.
+    CHK_EQ( s1.getTestMgr()->load_log_store()->next_slot() - 1,
+            s2.getTestMgr()->load_log_store()->next_slot() - 1 );
+    CHK_EQ( s1.getTestMgr()->load_log_store()->next_slot() - 1,
+            s3.getTestMgr()->load_log_store()->next_slot() - 1 );
+
+    // Even with disk delay, logs should have been committed by S2 and S3.
+    CHK_EQ( s1.getTestMgr()->load_log_store()->next_slot() - 1,
+            s1.raftServer->get_committed_log_idx() );
+
+    TestSuite::sleep_ms(1500, "wait for disk delay");
+    CHK_EQ( s1.getTestMgr()->load_log_store()->last_durable_index(),
+            s1.getTestMgr()->load_log_store()->next_slot() - 1 );
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+    TestSuite::sleep_sec(1, "shutting down");
+
+    SimpleLogger::shutdown();
+    return 0;
+}
+
 }  // namespace asio_service_test;
 using namespace asio_service_test;
 
@@ -2455,6 +2544,9 @@ int main(int argc, char** argv) {
 
     ts.doTest( "custom commit condition test",
                custom_commit_condition_test );
+
+    ts.doTest( "parallel log append test",
+               parallel_log_append_test );
 
 #ifdef ENABLE_RAFT_STATS
     _msg("raft stats: ENABLED\n");

--- a/tests/unit/raft_functional_common.hxx
+++ b/tests/unit/raft_functional_common.hxx
@@ -444,6 +444,10 @@ public:
 
     ptr<srv_config> get_srv_config() const { return mySrvConfig; }
 
+    void set_disk_delay(raft_server* raft, size_t delay_ms) {
+        curLogStore->set_disk_delay(raft, delay_ms);
+    }
+
 private:
     int myId;
     std::string myEndpoint;


### PR DESCRIPTION
* If this flag is set, the leader can do log replication and log
appending in parallel, thus it can reduce the latency of write
operation path.