### PR TITLE
fix Visual Studio build

### DIFF
--- a/src/tracer.hxx
+++ b/src/tracer.hxx
@@ -24,13 +24,15 @@ limitations under the License.
 
 #include <stdarg.h>
 
-static inline std::string msg_if_given(const char* format, ...)
-    __attribute__((format(printf, 1, 2)));
-
-
+#ifdef _WIN32
+static inline std::string msg_if_given
+                          ( _Printf_format_string_ const char* format,
+                            ... ) {
+#else
 static inline std::string msg_if_given
                           ( const char* format,
-                            ... ) {
+                            ... ) __attribute__((format(printf, 1, 2))) {
+#endif
     if (format[0] == 0x0) {
         return "";
     } else {

--- a/src/tracer.hxx
+++ b/src/tracer.hxx
@@ -29,9 +29,13 @@ static inline std::string msg_if_given
                           ( _Printf_format_string_ const char* format,
                             ... ) {
 #else
+static inline std::string msg_if_given(const char* format, ...)
+    __attribute__((format(printf, 1, 2)));
+
+
 static inline std::string msg_if_given
                           ( const char* format,
-                            ... ) __attribute__((format(printf, 1, 2))) {
+                            ... ) {
 #endif
     if (format[0] == 0x0) {
         return "";


### PR DESCRIPTION
fix Visual Studio build :
src\tracer.hxx(34): error C3646: '__attribute__': unknown override specifier

We use the Microsoft source-code annotation language (SAL) equivalent to __attribute__((format(printf, ...