### PR TITLE
Move `event_awaiter` class definition to public directory

### DIFF
--- a/examples/in_memory_log_store.hxx
+++ b/examples/in_memory_log_store.hxx
@@ -17,7 +17,7 @@ limitations under the License.
 
 #pragma once
 
-#include "event_awaiter.h"
+#include "event_awaiter.hxx"
 #include "internal_timer.hxx"
 #include "log_store.hxx"
 

--- a/include/libnuraft/event_awaiter.hxx
+++ b/include/libnuraft/event_awaiter.hxx
@@ -25,6 +25,8 @@ limitations under the License.
 #include <condition_variable>
 #include <mutex>
 
+namespace nuraft {
+
 class EventAwaiter {
 private:
     enum class AS {
@@ -95,4 +97,4 @@ private:
     std::condition_variable cv;
 };
 
-
+}

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -38,8 +38,6 @@ limitations under the License.
 #include <unordered_map>
 #include <unordered_set>
 
-class EventAwaiter;
-
 namespace nuraft {
 
 using CbReturnCode = cb_func::ReturnCode;
@@ -47,6 +45,7 @@ using CbReturnCode = cb_func::ReturnCode;
 class cluster_config;
 class custom_notification_msg;
 class delayed_task_scheduler;
+class EventAwaiter;
 class logger;
 class peer;
 class rpc_client;

--- a/include/libnuraft/snapshot_sync_ctx.hxx
+++ b/include/libnuraft/snapshot_sync_ctx.hxx
@@ -22,7 +22,7 @@ limitations under the License.
 #define _SNAPSHOT_SYNC_CTX_HXX_
 
 #include "basic_types.hxx"
-#include "event_awaiter.h"
+#include "event_awaiter.hxx"
 #include "internal_timer.hxx"
 #include "pp_util.hxx"
 #include "ptr.hxx"

--- a/src/global_mgr.cxx
+++ b/src/global_mgr.cxx
@@ -19,7 +19,7 @@ limitations under the License.
 
 #include "global_mgr.hxx"
 
-#include "event_awaiter.h"
+#include "event_awaiter.hxx"
 #include "logger.hxx"
 #include "raft_server.hxx"
 #include "tracer.hxx"

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -24,7 +24,7 @@ limitations under the License.
 
 #include "cluster_config.hxx"
 #include "error_code.hxx"
-#include "event_awaiter.h"
+#include "event_awaiter.hxx"
 #include "handle_custom_notification.hxx"
 #include "peer.hxx"
 #include "snapshot.hxx"

--- a/src/handle_client_request.hxx
+++ b/src/handle_client_request.hxx
@@ -22,7 +22,7 @@ limitations under the License.
 
 #include "async.hxx"
 #include "buffer.hxx"
-#include "event_awaiter.h"
+#include "event_awaiter.hxx"
 #include "internal_timer.hxx"
 #include "ptr.hxx"
 #include "raft_server.hxx"

--- a/src/handle_join_leave.cxx
+++ b/src/handle_join_leave.cxx
@@ -22,7 +22,7 @@ limitations under the License.
 #include "raft_server.hxx"
 
 #include "cluster_config.hxx"
-#include "event_awaiter.h"
+#include "event_awaiter.hxx"
 #include "peer.hxx"
 #include "snapshot_sync_ctx.hxx"
 #include "state_machine.hxx"

--- a/src/handle_priority.cxx
+++ b/src/handle_priority.cxx
@@ -22,7 +22,7 @@ limitations under the License.
 #include "raft_server.hxx"
 
 #include "cluster_config.hxx"
-#include "event_awaiter.h"
+#include "event_awaiter.hxx"
 #include "peer.hxx"
 #include "tracer.hxx"
 

--- a/src/handle_snapshot_sync.cxx
+++ b/src/handle_snapshot_sync.cxx
@@ -22,7 +22,7 @@ limitations under the License.
 
 #include "context.hxx"
 #include "error_code.hxx"
-#include "event_awaiter.h"
+#include "event_awaiter.hxx"
 #include "peer.hxx"
 #include "snapshot.hxx"
 #include "snapshot_sync_ctx.hxx"

--- a/src/handle_timeout.cxx
+++ b/src/handle_timeout.cxx
@@ -20,7 +20,7 @@ limitations under the License.
 
 #include "raft_server.hxx"
 
-#include "event_awaiter.h"
+#include "event_awaiter.hxx"
 #include "peer.hxx"
 #include "state_machine.hxx"
 #include "state_mgr.hxx"

--- a/src/handle_user_cmd.cxx
+++ b/src/handle_user_cmd.cxx
@@ -22,7 +22,7 @@ limitations under the License.
 
 #include "cluster_config.hxx"
 #include "context.hxx"
-#include "event_awaiter.h"
+#include "event_awaiter.hxx"
 #include "rpc_cli_factory.hxx"
 #include "tracer.hxx"
 

--- a/src/handle_vote.cxx
+++ b/src/handle_vote.cxx
@@ -21,7 +21,7 @@ limitations under the License.
 #include "raft_server.hxx"
 
 #include "cluster_config.hxx"
-#include "event_awaiter.h"
+#include "event_awaiter.hxx"
 #include "handle_custom_notification.hxx"
 #include "peer.hxx"
 #include "state_mgr.hxx"

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -23,7 +23,7 @@ limitations under the License.
 #include "cluster_config.hxx"
 #include "context.hxx"
 #include "error_code.hxx"
-#include "event_awaiter.h"
+#include "event_awaiter.hxx"
 #include "global_mgr.hxx"
 #include "handle_client_request.hxx"
 #include "handle_custom_notification.hxx"

--- a/src/snapshot_sync_ctx.cxx
+++ b/src/snapshot_sync_ctx.cxx
@@ -17,7 +17,7 @@ limitations under the License.
 
 #include "snapshot_sync_ctx.hxx"
 
-#include "event_awaiter.h"
+#include "event_awaiter.hxx"
 #include "peer.hxx"
 #include "raft_server.hxx"
 #include "state_machine.hxx"

--- a/tests/unit/asio_service_test.cxx
+++ b/tests/unit/asio_service_test.cxx
@@ -20,7 +20,7 @@ limitations under the License.
 #include "in_memory_log_store.hxx"
 #include "raft_package_asio.hxx"
 
-#include "event_awaiter.h"
+#include "event_awaiter.hxx"
 #include "test_common.h"
 
 #include <unordered_map>

--- a/tests/unit/failure_test.cxx
+++ b/tests/unit/failure_test.cxx
@@ -19,7 +19,7 @@ limitations under the License.
 #include "fake_network.hxx"
 #include "raft_package_fake.hxx"
 
-#include "event_awaiter.h"
+#include "event_awaiter.hxx"
 #include "test_common.h"
 
 #include <stdio.h>

--- a/tests/unit/raft_package_fake.hxx
+++ b/tests/unit/raft_package_fake.hxx
@@ -18,7 +18,7 @@ limitations under the License.
 #include "fake_network.hxx"
 #include "raft_functional_common.hxx"
 
-#include "event_awaiter.h"
+#include "event_awaiter.hxx"
 
 using namespace nuraft;
 using namespace raft_functional_common;

--- a/tests/unit/raft_server_test.cxx
+++ b/tests/unit/raft_server_test.cxx
@@ -19,7 +19,7 @@ limitations under the License.
 #include "fake_network.hxx"
 #include "raft_package_fake.hxx"
 
-#include "event_awaiter.h"
+#include "event_awaiter.hxx"
 #include "raft_params.hxx"
 #include "test_common.h"
 


### PR DESCRIPTION
* Since it is used by the in-memory log store for examples, we need to move it to the public include directory.