### PR TITLE
Fix test error

### DIFF
--- a/tests/unit/failure_test.cxx
+++ b/tests/unit/failure_test.cxx
@@ -208,6 +208,9 @@ int rmv_not_resp_srv_wq_test(bool explicit_failure) {
     // Remove s3 from leader.
     s1.dbgLog(" --- remove ---");
     s1.raftServer->remove_srv( s3.getTestMgr()->get_srv_config()->get_id() );
+    for (size_t ii = 0; ii < 10; ++ii) {
+        s1.fNet->execReqResp(s3_addr);
+    }
 
     s1.fNet->execReqResp(s2_addr);
     // Fail to send it to S3.

--- a/tests/unit/fake_network.cxx
+++ b/tests/unit/fake_network.cxx
@@ -154,7 +154,8 @@ bool FakeNetwork::delieverReqTo(const std::string& endpoint,
     ptr<FakeClient> conn = findClient(endpoint);
 
     // If destination is offline, make failure.
-    if (!conn->isDstOnline()) return makeReqFail(endpoint, random_order);
+    if (!conn->isDstOnline())
+        return makeReqFail(endpoint, random_order);
 
     auto pkg_entry = conn->pendingReqs.begin();
     if (pkg_entry == conn->pendingReqs.end()) return false;

--- a/tests/unit/raft_package_asio.hxx
+++ b/tests/unit/raft_package_asio.hxx
@@ -30,7 +30,7 @@ using namespace raft_functional_common;
 
 class RaftAsioPkg {
 public:
-    static const int HEARTBEAT_MS = 100;
+    static const int HEARTBEAT_MS = 125;
 
     using READ_META_FUNC = std::function
                                < bool( const asio_service::meta_cb_params&,


### PR DESCRIPTION
Change log :

1. `election_timeout_lower_bound_` can not be 0.
2. Add `invoke_election_timer` method identicating that we must wait election timeout before trigger leader election.
3. Only `S1` is leader in `init_options_test` but not all .
4. Remove server msg should deliver to `S3` in `rmv_not_resp_srv_wq_test`.
5. We should sleep some time lower than `heart_beat_interval_` when waiting reconnecting in `follower_reconnect_test`.
6. Change `RaftAsioPkg::HEARTBEAT_MS` to 125 (the default value)
