### PR TITLE
Support timestamp for log entry

### DIFF
--- a/examples/in_memory_log_store.cxx
+++ b/examples/in_memory_log_store.cxx
@@ -47,10 +47,14 @@ inmem_log_store::~inmem_log_store() {
 }
 
 ptr<log_entry> inmem_log_store::make_clone(const ptr<log_entry>& entry) {
+    // NOTE:
+    //   Timestamp is used only when `replicate_log_timestamp_` option is on.
+    //   Otherwise, log store does not need to store or load it.
     ptr<log_entry> clone = cs_new<log_entry>
                            ( entry->get_term(),
                              buffer::clone( entry->get_buf() ),
-                             entry->get_val_type() );
+                             entry->get_val_type(),
+                             entry->get_timestamp() );
     return clone;
 }
 

--- a/include/libnuraft/asio_service_options.hxx
+++ b/include/libnuraft/asio_service_options.hxx
@@ -84,6 +84,7 @@ struct asio_service_options {
         , invoke_resp_cb_on_empty_meta_(true)
         , verify_sn_(nullptr)
         , custom_resolver_(nullptr)
+        , replicate_log_timestamp_(false)
         {}
 
     /**
@@ -179,6 +180,20 @@ struct asio_service_options {
     std::function< void( const std::string&,
                          const std::string&,
                          asio_service_custom_resolver_response ) > custom_resolver_;
+
+    /**
+     * If `true`, each log entry will contain timestamp when it was generated
+     * by the leader, and those timestamps will be replicated to all followers
+     * so that they will see the same timestamp for the same log entry.
+     *
+     * To support this feature, the log store implementation should be able to
+     * restore the timestamp when it reads log entries.
+     *
+     * This feature is not backward compatible. To enable this feature, there
+     * should not be any member running with old version before supprting
+     * this flag.
+     */
+    bool replicate_log_timestamp_;
 };
 
 }

--- a/include/libnuraft/log_entry.hxx
+++ b/include/libnuraft/log_entry.hxx
@@ -37,10 +37,12 @@ class log_entry {
 public:
     log_entry(ulong term,
               const ptr<buffer>& buff,
-              log_val_type value_type = log_val_type::app_log)
+              log_val_type value_type = log_val_type::app_log,
+              uint64_t log_timestamp = 0)
         : term_(term)
         , value_type_(value_type)
         , buff_(buff)
+        , timestamp_us_(log_timestamp)
         {}
 
     __nocopy__(log_entry);
@@ -82,6 +84,14 @@ public:
         return buff_;
     }
 
+    uint64_t get_timestamp() const {
+        return timestamp_us_;
+    }
+
+    void set_timestamp(uint64_t t) {
+        timestamp_us_ = t;
+    }
+
     ptr<buffer> serialize() {
         buff_->pos(0);
         ptr<buffer> buf = buffer::alloc( sizeof(ulong) +
@@ -108,9 +118,27 @@ public:
     }
 
 private:
+    /**
+     * The term number when this log entry was generated.
+     */
     ulong term_;
+
+    /**
+     * Type of this log entry.
+     */
     log_val_type value_type_;
+
+    /**
+     * Actual data that this log entry carries.
+     */
     ptr<buffer> buff_;
+
+    /**
+     * The timestamp (since epoch) when this log entry was generated
+     * in microseconds. Used only when `log_entry_timestamp_` in
+     * `asio_service_options` is set.
+     */
+    uint64_t timestamp_us_;
 };
 
 }

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -804,7 +804,9 @@ protected:
     ptr<resp_msg> handle_prevote_req(req_msg& req);
     ptr<resp_msg> handle_vote_req(req_msg& req);
     ptr<resp_msg> handle_cli_req_prelock(req_msg& req, const req_ext_params& ext_params);
-    ptr<resp_msg> handle_cli_req(req_msg& req, const req_ext_params& ext_params);
+    ptr<resp_msg> handle_cli_req(req_msg& req,
+                                 const req_ext_params& ext_params,
+                                 uint64_t timestamp_us);
     ptr<resp_msg> handle_cli_req_callback(ptr<commit_ret_elem> elem,
                                           ptr<resp_msg> resp);
     ptr< cmd_result< ptr<buffer> > >

