### PR TITLE
fix segfault on 32bit system: fix #243, fix #362

### DIFF
--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -245,7 +245,7 @@ public:
 
         cached_address_ = socket_.remote_endpoint().address().to_string();
         cached_port_ = socket_.remote_endpoint().port();
-        p_in( "session %zu got connection from %s:%u (as a server)",
+        p_in( "session %lu got connection from %s:%u (as a server)",
               session_id_,
               cached_address_.c_str(),
               cached_port_ );
@@ -269,14 +269,14 @@ public:
     void handle_handshake(ptr<rpc_session> self,
                           const ERROR_CODE& err) {
         if (!err) {
-            p_in( "session %zu handshake with %s:%u succeeded (as a server)",
+            p_in( "session %lu handshake with %s:%u succeeded (as a server)",
                   session_id_,
                   cached_address_.c_str(),
                   cached_port_ );
             this->start(self);
 
         } else {
-            p_er( "session %zu handshake with %s:%u failed: error %d, %s",
+            p_er( "session %lu handshake with %s:%u failed: error %d, %s",
                   session_id_,
                   cached_address_.c_str(),
                   cached_port_,
@@ -293,7 +293,7 @@ public:
                                (const ERROR_CODE& err) -> void
             {
                 if (err) {
-                    p_er("session %zu error happend during "
+                    p_er("session %lu error happend during "
                          "async wait: %d, %s",
                          session_id_,
                          err.value(),
@@ -312,7 +312,7 @@ public:
                   (const ERROR_CODE& err, size_t) -> void
         {
             if (err) {
-                p_er( "session %zu failed to read rpc header from socket %s:%u "
+                p_er( "session %lu failed to read rpc header from socket %s:%u "
                       "due to error %d, %s, ref count %u",
                       session_id_,
                       cached_address_.c_str(),
@@ -440,7 +440,7 @@ private:
         if (!err) {
             this->read_complete(header_, log_ctx);
         } else {
-            p_er( "session %zu failed to read rpc log data from socket due "
+            p_er( "session %lu failed to read rpc log data from socket due "
                   "to error %d, %s",
                   session_id_,
                   err.value(),
@@ -589,7 +589,7 @@ private:
         }
 
        } catch (std::exception& ex) {
-        p_er( "session %zu failed to process request message "
+        p_er( "session %lu failed to process request message "
               "due to error: %s",
               this->session_id_,
               ex.what() );
@@ -676,7 +676,7 @@ private:
             if (!err_code) {
                 this->start(self);
             } else {
-                p_er( "session %zu failed to send response to peer due "
+                p_er( "session %lu failed to send response to peer due "
                       "to error %d",
                       session_id_,
                       err_code.value() );
@@ -685,7 +685,7 @@ private:
         } );
 
        } catch (std::exception& ex) {
-        p_er( "session %zu failed to process request message "
+        p_er( "session %lu failed to process request message "
               "due to error: %s",
               this->session_id_,
               ex.what() );

--- a/src/fix_format.hxx
+++ b/src/fix_format.hxx
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <inttypes.h>
+#include <string>
+
+#if __WORDSIZE == 32
+static void
+replace_all(std::string& s, const std::string& search, const std::string& target) {
+    size_t index = 0;
+    while (true) {
+        index = s.find(search, index);
+        if (index == std::string::npos) break;
+        s.replace(index, search.size(), target);
+        index += search.size();
+    }
+}
+
+#define _fix_format(format)                        \
+    std::string format_string(format);             \
+    replace_all(format_string, "%ld", "%" PRId64); \
+    replace_all(format_string, "%lu", "%" PRIu64); \
+    format = format_string.c_str();
+#else
+#define _fix_format(format)
+#endif

--- a/src/handle_snapshot_sync.cxx
+++ b/src/handle_snapshot_sync.cxx
@@ -460,7 +460,7 @@ bool raft_server::handle_snapshot_sync_req(snapshot_sync_req& req) {
     bool is_last_obj = req.is_done();
     if (is_first_obj || is_last_obj) {
         // INFO level: log only first and last object.
-        p_in("save snapshot (idx %zu, term %zu) offset 0x%zx, %s %s\n",
+        p_in("save snapshot (idx %lu, term %lu) offset 0x%lx, %s %s\n",
              req.get_snapshot().get_last_log_idx(),
              req.get_snapshot().get_last_log_term(),
              req.get_offset(),
@@ -468,7 +468,7 @@ bool raft_server::handle_snapshot_sync_req(snapshot_sync_req& req) {
              (is_last_obj)  ? "last obj"  : "" );
     } else {
         // above DEBUG: log all.
-        p_db("save snapshot (idx %zu, term %zu) offset 0x%zx, %s %s\n",
+        p_db("save snapshot (idx %lu, term %lu) offset 0x%lx, %s %s\n",
              req.get_snapshot().get_last_log_idx(),
              req.get_snapshot().get_last_log_term(),
              req.get_offset(),

--- a/src/handle_timeout.cxx
+++ b/src/handle_timeout.cxx
@@ -305,7 +305,7 @@ void raft_server::handle_election_timeout() {
 
         // `term` changed, cannot use previous pre-vote result.
         if (pre_vote_.term_ != state_term) {
-            p_in("pre-vote term (%zu) is different, reset it to %zu",
+            p_in("pre-vote term (%lu) is different, reset it to %lu",
                  pre_vote_.term_, state_term);
             pre_vote_.reset(state_term);
         }

--- a/src/handle_vote.cxx
+++ b/src/handle_vote.cxx
@@ -439,7 +439,7 @@ void raft_server::handle_prevote_resp(resp_msg& resp) {
     if (resp.get_term() != pre_vote_.term_) {
         // Vote response for other term. Should ignore it.
         p_in("[PRE-VOTE RESP] from peer %d, my role %s, "
-             "but different resp term %zu (pre-vote term %zu). "
+             "but different resp term %lu (pre-vote term %lu). "
              "ignore it.",
              resp.get_src(), srv_role_to_string(role_).c_str(),
              resp.get_term(), pre_vote_.term_);
@@ -462,7 +462,7 @@ void raft_server::handle_prevote_resp(resp_msg& resp) {
 
     int32 election_quorum_size = get_quorum_for_election() + 1;
 
-    p_in("[PRE-VOTE RESP] peer %d (%s), term %zu, resp term %zu, "
+    p_in("[PRE-VOTE RESP] peer %d (%s), term %lu, resp term %lu, "
          "my role %s, dead %d, live %d, "
          "num voting members %d, quorum %d\n",
          resp.get_src(), (resp.get_accepted())?"O":"X",

--- a/src/tracer.hxx
+++ b/src/tracer.hxx
@@ -17,6 +17,7 @@ limitations under the License.
 
 #pragma once
 
+#include "fix_format.hxx"
 #include "logger.hxx"
 
 #include <string>
@@ -29,6 +30,7 @@ static inline std::string msg_if_given
     if (format[0] == 0x0) {
         return "";
     } else {
+        _fix_format(format);
         size_t len = 0;
         char msg[2048];
         va_list args;

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -1009,9 +1009,10 @@ public:
                 std::string _unit =
                     (unit.empty()) ? "" : unit + " ";
 
-                _msg("\r%s%ld/%ld %s(%.1f%%)",
-                     _comment.c_str(), curValue, num, _unit.c_str(),
-                     (double)curValue*100/num);
+                Msg mm;
+                mm << "\r" << _comment << curValue << "/" << num << " " << _unit
+                   << std::fixed << std::setprecision(1) << "("
+                   << (double)curValue * 100 / num << "%)";
                 fflush(stdout);
             }
             if (curValue >= num) {

--- a/tests/unit/asio_service_test.cxx
+++ b/tests/unit/asio_service_test.cxx
@@ -107,10 +107,10 @@ int make_group_test() {
         uint64_t last_log_idx = s1.raftServer->get_last_log_idx();
         CHK_EQ(srv_id, pi.id_);
         CHK_EQ(last_log_idx, pi.last_log_idx_);
-        _msg("srv %d: %lu, responeded %.1f ms ago\n",
-             pi.id_,
-             pi.last_log_idx_,
-             pi.last_succ_resp_us_ / 1000.0);
+        TestSuite::Msg mm;
+        mm << "srv " << pi.id_ << ": " << pi.last_log_idx_ << ", responded " << std::fixed
+           << std::setprecision(1) << pi.last_succ_resp_us_ / 1000.0 << " ms ago"
+           << std::endl;
     }
 
     // Sleep a while and get all info.
@@ -121,10 +121,10 @@ int make_group_test() {
     for (raft_server::peer_info& pi: v_pi) {
         uint64_t last_log_idx = s1.raftServer->get_last_log_idx();
         CHK_EQ(last_log_idx, pi.last_log_idx_);
-        _msg("srv %d: %lu, responeded %.1f ms ago\n",
-             pi.id_,
-             pi.last_log_idx_,
-             pi.last_succ_resp_us_ / 1000.0);
+        TestSuite::Msg mm;
+        mm << "srv " << pi.id_ << ": " << pi.last_log_idx_ << ", responded " << std::fixed
+           << std::setprecision(1) << pi.last_succ_resp_us_ / 1000.0 << " ms ago"
+           << std::endl;
     }
 
     s1.raftServer->shutdown();
@@ -2653,14 +2653,15 @@ int main(int argc, char** argv) {
 #else
     _msg("raft stats: DISABLED\n");
 #endif
-    _msg("num allocs: %zu\n"
-         "amount of allocs: %zu bytes\n"
-         "num active buffers: %zu\n"
-         "amount of active buffers: %zu bytes\n",
-         raft_server::get_stat_counter("num_buffer_allocs"),
-         raft_server::get_stat_counter("amount_buffer_allocs"),
-         raft_server::get_stat_counter("num_active_buffers"),
-         raft_server::get_stat_counter("amount_active_buffers"));
+    TestSuite::Msg mm;
+    mm << "num allocs: " << raft_server::get_stat_counter("num_buffer_allocs")
+       << std::endl
+       << "amount of allocs: " << raft_server::get_stat_counter("amount_buffer_allocs")
+       << " bytes" << std::endl
+       << "num active buffers: " << raft_server::get_stat_counter("num_active_buffers")
+       << std::endl
+       << "amount of active buffers: "
+       << raft_server::get_stat_counter("amount_active_buffers") << " bytes" << std::endl;
 
     return 0;
 }


### PR DESCRIPTION
this PR fixes the unportability of NuRaft, now NuRaft could finally works on 32bit systems.

1. core problem is the widely-used typedef `nuraft::ulong` is defined as `uint64_t`, which is 8 bytes. on 64bit systems, 8B integer is defined as `unsigned long` which could be printed with `%ld` / `%lu`, but on 32bit systems, 8B integer should only be printed with `%lld` / `%llu`, if not doing so, the following data would have wrong offset, **causing the whole program be terminated by segfault.**

2. another problem is that NuRaft use a lot of `%zu` / `%z` (which is print a `size_t`) to print `nuraft:ulong`, **this could also cause segfault on 32bit systems**, since `size_t` is actually _shorter than_ 8B, as demonstrated in the following demo:

on armhf SoC and x86_32 (32bit):

```
root@ATK-IMX6U:~# ./test
long int=4  uint64_t=ulong=8
long long int=8  uint64_t=ulong=8
size_t=4  uint64_t=ulong=8
```

on aarch64 and x86_64 (64bit):

```
<~/C/l>-> ./test.x86
long int=8  uint64_t=ulong=8
long long int=8  uint64_t=ulong=8
size_t=8  uint64_t=ulong=8
```

---

this PR fix both bug (1) and (2):
1. for bug (1), there're several possible solutions:
   - the most simple solution is to just change `nuraft::ulong` to platform-dependent `unsigned long`, thus fits the `%ld` used. but this has an obvious adverse effect on Raft protocol, since 32bit is very prone to overflow, especially in some mission-critical storage system that may under heavy load just as NuRaft.
   - [`inttypes.h`](https://en.cppreference.com/w/c/types/integer) have several platform-dependent macros we can use to properly print a 64bit integer on both 32bit and 64bit platforms. we can also automatically replace `%ld` / `%lu` to `"%" PRId64` / `"%" PRId64`. this could be done at compile-time or run-time. unfortunately the vararg macros of NuRaft's logger seems incapable of processing C's string concat syntax (`"%" "d" == "%d"`), thus this PR implement this fix at run-time, which leads to a very small performance degrade on 32bit systems. considering 32bit systems're really rare these days and people usually don't use a very noisy log level, I think this solution's OK.
   - we can also do such global replace (`%ld -> %lld`, `%lu -> %llu`) in _build system_. but I'm not very familiar with CMake, and comparing to the two solutions stated above which fix the bug _by code_, I dont think fix _by build system_ (something that is _not_ code) is a great idea.
   - finally, we can document such global replace in README.md to those rare 32bit platform users that they need to do two global replacement _before_ building NuRaft.
2. for bug (2), this PR correct some misuse of `%zu` and `%z`. this is **necessary** and must be settle down, and from now on NuRaft mustn't introduce new code that misuses `%zu` or `%z`. I havn't check every `%zu` and `%z`, I just fix some misuses of them that would cause the tests to segfault, this means maybe there're many of them still lurking in the code.

---

more details could be found in #362.