### PR TITLE
build: install `src/event_awaiter.h`, which is needed for running examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,5 +310,4 @@ endif()
 install(TARGETS static_lib ARCHIVE DESTINATION lib)
 install(TARGETS shared_lib LIBRARY DESTINATION lib)
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/libnuraft DESTINATION include)
-
-
+install(FILES ${PROJECT_SOURCE_DIR}/src/event_awaiter.h DESTINATION include)


### PR DESCRIPTION
Right now, in_memory_log_store.hxx has dependency on `event_awaiter.h`, so it would be good install the file for running the example in runtime.

https://github.com/eBay/NuRaft/blob/1524ac986ff38ec691062b82e821f09aa6011524/examples/in_memory_log_store.hxx#L20

relates to https://github.com/Homebrew/homebrew-core/pull/121246