--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -110,6 +110,9 @@ limitations under the License.
 // If set, RPC message (response) includes additional hints.
 #define INCLUDE_HINT (0x2)
 
+// If set, each log entry will contain timestamp.
+#define INCLUDE_LOG_TIMESTAMP (0x4)
+
 // =======================
 
 namespace nuraft {
@@ -504,39 +507,49 @@ private:
         ptr<req_msg> req = cs_new<req_msg>
                            ( term, t, src, dst, last_term, last_idx, commit_idx );
         if (hdr->get_int() > 0 && log_ctx) {
-            log_ctx->pos(0);
+            buffer_serializer ss(log_ctx);
+            size_t log_ctx_size = log_ctx->size();
+
             // If flag is set, read meta first.
             if (flags_ & INCLUDE_META) {
                 size_t meta_len = 0;
-                const byte* meta_raw = log_ctx->get_bytes(meta_len);
+                const byte* meta_raw = (const byte*)ss.get_bytes(meta_len);
                 if (meta_len) {
                     meta_str = std::string((const char*)meta_raw, meta_len);
                 }
             }
 
-            while (log_ctx->size() > log_ctx->pos()) {
-                if (log_ctx->size() - log_ctx->pos() < sz_ulong + sz_byte + sz_int) {
+            size_t LOG_ENTRY_SIZE = 8 + 1 + 4;
+            if (flags_ & INCLUDE_LOG_TIMESTAMP) {
+                LOG_ENTRY_SIZE += 8;
+            }
+
+            while (log_ctx_size > ss.pos()) {
+                if (log_ctx_size - ss.pos() < LOG_ENTRY_SIZE) {
                     // Possibly corrupted packet. Stop here.
                     p_wn("wrong log ctx size %zu pos %zu, stop this session",
-                         log_ctx->size(), log_ctx->pos());
+                         log_ctx_size, ss.pos());
                     this->stop();
                     return;
                 }
-                ulong term = log_ctx->get_ulong();
-                log_val_type val_type = (log_val_type)log_ctx->get_byte();
-                size_t val_size = log_ctx->get_int();
-                if (log_ctx->size() - log_ctx->pos() < val_size) {
+                ulong term = ss.get_u64();
+                log_val_type val_type = (log_val_type)ss.get_u8();
+                uint64_t timestamp = (flags_ & INCLUDE_LOG_TIMESTAMP) ? ss.get_u64() : 0;
+
+                size_t val_size = ss.get_i32();
+                if (log_ctx_size - ss.pos() < val_size) {
                     // Out-of-bound size.
                     p_wn("wrong value size %zu log ctx %zu %zu, "
                          "stop this session",
-                         val_size, log_ctx->size(), log_ctx->pos());
+                         val_size, log_ctx_size, ss.pos());
                     this->stop();
                     return;
                 }
 
                 ptr<buffer> buf( buffer::alloc(val_size) );
-                log_ctx->get(buf);
-                ptr<log_entry> entry( cs_new<log_entry>(term, buf, val_type) );
+                ss.get_buffer(buf);
+                ptr<log_entry> entry(
+                    cs_new<log_entry>(term, buf, val_type, timestamp) );
                 req->log_entries().push_back(entry);
             }
         }
@@ -1085,22 +1098,38 @@ public:
         std::vector<ptr<buffer>> log_entry_bufs;
         int32 log_data_size(0);
 
+        uint32_t flags = 0x0;
+        size_t LOG_ENTRY_SIZE = 8 + 1 + 4;
+        if (impl_->get_options().replicate_log_timestamp_) {
+            LOG_ENTRY_SIZE += 8;
+            flags |= INCLUDE_LOG_TIMESTAMP;
+        }
+
         for (auto& entry: req->log_entries()) {
             ptr<log_entry>& le = entry;
             ptr<buffer> entry_buf = buffer::alloc
-                                    ( 8 + 1 + 4 + le->get_buf().size() );
+                                    ( LOG_ENTRY_SIZE + le->get_buf().size() );
+#if 0
             entry_buf->put( le->get_term() );
             entry_buf->put( (byte)le->get_val_type() );
             entry_buf->put( (int32)le->get_buf().size() );
             le->get_buf().pos(0);
             entry_buf->put( le->get_buf() );
             entry_buf->pos( 0 );
-
+#else
+            buffer_serializer ss(entry_buf);
+            ss.put_u64( le->get_term() );
+            ss.put_u8( le->get_val_type() );
+            if (impl_->get_options().replicate_log_timestamp_) {
+                ss.put_u64( le->get_timestamp() );
+            }
+            ss.put_i32( le->get_buf().size() );
+            ss.put_raw( le->get_buf().data_begin(), le->get_buf().size() );
+#endif
             log_entry_bufs.push_back(entry_buf);
             log_data_size += (int32)entry_buf->size();
         }
 
-        uint32_t flags = 0x0;
         size_t meta_size = 0;
         std::string meta_str;
         if (impl_->get_options().write_req_meta_) {

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -691,7 +691,8 @@ ptr<resp_msg> raft_server::handle_append_entries(req_msg& req)
                 cnt < req.log_entries().size() )
         {
             ptr<log_entry> entry = req.log_entries().at(cnt);
-            p_in("overwrite at %zu, term %zu\n", log_idx, entry->get_term());
+            p_in("overwrite at %lu, term %lu, timestamp %lu\n",
+                 log_idx, entry->get_term(), entry->get_timestamp());
             store_log_entry(entry, log_idx);
 
             if (entry->get_val_type() == log_val_type::app_log) {
@@ -719,8 +720,9 @@ ptr<resp_msg> raft_server::handle_append_entries(req_msg& req)
 
         // Append new log entries
         while (cnt < req.log_entries().size()) {
-            p_tr("append at %zu\n", log_store_->next_slot());
             ptr<log_entry> entry = req.log_entries().at( cnt++ );
+            p_tr("append at %lu, term %lu, timestamp %lu\n",
+                 log_store_->next_slot(), entry->get_term(), entry->get_timestamp());
             ulong idx_for_entry = store_log_entry(entry);
             if (entry->get_val_type() == log_val_type::conf) {
                 p_in( "receive a config change from leader at %llu",

--- a/src/handle_client_request.cxx
+++ b/src/handle_client_request.cxx
@@ -30,6 +30,7 @@ limitations under the License.
 #include "tracer.hxx"
 
 #include <cassert>
+#include <chrono>
 #include <sstream>
 
 namespace nuraft {
@@ -39,17 +40,19 @@ ptr<resp_msg> raft_server::handle_cli_req_prelock(req_msg& req,
 {
     ptr<resp_msg> resp = nullptr;
     ptr<raft_params> params = ctx_->get_params();
+    uint64_t timestamp_us = timer_helper::get_timeofday_us();
+
     switch (params->locking_method_type_) {
         case raft_params::single_mutex: {
             recur_lock(lock_);
-            resp = handle_cli_req(req, ext_params);
+            resp = handle_cli_req(req, ext_params, timestamp_us);
             break;
         }
         case raft_params::dual_mutex:
         default: {
             // TODO: Use RW lock here.
             auto_lock(cli_lock_);
-            resp = handle_cli_req(req, ext_params);
+            resp = handle_cli_req(req, ext_params, timestamp_us);
             break;
         }
     }
@@ -80,13 +83,15 @@ void raft_server::request_append_entries_for_all() {
 }
 
 ptr<resp_msg> raft_server::handle_cli_req(req_msg& req,
-                                          const req_ext_params& ext_params)
+                                          const req_ext_params& ext_params,
+                                          uint64_t timestamp_us)
 {
     ptr<resp_msg> resp = nullptr;
     ulong last_idx = 0;
     ptr<buffer> ret_value = nullptr;
     ulong resp_idx = 1;
     ulong cur_term = state_->get_term();
+    ptr<raft_params> params = ctx_->get_params();
 
     resp = cs_new<resp_msg>( cur_term,
                              msg_type::append_entries_response,
@@ -111,9 +116,10 @@ ptr<resp_msg> raft_server::handle_cli_req(req_msg& req,
     for (size_t i = 0; i < num_entries; ++i) {
         // force the log's term to current term
         entries.at(i)->set_term(cur_term);
+        entries.at(i)->set_timestamp(timestamp_us);
 
         ulong next_slot = store_log_entry(entries.at(i));
-        p_db("append at log_idx %zu\n", next_slot);
+        p_db("append at log_idx %lu, timestamp %lu\n", next_slot, timestamp_us);
         last_idx = next_slot;
 
         ptr<buffer> buf = entries.at(i)->get_buf_ptr();

--- a/src/handle_join_leave.cxx
+++ b/src/handle_join_leave.cxx
@@ -18,6 +18,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 **************************************************************************/
 
+#include "internal_timer.hxx"
 #include "raft_server.hxx"
 
 #include "cluster_config.hxx"
@@ -254,7 +255,8 @@ void raft_server::sync_log_to_new_srv(ulong start_idx) {
         ptr<buffer> new_conf_buf(new_conf->serialize());
         ptr<log_entry> entry( cs_new<log_entry>( state_->get_term(),
                                                  new_conf_buf,
-                                                 log_val_type::conf ) );
+                                                 log_val_type::conf,
+                                                 timer_helper::get_timeofday_us() ) );
         store_log_entry(entry);
         config_changing_ = true;
         uncommitted_config_ = new_conf;
@@ -509,7 +511,8 @@ void raft_server::rm_srv_from_cluster(int32 srv_id) {
     ptr<buffer> new_conf_buf( new_conf->serialize() );
     ptr<log_entry> entry( cs_new<log_entry>( state_->get_term(),
                                              new_conf_buf,
-                                             log_val_type::conf ) );
+                                             log_val_type::conf,
+                                             timer_helper::get_timeofday_us() ) );
     store_log_entry(entry);
 
     auto p_entry = peers_.find(srv_id);

--- a/src/handle_priority.cxx
+++ b/src/handle_priority.cxx
@@ -18,6 +18,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 **************************************************************************/
 
+#include "internal_timer.hxx"
 #include "raft_server.hxx"
 
 #include "cluster_config.hxx"
@@ -88,7 +89,8 @@ void raft_server::set_priority(const int srv_id, const int new_priority)
     ptr<log_entry> entry( cs_new<log_entry>
                           ( state_->get_term(),
                             new_conf_buf,
-                            log_val_type::conf ) );
+                            log_val_type::conf,
+                            timer_helper::get_timeofday_us() ) );
 
     config_changing_ = true;
     uncommitted_config_ = cloned_config;

--- a/tests/unit/raft_functional_common.hxx
+++ b/tests/unit/raft_functional_common.hxx
@@ -452,6 +452,8 @@ public:
         curLogStore->set_disk_delay(raft, delay_ms);
     }
 
+    ptr<inmem_log_store> get_inmem_log_store() const { return curLogStore; }
+
 private:
     int myId;
     std::string myEndpoint;

--- a/tests/unit/raft_package_asio.hxx
+++ b/tests/unit/raft_package_asio.hxx
@@ -53,6 +53,7 @@ public:
         , writeReqMeta(nullptr)
         , alwaysInvokeCb(true)
         , useCustomResolver(false)
+        , useLogTimestamp(false)
         , myLogWrapper(nullptr)
         , myLog(nullptr)
         {}
@@ -116,6 +117,8 @@ public:
                     }
                 };
         }
+
+        asio_opt.replicate_log_timestamp_ = useLogTimestamp;
 
         if (readReqMeta) asio_opt.read_req_meta_ = readReqMeta;
         if (writeReqMeta) asio_opt.write_req_meta_ = writeReqMeta;
@@ -251,6 +254,8 @@ public:
     bool alwaysInvokeCb;
 
     bool useCustomResolver;
+
+    bool useLogTimestamp;
 
     ptr<logger_wrapper> myLogWrapper;
     ptr<logger> myLog;


### PR DESCRIPTION
* Added an option that enables automatic generation of timestamp
for each log entry. Log store implementation should be able to
store and load timestamps in log entries.