### PR TITLE
Fix possible integer overflow when serializing log_val_type.

### DIFF
--- a/include/libnuraft/log_val_type.hxx
+++ b/include/libnuraft/log_val_type.hxx
@@ -23,13 +23,13 @@ limitations under the License.
 
 namespace nuraft {
 
-enum log_val_type {
+enum log_val_type : byte {
     app_log         = 1,
     conf            = 2,
     cluster_server  = 3,
     log_pack        = 4,
     snp_sync_req    = 5,
-    custom          = 999,
+    custom          = 231,
 };
 
 }


### PR DESCRIPTION
We can see that the "custom" entrie of the log_val_type enum is set to 999. However, when this value is serialized, it is cast as 8bit unsigned integer which maximum value is 255.

We type the enumeration to 8bit interger and we change the value of custom to 999 (given that 999 % 256 = 231).

#400 