### PR TITLE
Fix log output

### DIFF
--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -1034,7 +1034,7 @@ bool raft_server::check_leadership_validity() {
     if ( (num_voting_members - nr_peers) < min_quorum_size ) {
         p_er("%zu nodes (out of %zu, %zu including learners) are not "
              "responding longer than %zu ms, "
-             "at least %zu nodes (including leader) should be alive "
+             "at least %d nodes (including leader) should be alive "
              "to proceed commit",
              nr_peers,
              num_voting_members,

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -1032,8 +1032,8 @@ bool raft_server::check_leadership_validity() {
     }
     int32 min_quorum_size = get_quorum_for_commit() + 1;
     if ( (num_voting_members - nr_peers) < min_quorum_size ) {
-        p_er("%zu nodes (out of %zu, %zu including learners) are not "
-             "responding longer than %zu ms, "
+        p_er("%d nodes (out of %d, %zu including learners) are not "
+             "responding longer than %d ms, "
              "at least %d nodes (including leader) should be alive "
              "to proceed commit",
              nr_peers,


### PR DESCRIPTION
Found an overflow int32 logging.

```
2 nodes (out of 3, 3 including learners) are not responding longer than 10000 ms, at least 1645066963648514 node        s (including leader) should be alive to proceed commit
```