### PR TITLE
Windows does not include POSIX gettimeofday() call.

### DIFF
--- a/include/libnuraft/internal_timer.hxx
+++ b/include/libnuraft/internal_timer.hxx
@@ -121,11 +121,9 @@ struct timer_helper {
 
     static uint64_t get_timeofday_us() {
         namespace sc = std::chrono;
-        sc::system_clock::duration d = sc::system_clock::now().time_since_epoch();
-        sc::seconds s = sc::duration_cast<sc::seconds>(d);
-        uint64_t ret = s.count() * 1000000UL;
-        ret += sc::duration_cast<sc::microseconds>(d - s).count();
-        return ret;
+        sc::system_clock::duration const d = sc::system_clock::now().time_since_epoch();
+        uint64_t const s = sc::duration_cast<sc::microseconds>(d).count();
+        return s;
     }
 
     std::chrono::time_point<std::chrono::system_clock> t_created_;

--- a/include/libnuraft/internal_timer.hxx
+++ b/include/libnuraft/internal_timer.hxx
@@ -21,8 +21,6 @@ limitations under the License.
 #include <mutex>
 #include <thread>
 
-#include <sys/time.h>
-
 namespace nuraft {
 
 struct timer_helper {
@@ -122,10 +120,11 @@ struct timer_helper {
     }
 
     static uint64_t get_timeofday_us() {
-        struct timeval tv;
-        gettimeofday(&tv, nullptr);
-        uint64_t ret = tv.tv_sec * 1000000UL;
-        ret += tv.tv_usec;
+        namespace sc = std::chrono;
+        sc::system_clock::duration d = sc::system_clock::now().time_since_epoch();
+        sc::seconds s = sc::duration_cast<sc::seconds>(d);
+        uint64_t ret = s.count() * 1000000UL;
+        ret += sc::duration_cast<sc::microseconds>(d - s).count();
         return ret;
     }
 


### PR DESCRIPTION
Convert call to gettimeofday() (POSIX only) to use C++11 APIs available on all platforms.