### PR TITLE
Support custom resolver

### DIFF
--- a/include/libnuraft/asio_service_options.hxx
+++ b/include/libnuraft/asio_service_options.hxx
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include <functional>
 #include <string>
+#include <system_error>
 
 namespace nuraft {
 
@@ -60,6 +61,12 @@ struct asio_service_meta_cb_params {
 };
 
 /**
+ * Response callback function for customer resolvers.
+ */
+using asio_service_custom_resolver_response =
+    std::function< void(const std::string&, const std::string&, std::error_code) >;
+
+/**
  * Options used for initialization of Asio service.
  */
 struct asio_service_options {
@@ -76,56 +83,102 @@ struct asio_service_options {
         , read_resp_meta_(nullptr)
         , invoke_resp_cb_on_empty_meta_(true)
         , verify_sn_(nullptr)
+        , custom_resolver_(nullptr)
         {}
 
-    // Number of ASIO worker threads.
-    // If zero, it will be automatically set to number of cores.
+    /**
+     * Number of ASIO worker threads.
+     * If zero, it will be automatically set to number of cores.
+     */
     size_t thread_pool_size_;
 
-    // Lifecycle callback function on worker thread start.
+    /**
+     * Lifecycle callback function on worker thread start.
+     */
     std::function< void(uint32_t) > worker_start_;
 
-    // Lifecycle callback function on worker thread stop.
+    /**
+     * Lifecycle callback function on worker thread stop.
+     */
     std::function< void(uint32_t) > worker_stop_;
 
-    // If `true`, enable SSL/TLS secure connection.
+    /**
+     * If `true`, enable SSL/TLS secure connection.
+     */
     bool enable_ssl_;
 
-    // If `true`, skip certificate verification.
+    /**
+     * If `true`, skip certificate verification.
+     */
     bool skip_verification_;
 
-    // Path to certification & key files.
+    /**
+     * Path to server certificate file.
+     */
     std::string server_cert_file_;
+
+    /**
+     * Path to server key file.
+     */
     std::string server_key_file_;
+
+    /**
+     * Path to root certificate file.
+     */
     std::string root_cert_file_;
 
-    // Callback function for writing Raft RPC request metadata.
+    /**
+     * Callback function for writing Raft RPC request metadata.
+     */
     std::function< std::string(const asio_service_meta_cb_params&) > write_req_meta_;
 
-    // Callback function for reading and verifying Raft RPC request metadata.
-    // If it returns false, the request will be discarded.
+    /**
+     * Callback function for reading and verifying Raft RPC request metadata.
+     * If it returns `false`, the request will be discarded.
+     */
     std::function< bool( const asio_service_meta_cb_params&,
                          const std::string& ) > read_req_meta_;
 
-    // If `true`, it will invoke `read_req_meta_` even though
-    // the received meta is empty.
+    /**
+     * If `true`, it will invoke `read_req_meta_` even though
+     * the received meta is empty.
+     */
     bool invoke_req_cb_on_empty_meta_;
 
-    // Callback function for writing Raft RPC response metadata.
+    /**
+     * Callback function for writing Raft RPC response metadata.
+     */
     std::function< std::string(const asio_service_meta_cb_params&) > write_resp_meta_;
 
-    // Callback function for reading and verifying Raft RPC response metadata.
-    // If it returns false, the response will be ignored.
+    /**
+     * Callback function for reading and verifying Raft RPC response metadata.
+     * If it returns false, the response will be ignored.
+     */
     std::function< bool( const asio_service_meta_cb_params&,
                          const std::string& ) > read_resp_meta_;
 
-    // If `true`, it will invoke `read_resp_meta_` even though
-    // the received meta is empty.
+    /**
+     * If `true`, it will invoke `read_resp_meta_` even though
+     * the received meta is empty.
+     */
     bool invoke_resp_cb_on_empty_meta_;
 
-    // Callback function for verifying certificate subject name.
-    // If not given, subject name will not be verified.
+    /**
+     * Callback function for verifying certificate subject name.
+     * If not given, subject name will not be verified.
+     */
     std::function< bool(const std::string&) > verify_sn_;
+
+    /**
+     * Custom IP address resolver. If given, it will be invoked
+     * before the connection is established.
+     *
+     * If you want to selectively bypass some hosts, just pass the given
+     * host and port to the response function as they are.
+     */
+    std::function< void( const std::string&,
+                         const std::string&,
+                         asio_service_custom_resolver_response ) > custom_resolver_;
 };
 
 }

--- a/tests/unit/asio_service_test.cxx
+++ b/tests/unit/asio_service_test.cxx
@@ -2463,6 +2463,86 @@ int parallel_log_append_test() {
     return 0;
 }
 
+int custom_resolver_test() {
+    reset_log_files();
+
+    std::string s1_addr = "S1:1234";
+    std::string s2_addr = "S2:1234";
+    std::string s3_addr = "S3:1234";
+
+    RaftAsioPkg s1(1, s1_addr);
+    RaftAsioPkg s2(2, s2_addr);
+    RaftAsioPkg s3(3, s3_addr);
+    std::vector<RaftAsioPkg*> pkgs = {&s1, &s2, &s3};
+
+    // Enable custom resolver.
+    s1.useCustomResolver = s2.useCustomResolver = s3.useCustomResolver = true;
+
+    _msg("launching asio-raft servers\n");
+    CHK_Z( launch_servers(pkgs, false) );
+
+    _msg("organizing raft group\n");
+    CHK_Z( make_group(pkgs) );
+
+    // Set async mode.
+    for (auto& entry: pkgs) {
+        RaftAsioPkg* pp = entry;
+        raft_params param = pp->raftServer->get_current_params();
+        param.return_method_ = raft_params::async_handler;
+        param.parallel_log_appending_ = true;
+        pp->raftServer->update_params(param);
+    }
+
+    // Append messages asynchronously.
+    const size_t NUM = 10;
+    std::list< ptr< cmd_result< ptr<buffer> > > > handlers;
+    std::list<ulong> idx_list;
+    std::mutex idx_list_lock;
+    auto do_async_append = [&]() {
+        handlers.clear();
+        idx_list.clear();
+        for (size_t ii=0; ii<NUM; ++ii) {
+            std::string test_msg = "test" + std::to_string(ii);
+            ptr<buffer> msg = buffer::alloc(test_msg.size() + 1);
+            msg->put(test_msg);
+            ptr< cmd_result< ptr<buffer> > > ret =
+                s1.raftServer->append_entries( {msg} );
+
+            cmd_result< ptr<buffer> >::handler_type my_handler =
+                std::bind( async_handler,
+                           &idx_list,
+                           &idx_list_lock,
+                           std::placeholders::_1,
+                           std::placeholders::_2 );
+            ret->when_ready( my_handler );
+
+            handlers.push_back(ret);
+        }
+    };
+    do_async_append();
+
+    TestSuite::sleep_sec(1, "wait for replication");
+
+    // Now all async handlers should have result.
+    {
+        std::lock_guard<std::mutex> l(idx_list_lock);
+        CHK_EQ(NUM, idx_list.size());
+    }
+
+    // State machine should be identical.
+    CHK_OK( s2.getTestSm()->isSame( *s1.getTestSm() ) );
+    CHK_OK( s3.getTestSm()->isSame( *s1.getTestSm() ) );
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+    TestSuite::sleep_sec(1, "shutting down");
+
+    SimpleLogger::shutdown();
+    return 0;
+}
+
+
 }  // namespace asio_service_test;
 using namespace asio_service_test;
 
