### PR TITLE
Don't do log rewind if `append_entries` is declined by callback

### DIFF
--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -1568,7 +1568,7 @@ private:
         if (remaining_len) {
             // It has context, read it.
             ptr<buffer> actual_ctx = buffer::alloc(remaining_len);
-            ctx_buf->get(actual_ctx);
+            bs.get_buffer(actual_ctx);
             rsp->set_ctx(actual_ctx);
         }
 


### PR DESCRIPTION
* If `append_entries` is declined by callback, not by term mismatch, the leader should not do log rewind.

* Also, if it is declined by callback, the follower should not initiate leader election not to disrupt the entire cluster.