### PR TITLE
Initialize parallel_log_appending

### DIFF
--- a/include/libnuraft/raft_params.hxx
+++ b/include/libnuraft/raft_params.hxx
@@ -95,6 +95,7 @@ struct raft_params {
         , grace_period_of_lagging_state_machine_(0)
         , use_bg_thread_for_snapshot_io_(false)
         , use_full_consensus_among_healthy_members_(false)
+        , parallel_log_appending_(false)
         {}
 
     /**


### PR DESCRIPTION
Really small fix to make it more consistent and to make MSAN happy 😄 (it was caught in our CI https://github.com/ClickHouse/ClickHouse/pull/39609)