### PR TITLE
Fix a typo "idnex" -> "index"

### DIFF
--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -749,7 +749,7 @@ ptr<resp_msg> raft_server::handle_append_entries(req_msg& req)
             while ( last_durable_index <
                     req.get_last_log_idx() + req.log_entries().size() ) {
                 // Some logs are not durable yet, wait here and block the thread.
-                p_tr( "durable idnex %lu, sleep and wait for log appending completion",
+                p_tr( "durable index %lu, sleep and wait for log appending completion",
                       last_durable_index );
                 ea_follower_log_append_->wait_ms(params->heart_beat_interval_);
 


### PR DESCRIPTION
I was not sure about it, but the previous lines suggest "index".