### PR TITLE
New API `get_first_log_idx` & `get_first_log_term`

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -395,6 +395,22 @@ public:
     { return log_store_->term_at(log_idx); }
 
     /**
+     * Get the term of the first log.
+     *
+     * @return Term of the first log.
+     */
+    ulong get_first_log_term() const
+    { return log_store_->term_at(get_first_log_idx()); }
+
+    /**
+     * Get the first log index number.
+     *
+     * @return First log index number.
+     */
+    ulong get_first_log_idx() const
+    { return log_store_->start_index(); }
+
+    /**
      * Get the term of the last log.
      *
      * @return Term of the last log.


### PR DESCRIPTION
### Usage

I want to get Raft log informations, such as `first_log_idx`, `first_log_term`, `last_log_idx `, `last_committed_log_idx `, `last_snapshot_idx ` etc.

PS: We can calculate log count with `first_log_idx` and `last_log_idx `.