### PR TITLE
Add `compact_async` API to log store

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -926,6 +926,9 @@ protected:
     void on_snapshot_completed(ptr<snapshot>& s,
                                bool result,
                                ptr<std::exception>& err);
+    void on_log_compacted(ulong log_idx,
+                          bool result,
+                          ptr<std::exception>& err);
     void on_retryable_req_err(ptr<peer>& p, ptr<req_msg>& req);
     ulong term_for_log(ulong log_idx);
 

--- a/src/handle_commit.cxx
+++ b/src/handle_commit.cxx
@@ -620,12 +620,28 @@ void raft_server::on_snapshot_completed
             ulong compact_upto = new_snp->get_last_log_idx() -
                                      (ulong)params->reserved_log_items_;
             p_in("log_store_ compact upto %" PRIu64 "", compact_upto);
-            log_store_->compact(compact_upto);
+
+            cmd_result<bool>::handler_type handler =
+                (cmd_result<bool>::handler_type)
+                std::bind( &raft_server::on_log_compacted,
+                           this,
+                           compact_upto,
+                           std::placeholders::_1,
+                           std::placeholders::_2 );
+
+            log_store_->compact_async(compact_upto, handler);
         }
     }
  } while (false);
 
     snp_in_progress_.store(false);
+}
+
+void raft_server::on_log_compacted(ulong log_idx,
+                                   bool result,
+                                   ptr<std::exception>& err)
+{
+    // Place holder. Just move forward.
 }
 
 void raft_server::reconfigure(const ptr<cluster_config>& new_config) {


### PR DESCRIPTION
* Log compaction is a disk IO intensive task, so we want to avoid executing it inside Raft's `lock_`.

* For that purpose, added an API to compact log asynchronously. `compact_async` can return immediately, and a callback will be invoked on the completion of the log compaction.