### PR TITLE
Allowing clients to provide pre-Configured SSL_CTX for both client and server use-cases.

### DIFF
--- a/include/libnuraft/asio_service_options.hxx
+++ b/include/libnuraft/asio_service_options.hxx
@@ -21,6 +21,9 @@ limitations under the License.
 #include <string>
 #include <system_error>
 
+
+typedef struct ssl_ctx_st SSL_CTX;
+
 namespace nuraft {
 
 /**
@@ -169,6 +172,20 @@ struct asio_service_options {
      * If not given, subject name will not be verified.
      */
     std::function< bool(const std::string&) > verify_sn_;
+
+    /**
+     * Callback function that provides pre-configured SSL_CTX.
+     * Asio takes ownership of the provided object
+     * and disposes it later with SSL_CTX_free.
+     *
+     * No configuration changes are applied to the provided context,
+     * so callback must return properly configured and operational SSL_CTX.
+     *
+     * Note that it might be unsafe to share SSL_CTX with other threads,
+     * consult with your OpenSSL library documentation/guidelines.
+     */
+    std::function<SSL_CTX* (void)> ssl_context_provider_server_;
+    std::function<SSL_CTX* (void)> ssl_context_provider_client_;
 
     /**
      * Custom IP address resolver. If given, it will be invoked

--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -1638,12 +1638,23 @@ void _timer_handler_(ptr<delayed_task>& task, ERROR_CODE err) {
     }
 }
 
+namespace {
+
+ssl_context get_or_create_ssl_context(std::function<SSL_CTX* (void)> ctx_provider_func, ssl_context::method method) {
+    if (ctx_provider_func)
+        return ssl_context(ctx_provider_func());
+    else
+        return ssl_context(method);
+}
+
+}
+
 asio_service_impl::asio_service_impl(const asio_service::options& _opt,
                                      ptr<logger> l)
     : io_svc_()
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
-    , ssl_server_ctx_(ssl_context::tlsv12_server)
-    , ssl_client_ctx_(ssl_context::tlsv12_client)
+    , ssl_server_ctx_(get_or_create_ssl_context(_opt.ssl_context_provider_server_, ssl_context::tlsv12_server))
+    , ssl_client_ctx_(get_or_create_ssl_context(_opt.ssl_context_provider_client_, ssl_context::tlsv12_client))
 #else
     , ssl_server_ctx_(ssl_context::sslv23)  // Any version
     , ssl_client_ctx_(ssl_context::sslv23)
@@ -1664,22 +1675,29 @@ asio_service_impl::asio_service_impl(const asio_service::options& _opt,
 #ifdef SSL_LIBRARY_NOT_FOUND
         assert(0); // Should not reach here.
 #else
-        // For server (listener)
-        ssl_server_ctx_.set_options( ssl_context::default_workarounds |
-                                     ssl_context::no_sslv2 |
-                                     ssl_context::single_dh_use );
-        ssl_server_ctx_.set_password_callback
-                        ( std::bind( &asio_service_impl::get_password,
-                                     this,
-                                     std::placeholders::_1,
-                                     std::placeholders::_2 ) );
-        ssl_server_ctx_.use_certificate_chain_file
-                        ( _opt.server_cert_file_ );
-        ssl_server_ctx_.use_private_key_file( _opt.server_key_file_,
-                                              ssl_context::pem );
 
-        // For client
-        ssl_client_ctx_.load_verify_file(_opt.root_cert_file_);
+        // Provider gives properly configured server contex
+        if (!_opt.ssl_context_provider_server_) {
+            // For server (listener)
+            ssl_server_ctx_.set_options( ssl_context::default_workarounds |
+                                         ssl_context::no_sslv2 |
+                                         ssl_context::single_dh_use );
+            ssl_server_ctx_.set_password_callback
+                            ( std::bind( &asio_service_impl::get_password,
+                                         this,
+                                         std::placeholders::_1,
+                                         std::placeholders::_2 ) );
+            ssl_server_ctx_.use_certificate_chain_file
+                            ( _opt.server_cert_file_ );
+            ssl_server_ctx_.use_private_key_file( _opt.server_key_file_,
+                                                  ssl_context::pem );
+        }
+
+        // Provider gives properly configured client contex
+        if (!_opt.ssl_context_provider_client_) {
+            // For client
+            ssl_client_ctx_.load_verify_file(_opt.root_cert_file_);
+        }
 #endif
     }
 


### PR DESCRIPTION
To avoid adding too many configuration parameters to the asio_service_options, two new callbacks were added:
- std::function<SSL_CTX* (void)> ssl_context_provider_server_;
- std::function<SSL_CTX* (void)> ssl_context_provider_client_;

Which provide preconfigured, ready to use SSL_CTX, so the clients of the library may configure contexts in any required way.

Ported from https://github.com/ClickHouse/NuRaft/pull/56