### PR TITLE
Fix Deadlock between snapshot_sync_req and background snapshot creation.

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -34,6 +34,7 @@ limitations under the License.
 
 #include <list>
 #include <map>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -855,8 +856,8 @@ protected:
 
     void drop_all_pending_commit_elems();
 
-    ptr<resp_msg> handle_ext_msg(req_msg& req);
-    ptr<resp_msg> handle_install_snapshot_req(req_msg& req);
+    ptr<resp_msg> handle_ext_msg(req_msg& req, std::unique_lock<std::recursive_mutex>& guard);
+    ptr<resp_msg> handle_install_snapshot_req(req_msg& req, std::unique_lock<std::recursive_mutex>& guard);
     ptr<resp_msg> handle_rm_srv_req(req_msg& req);
     ptr<resp_msg> handle_add_srv_req(req_msg& req);
     ptr<resp_msg> handle_log_sync_req(req_msg& req);
@@ -870,7 +871,7 @@ protected:
     void handle_log_sync_resp(resp_msg& resp);
     void handle_leave_cluster_resp(resp_msg& resp);
 
-    bool handle_snapshot_sync_req(snapshot_sync_req& req);
+    bool handle_snapshot_sync_req(snapshot_sync_req& req, std::unique_lock<std::recursive_mutex>& guard);
 
     bool check_cond_for_zp_election();
     void request_prevote();

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -727,7 +727,7 @@ ptr<resp_msg> raft_server::process_req(req_msg& req,
 
     } else {
         // extended requests
-        resp = handle_ext_msg(req);
+        resp = handle_ext_msg(req, guard);
     }
 
     if (resp) {
@@ -1375,7 +1375,7 @@ bool raft_server::update_term(ulong term) {
     return false;
 }
 
-ptr<resp_msg> raft_server::handle_ext_msg(req_msg& req) {
+ptr<resp_msg> raft_server::handle_ext_msg(req_msg& req, std::unique_lock<std::recursive_mutex>& guard) {
     switch (req.get_type()) {
     case msg_type::add_server_request:
         return handle_add_srv_req(req);
@@ -1393,7 +1393,7 @@ ptr<resp_msg> raft_server::handle_ext_msg(req_msg& req) {
         return handle_leave_cluster_req(req);
 
     case msg_type::install_snapshot_request:
-        return handle_install_snapshot_req(req);
+        return handle_install_snapshot_req(req, guard);
 
     case msg_type::reconnect_request:
         return handle_reconnect_req(req);


### PR DESCRIPTION
The RPC service can deadlock the background thread during snapshot creation and synchronization. Both race to take the lock_ mutex, but the RPC service will hold it while waiting for the snapshot to complete (which it never will). The loop that checks for snapshot progress needs to give up this lock.