### PR TITLE
Pass term number through `BecomeFollower` callback

### DIFF
--- a/include/libnuraft/callback.hxx
+++ b/include/libnuraft/callback.hxx
@@ -61,7 +61,7 @@ public:
 
         /**
          * Became a leader.
-         * ctx: null.
+         * ctx: pointer to term number.
          */
         BecomeLeader = 6,
 
@@ -92,7 +92,7 @@ public:
 
         /**
          * Became a follower.
-         * ctx: null.
+         * ctx: pointer to term number.
          */
         BecomeFollower = 11,
 

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -1273,6 +1273,8 @@ void raft_server::become_follower() {
         role_ = srv_role::follower;
 
         cb_func::Param param(id_, leader_);
+        uint64_t my_term = state_->get_term();
+        param.ctx = &my_term;
         (void) ctx_->cb_func_.call(cb_func::BecomeFollower, &param);
 
         write_paused_ = false;


### PR DESCRIPTION
* Same as `BecomeLeader`, `BecomeFollower` needs to carry the term
number.