### PR TITLE
Little fixes try_update_precommit_index method

### DIFF
--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -822,7 +822,7 @@ bool raft_server::try_update_precommit_index(ulong desired, const size_t MAX_ATT
     size_t num_attempts = 0;
     ulong prev_precommit_index = precommit_index_;
     while ( prev_precommit_index < desired &&
-        (num_attempts < MAX_ATTEMPTS || MAX_ATTEMPTS == 0)) {
+            (num_attempts < MAX_ATTEMPTS || MAX_ATTEMPTS == 0) ) {
         if ( precommit_index_.compare_exchange_strong( prev_precommit_index,
                                                        desired ) ) {
             return true;
@@ -830,7 +830,6 @@ bool raft_server::try_update_precommit_index(ulong desired, const size_t MAX_ATT
         // Otherwise: retry until `precommit_index_` is equal to or greater than
         //            `desired`.
         num_attempts++;
-        prev_precommit_index = precommit_index_;
     }
     if (precommit_index_ >= desired) {
         return true;


### PR DESCRIPTION
Little fixes `try_update_precommit_index` method

Change log：

1.  if `MAX_ATTEMPTS ` is 0, try forever.
2.  Update `prev_precommit_index` value in each cas loop.