### PR TITLE
Make manually create snapshot result knowable

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -743,9 +743,16 @@ public:
      * Manually create a snapshot based on the latest committed
      * log index of the state machine.
      *
-     * @return `true` on success.
+     * @return `true` on success or on scheduled for asynchronously creation.
      */
-    bool create_snapshot();
+    ulong create_snapshot();
+
+    /**
+     * Check whether a snapshot is created
+     * @param log_idx
+     * @return true if last_log_idx_ of last snapshot or equal with or bigger than log_idx
+     */
+    bool snapshot_created(ulong log_idx);
 
 protected:
     typedef std::unordered_map<int32, ptr<peer>>::const_iterator peer_itor;

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -743,16 +743,17 @@ public:
      * Manually create a snapshot based on the latest committed
      * log index of the state machine.
      *
-     * @return `true` on success or on scheduled for asynchronously creation.
+     * @return Log index number of the created snapshot or`0` if failed.
      */
     ulong create_snapshot();
 
     /**
-     * Check whether a snapshot is created
-     * @param log_idx
-     * @return true if last_log_idx_ of last snapshot or equal with or bigger than log_idx
+     * Get the log index number of the last snapshot.
+     *
+     * @return Log index number of the last snapshot.
+     *         `0` if snapshot does not exist.
      */
-    bool snapshot_created(ulong log_idx);
+    ulong get_last_snapshot_idx() const;
 
 protected:
     typedef std::unordered_map<int32, ptr<peer>>::const_iterator peer_itor;

--- a/src/handle_commit.cxx
+++ b/src/handle_commit.cxx
@@ -469,8 +469,9 @@ ulong raft_server::create_snapshot() {
     return snapshot_and_compact(committed_idx, true) ? committed_idx : 0;
 }
 
-bool raft_server::snapshot_created(ulong committed_idx) {
-    return get_last_snapshot()->get_last_log_idx() >= committed_idx;
+ulong raft_server::get_last_snapshot_idx() const {
+    std::lock_guard<std::mutex> l(last_snapshot_lock_);
+    return last_snapshot_ ? last_snapshot_->get_last_log_idx(): 0;
 }
 
 bool raft_server::snapshot_and_compact(ulong committed_idx, bool forced_creation) {

--- a/src/handle_commit.cxx
+++ b/src/handle_commit.cxx
@@ -463,10 +463,14 @@ bool raft_server::apply_config_log_entry(ptr<log_entry>& le,
     return true;
 }
 
-bool raft_server::create_snapshot() {
+ulong raft_server::create_snapshot() {
     uint64_t committed_idx = sm_commit_index_;
     p_in("manually create a snapshot on %lu", committed_idx);
-    return snapshot_and_compact(committed_idx, true);
+    return snapshot_and_compact(committed_idx, true) ? committed_idx : 0;
+}
+
+bool raft_server::snapshot_created(ulong committed_idx) {
+    return get_last_snapshot()->get_last_log_idx() >= committed_idx;
 }
 
 bool raft_server::snapshot_and_compact(ulong committed_idx, bool forced_creation) {

--- a/tests/unit/raft_server_test.cxx
+++ b/tests/unit/raft_server_test.cxx
@@ -1990,8 +1990,7 @@ int snapshot_manual_creation_test() {
     // Create a manual snapshot.
     ulong log_idx = s1.raftServer->create_snapshot();
     CHK_EQ( committed_index, log_idx );
-    CHK_EQ( committed_index, s1.getTestSm()->last_snapshot()->get_last_log_idx() );
-    CHK_OK( s1.raftServer->snapshot_created(log_idx) )
+    CHK_EQ( log_idx, s1.raftServer->get_last_snapshot_idx() );
 
     // Make req to S3 failed.
     s1.fNet->makeReqFail("S3");

--- a/tests/unit/raft_server_test.cxx
+++ b/tests/unit/raft_server_test.cxx
@@ -1988,8 +1988,10 @@ int snapshot_manual_creation_test() {
     uint64_t committed_index = s1.raftServer->get_committed_log_idx();
 
     // Create a manual snapshot.
-    CHK_OK( s1.raftServer->create_snapshot() );
+    ulong log_idx = s1.raftServer->create_snapshot();
+    CHK_EQ( committed_index, log_idx );
     CHK_EQ( committed_index, s1.getTestSm()->last_snapshot()->get_last_log_idx() );
+    CHK_OK( s1.raftServer->snapshot_created(log_idx) )
 
     // Make req to S3 failed.
     s1.fNet->makeReqFail("S3");


### PR DESCRIPTION
### Use case:
In my case snapshot creation is asynchronous , we want to know when creation is done.

### Change log:

1. `create_snapshot` return `ulong` which is back forward compatible
2. add API `snapshot_created`