@@ -2564,6 +2644,9 @@ int main(int argc, char** argv) {
 
     ts.doTest( "parallel log append test",
                parallel_log_append_test );
+
+    ts.doTest( "custom resolver test",
+               custom_resolver_test );
 
 #ifdef ENABLE_RAFT_STATS
     _msg("raft stats: ENABLED\n");

--- a/tests/unit/raft_package_asio.hxx
+++ b/tests/unit/raft_package_asio.hxx
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 **************************************************************************/
 
+#include "asio_service_options.hxx"
 #include "raft_functional_common.hxx"
 #include "internal_timer.hxx"
 
@@ -51,6 +52,7 @@ public:
         , readReqMeta(nullptr)
         , writeReqMeta(nullptr)
         , alwaysInvokeCb(true)
+        , useCustomResolver(false)
         , myLogWrapper(nullptr)
         , myLog(nullptr)
         {}
@@ -98,6 +100,21 @@ public:
             asio_opt.server_cert_file_  = "./cert.pem";
             asio_opt.root_cert_file_    = "./cert.pem"; // self-signed.
             asio_opt.server_key_file_   = "./key.pem";
+        }
+
+        if (useCustomResolver) {
+            asio_opt.custom_resolver_ =
+                []( const std::string& host,
+                    const std::string& port,
+                    asio_service_custom_resolver_response when_done ) {
+                    if (host.substr(0, 2) == "S1") {
+                        when_done("127.0.0.1", "20010", std::error_code());
+                    } else if (host.substr(0, 2) == "S2") {
+                        when_done("127.0.0.1", "20020", std::error_code());
+                    } else {
+                        when_done("127.0.0.1", "20030", std::error_code());
+                    }
+                };
         }
 
         if (readReqMeta) asio_opt.read_req_meta_ = readReqMeta;
@@ -232,6 +249,8 @@ public:
     WRITE_META_FUNC writeRespMeta;
 
     bool alwaysInvokeCb;
+
+    bool useCustomResolver;
 
     ptr<logger_wrapper> myLogWrapper;
     ptr<logger> myLog;


### PR DESCRIPTION
* The custom resolver can be invoked before the default resolver in
order to resolve the endpoint in its own way.