### PR TITLE
little fix of check_leadership_validity

### DIFF
--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -1263,7 +1263,7 @@ bool raft_server::request_leadership() {
 
 void raft_server::become_follower() {
     // stop hb for all peers
-    p_in("[BECOME FOLLOWER]");
+    p_in("[BECOME FOLLOWER] term %lu", state_->get_term());
     {   std::lock_guard<std::mutex> ll(cli_lock_);
         for (peer_itor it = peers_.begin(); it != peers_.end(); ++it) {
             it->second->enable_hb(false);

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -1021,6 +1021,9 @@ void raft_server::become_leader() {
 bool raft_server::check_leadership_validity() {
     recur_lock(lock_);
 
+    if (role_ != leader)
+        return false;
+
     // Check if quorum is not responding.
     int32 num_voting_members = get_num_voting_members();
 
@@ -1260,7 +1263,7 @@ bool raft_server::request_leadership() {
 
 void raft_server::become_follower() {
     // stop hb for all peers
-    p_tr("  FOLLOWER\n");
+    p_in("[BECOME FOLLOWER]");
     {   std::lock_guard<std::mutex> ll(cli_lock_);
         for (peer_itor it = peers_.begin(); it != peers_.end(); ++it) {
             it->second->enable_hb(false);


### PR DESCRIPTION
Bellow log is a leader changed to a follower.
When it cancel `commit_ret_elem`, leadership checking result is stell valid after  it become follower. 

```
6960837 2022.02.19 13:46:00.533834 [ 111598 ] {} <Information> RaftInstance: create snapshot idx 94081208049 log_term 1571 done: 4633373 us elapsed
6960838 2022.02.19 13:46:00.534057 [ 111586 ] {} <Information> RaftInstance: [PRE-VOTE REQ] my role leader, from peer 1, log term: req 1571 / mine 1571
6960839 last idx: req 94081208069 / mine 94081208069, term: req 1571 / mine 1571
6960840 HB alive
6960841 2022.02.19 13:46:00.534123 [ 111586 ] {} <Information> RaftInstance: pre-vote decision: X (deny)
6960842 2022.02.19 13:46:00.534161 [ 111581 ] {} <Information> RaftInstance: [PRE-VOTE REQ] my role leader, from peer 3, log term: req 1571 / mine 1571
6960843 last idx: req 94081208069 / mine 94081208069, term: req 1571 / mine 1571
6960844 HB alive
6960845 2022.02.19 13:46:00.534195 [ 111581 ] {} <Information> RaftInstance: pre-vote decision: X (deny)
6960846 2022.02.19 13:46:00.534391 [ 111595 ] {} <Information> RaftStateManager: save srv_state with term 1572 and vote_for -1
6960847 2022.02.19 13:46:00.534580 [ 111595 ] {} <Warning> RaftInstance: cancelled 27 blocking client requests from 94011208087 to 94081208070.
6960848 2022.02.19 13:46:00.534661 [ 111607 ] {} <Warning> RaftInstance: [NOT OK] commit_ret_cv 94081208055 wake up (4631709 us), return value (nil), result code -1
6960849 2022.02.19 13:46:00.534673 [ 110864 ] {} <Warning> RaftInstance: [NOT OK] commit_ret_cv 94081208056 wake up (4631470 us), return value (nil), result code -1
6960850 2022.02.19 13:46:00.534693 [ 111607 ] {} <Information> RaftInstance: leadership is still valid
6960851 2022.02.19 13:46:00.534712 [ 110864 ] {} <Information> RaftInstance: leadership is still valid
6960852 2022.02.19 13:46:00.534725 [ 111606 ] {} <Warning> RaftInstance: [NOT OK] commit_ret_cv 94081208058 wake up (4630035 us), return value (nil), result code -1
6960853 2022.02.19 13:46:00.534733 [ 111600 ] {} <Warning> RaftInstance: [NOT OK] commit_ret_cv 94081208057 wake up (4630396 us), return value (nil), result code -1
6960854 2022.02.19 13:46:00.534768 [ 111606 ] {} <Information> RaftInstance: leadership is still valid
6960855 2022.02.19 13:46:00.534778 [ 111604 ] {} <Warning> RaftInstance: [NOT OK] commit_ret_cv 94081208062 wake up (4628148 us), return value (nil), result code -1
6960856 2022.02.19 13:46:00.534748 [ 111603 ] {} <Warning> RaftInstance: [NOT OK] commit_ret_cv 94081208060 wake up (4629164 us), return value (nil), result code -1
6960857 2022.02.19 13:46:00.534810 [ 111600 ] {} <Information> RaftInstance: leadership is still valid
6960858 2022.02.19 13:46:00.534815 [ 110865 ] {} <Warning> RaftInstance: [NOT OK] commit_ret_cv 94081208061 wake up (4628868 us), return value (nil), result code -1
6960859 2022.02.19 13:46:00.534742 [ 110863 ] {} <Warning> RaftInstance: [NOT OK] commit_ret_cv 94081208059 wake up (4629669 us), return value (nil), result code -1
6960860 2022.02.19 13:46:00.534826 [ 111604 ] {} <Information> RaftInstance: leadership is still valid
6960861 2022.02.19 13:46:00.534838 [ 111603 ] {} <Information> RaftInstance: leadership is still valid
```