### PR TITLE
Allow get_servers() on const cluster_config

### DIFF
--- a/include/libnuraft/cluster_config.hxx
+++ b/include/libnuraft/cluster_config.hxx
@@ -69,7 +69,7 @@ public:
         return prev_log_idx_;
     }
 
-    std::list<ptr<srv_config>> const& get_servers() const {
+    const std::list<ptr<srv_config>>& get_servers() const {
         return servers_;
     }
 

--- a/include/libnuraft/cluster_config.hxx
+++ b/include/libnuraft/cluster_config.hxx
@@ -52,9 +52,6 @@ public:
     __nocopy__(cluster_config);
 
 public:
-    typedef std::list<ptr<srv_config>>::iterator srv_itor;
-    typedef std::list<ptr<srv_config>>::const_iterator const_srv_itor;
-
     static ptr<cluster_config> deserialize(buffer& buf);
 
     static ptr<cluster_config> deserialize(buffer_serializer& buf);
@@ -70,6 +67,10 @@ public:
 
     ulong get_prev_log_idx() const {
         return prev_log_idx_;
+    }
+
+    std::list<ptr<srv_config>> const& get_servers() const {
+        return servers_;
     }
 
     std::list<ptr<srv_config>>& get_servers() {

--- a/src/cluster_config.cxx
+++ b/src/cluster_config.cxx
@@ -25,7 +25,7 @@ namespace nuraft {
 ptr<buffer> cluster_config::serialize() const {
     size_t sz = 2 * sz_ulong + sz_int + sz_byte;
     std::vector<ptr<buffer>> srv_buffs;
-    for (cluster_config::const_srv_itor it = servers_.begin(); it != servers_.end(); ++it) {
+    for (auto it = servers_.cbegin(); it != servers_.cend(); ++it) {
         ptr<buffer> buf = (*it)->serialize();
         srv_buffs.push_back(buf);
         sz += buf->size();

--- a/src/handle_join_leave.cxx
+++ b/src/handle_join_leave.cxx
@@ -498,8 +498,8 @@ void raft_server::rm_srv_from_cluster(int32 srv_id) {
     ptr<cluster_config> new_conf = cs_new<cluster_config>
                                    ( log_store_->next_slot(),
                                      cur_conf->get_log_idx() );
-    for ( cluster_config::const_srv_itor it = cur_conf->get_servers().begin();
-          it != cur_conf->get_servers().end();
+    for (auto it = cur_conf->get_servers().cbegin();
+          it != cur_conf->get_servers().cend();
           ++it ) {
         if ((*it)->get_id() != srv_id) {
             new_conf->get_servers().push_back(*it);

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -196,8 +196,8 @@ raft_server::raft_server(context* ctx, const init_options& opt)
                               log_store_->start_index() );
           i < log_store_->next_slot();
           ++i ) {
-        if (auto entry = log_store_->entry_at(i);
-                              entry->get_val_type() == log_val_type::conf) {
+        auto const entry = log_store_->entry_at(i);
+        if (entry->get_val_type() == log_val_type::conf) {
             p_in( "detect a configuration change "
                   "that is not committed yet at index %" PRIu64 "", i );
             config_changing_ = true;

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -196,8 +196,8 @@ raft_server::raft_server(context* ctx, const init_options& opt)
                               log_store_->start_index() );
           i < log_store_->next_slot();
           ++i ) {
-        ptr<log_entry> entry(log_store_->entry_at(i));
-        if (entry->get_val_type() == log_val_type::conf) {
+        if (auto entry = log_store_->entry_at(i);
+                              entry->get_val_type() == log_val_type::conf) {
             p_in( "detect a configuration change "
                   "that is not committed yet at index %" PRIu64 "", i );
             config_changing_ = true;
@@ -206,8 +206,8 @@ raft_server::raft_server(context* ctx, const init_options& opt)
     }
 
     std::stringstream peer_info_msg;
-    std::list< ptr<srv_config> >& srvs = c_conf->get_servers();
-    for (cluster_config::srv_itor it = srvs.begin(); it != srvs.end(); ++it) {
+    auto srvs_end = c_conf->get_servers().end();
+    for (auto it = c_conf->get_servers().begin(); it != srvs_end; ++it) {
         ptr<srv_config> cur_srv = *it;
         if (cur_srv->get_id() != id_) {
             timer_task<int32>::executor exec =
@@ -737,8 +737,9 @@ ptr<resp_msg> raft_server::process_req(req_msg& req,
 
 void raft_server::reset_peer_info() {
     ptr<cluster_config> c_config = get_config();
-    p_db("servers: %zu\n", c_config->get_servers().size());
-    if (c_config->get_servers().size() > 1) {
+    auto const srv_cnt = c_config->get_servers().size();
+    p_db("servers: %zu\n", srv_cnt);
+    if (srv_cnt > 1) {
         ptr<srv_config> my_srv_config = c_config->get_server(id_);
         if (!my_srv_config) {
             // It means that this node was removed, and then
@@ -1582,7 +1583,7 @@ void raft_server::get_srv_config_all
      ( std::vector< ptr<srv_config> >& configs_out ) const
 {
     ptr<cluster_config> c_conf = get_config();
-    std::list< ptr<srv_config> >& servers = c_conf->get_servers();
+    auto& servers = c_conf->get_servers();
     for (auto& entry: servers) configs_out.push_back(entry);
 }
 


### PR DESCRIPTION
Currently one must const_cast a cluster_config in order to iterate the servers it contains. This is done potentially during commit_conf or snapshots if one does not use the serialize/deserialize methods.