### PR TITLE
Return status of set_priority. Ability to broadcast priority changes if there's a leader

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -314,15 +314,14 @@ public:
         append_entries_ext(const std::vector< ptr<buffer> >& logs,
                            const req_ext_params& ext_params);
 
-    enum class priority_set_result {
-        SET = 0,
-        BROADCAST = 1,
-        IGNORED = 2
+    enum class PrioritySetResult {
+        SET,
+        BROADCAST,
+        IGNORED
     };
 
     /**
      * Update the priority of given server.
-     * Only leader will accept this operation.
      *
      * @param srv_id ID of server to update priority.
      * @param new_priority
@@ -334,11 +333,11 @@ public:
      * @return SET If we're a leader and we have committed priority change.
      * @return BROADCAST
      *     If either there's no live leader now, or we're a leader and we want to set our priority to 0,
-     *     or broadcast_when_leader_exists = true and we're not a leader.
+     *     or we're not a leader and broadcast_when_leader_exists = true.
      *     We have sent messages to other peers about priority change but haven't committed this change.
      * @return IGNORED If we're not a leader and broadcast_when_leader_exists = false. We ignored the request.
      */
-    priority_set_result set_priority(
+    PrioritySetResult set_priority(
         const int srv_id, const int new_priority,
         bool broadcast_when_leader_exists = false);
 

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -314,11 +314,7 @@ public:
         append_entries_ext(const std::vector< ptr<buffer> >& logs,
                            const req_ext_params& ext_params);
 
-    enum class PrioritySetResult {
-        SET,
-        BROADCAST,
-        IGNORED
-    };
+    enum class PrioritySetResult { SET, BROADCAST, IGNORED };
 
     /**
      * Update the priority of given server.
@@ -328,18 +324,21 @@ public:
      *     Priority value, greater than or equal to 0.
      *     If priority is set to 0, this server will never be a leader.
      * @param broadcast_when_leader_exists
-     *     If we're not a leader and a leader exists, broadcast priority change to other peers.
-     *     If false, set_priority does nothing.
+     *     If we're not a leader and a leader exists, broadcast priority change to other
+     *     peers. If false, set_priority does nothing. Please note that setting this
+     *     option to true may possibly cause cluster config to diverge.
      * @return SET If we're a leader and we have committed priority change.
      * @return BROADCAST
-     *     If either there's no live leader now, or we're a leader and we want to set our priority to 0,
-     *     or we're not a leader and broadcast_when_leader_exists = true.
-     *     We have sent messages to other peers about priority change but haven't committed this change.
-     * @return IGNORED If we're not a leader and broadcast_when_leader_exists = false. We ignored the request.
+     *     If either there's no live leader now, or we're a leader and we want to set our
+     *     priority to 0, or we're not a leader and broadcast_when_leader_exists = true.
+     *     We have sent messages to other peers about priority change but haven't
+     *     committed this change.
+     * @return IGNORED If we're not a leader and broadcast_when_leader_exists = false. We
+     *     ignored the request.
      */
-    PrioritySetResult set_priority(
-        const int srv_id, const int new_priority,
-        bool broadcast_when_leader_exists = false);
+    PrioritySetResult set_priority(const int srv_id,
+                                   const int new_priority,
+                                   bool broadcast_when_leader_exists = false);
 
     /**
      * Broadcast the priority change of given server to all peers.

--- a/src/handle_priority.cxx
+++ b/src/handle_priority.cxx
@@ -32,7 +32,7 @@ limitations under the License.
 
 namespace nuraft {
 
-raft_server::priority_set_result
+raft_server::PrioritySetResult
 raft_server::set_priority(const int srv_id,
                           const int new_priority,
                           bool broadcast_when_leader_exists) {
@@ -45,13 +45,13 @@ raft_server::set_priority(const int srv_id,
         if (!is_leader_alive()) {
             p_wn("No live leader now, broadcast priority change");
             broadcast_priority_change(srv_id, new_priority);
-            return priority_set_result::BROADCAST;
+            return PrioritySetResult::BROADCAST;
         } else if (broadcast_when_leader_exists) {
             p_wn("Leader is present but broadcasting priority change as requested");
             broadcast_priority_change(srv_id, new_priority);
-            return priority_set_result::BROADCAST;
+            return PrioritySetResult::BROADCAST;
         }
-        return priority_set_result::IGNORED;
+        return PrioritySetResult::IGNORED;
     }
 
     if (id_ == srv_id && new_priority == 0) {
@@ -61,7 +61,7 @@ raft_server::set_priority(const int srv_id,
         // immediately yield its leadership.
         // So in this case, boradcast this change.
         broadcast_priority_change(srv_id, new_priority);
-        return priority_set_result::BROADCAST;
+        return PrioritySetResult::BROADCAST;
     }
 
     // Clone current cluster config.
@@ -104,7 +104,7 @@ raft_server::set_priority(const int srv_id,
 
     store_log_entry(entry);
     request_append_entries();
-    return priority_set_result::SET;
+    return PrioritySetResult::SET;
 }
 
 void raft_server::broadcast_priority_change(const int srv_id,

--- a/src/handle_priority.cxx
+++ b/src/handle_priority.cxx
@@ -38,7 +38,6 @@ raft_server::set_priority(const int srv_id,
                           bool broadcast_when_leader_exists) {
     recur_lock(lock_);
 
-    // Do nothing if not a leader.
     if (id_ != leader_) {
         p_in("Got set_priority request but I'm not a leader: my ID %d, leader %d",
              id_, leader_.load());

--- a/tests/unit/asio_service_test.cxx
+++ b/tests/unit/asio_service_test.cxx
@@ -1245,11 +1245,11 @@ int leadership_transfer_test() {
     CHK_EQ(1, s3->raftServer->get_leader());
 
     // Set the priority of S2 to 10.
-    CHK_TRUE( s1->raftServer->set_priority(2, 10) == raft_server::priority_set_result::SET );
+    CHK_TRUE( s1->raftServer->set_priority(2, 10) == raft_server::PrioritySetResult::SET );
     TestSuite::sleep_ms(500, "set priority of S2");
 
     // Set the priority of S3 to 5.
-    CHK_TRUE( s1->raftServer->set_priority(3, 5) == raft_server::priority_set_result::SET );
+    CHK_TRUE( s1->raftServer->set_priority(3, 5) == raft_server::PrioritySetResult::SET );
     TestSuite::sleep_ms(500, "set priority of S3");
 
     // Yield the leadership to S2.
@@ -1287,7 +1287,7 @@ int leadership_transfer_test() {
     s1->raftServer->update_params(params);
 
     // Set S2's priority higher than S1
-    CHK_TRUE( s1->raftServer->set_priority(2, 100) == raft_server::priority_set_result::SET );
+    CHK_TRUE( s1->raftServer->set_priority(2, 100) == raft_server::PrioritySetResult::SET );
 
     // Due to S3, transfer shouldn't happen.
     TestSuite::sleep_sec(2, "shutdown S3, set priority of S2, and wait");
@@ -1532,7 +1532,7 @@ int enforced_state_machine_catchup_test() {
     TestSuite::sleep_sec(1, "wait for replication");
 
     // Adjust the priority of S2 to zero, to block it becoming a leader.
-    CHK_TRUE( s1.raftServer->set_priority(2, 0) == raft_server::priority_set_result::SET );
+    CHK_TRUE( s1.raftServer->set_priority(2, 0) == raft_server::PrioritySetResult::SET );
 
     TestSuite::sleep_sec(1, "set S2's priority to zero");
 
@@ -1620,7 +1620,7 @@ int enforced_state_machine_catchup_with_term_inc_test() {
     TestSuite::sleep_sec(1, "wait for replication");
 
     // Adjust the priority of S2 to zero, to block it becoming a leader.
-    CHK_TRUE( s1.raftServer->set_priority(2, 0) == raft_server::priority_set_result::SET );
+    CHK_TRUE( s1.raftServer->set_priority(2, 0) == raft_server::PrioritySetResult::SET );
     TestSuite::sleep_sec(1, "set S2's priority to zero");
 
     // Stop S3, delete data.

--- a/tests/unit/asio_service_test.cxx
+++ b/tests/unit/asio_service_test.cxx
@@ -1245,11 +1245,11 @@ int leadership_transfer_test() {
     CHK_EQ(1, s3->raftServer->get_leader());
 
     // Set the priority of S2 to 10.
-    s1->raftServer->set_priority(2, 10);
+    CHK_TRUE( s1->raftServer->set_priority(2, 10) == raft_server::priority_set_result::SET );
     TestSuite::sleep_ms(500, "set priority of S2");
 
     // Set the priority of S3 to 5.
-    s1->raftServer->set_priority(3, 5);
+    CHK_TRUE( s1->raftServer->set_priority(3, 5) == raft_server::priority_set_result::SET );
     TestSuite::sleep_ms(500, "set priority of S3");
 
     // Yield the leadership to S2.
@@ -1287,7 +1287,7 @@ int leadership_transfer_test() {
     s1->raftServer->update_params(params);
 
     // Set S2's priority higher than S1
-    s1->raftServer->set_priority(2, 100);
+    CHK_TRUE( s1->raftServer->set_priority(2, 100) == raft_server::priority_set_result::SET );
 
     // Due to S3, transfer shouldn't happen.
     TestSuite::sleep_sec(2, "shutdown S3, set priority of S2, and wait");
@@ -1532,7 +1532,8 @@ int enforced_state_machine_catchup_test() {
     TestSuite::sleep_sec(1, "wait for replication");
 
     // Adjust the priority of S2 to zero, to block it becoming a leader.
-    s1.raftServer->set_priority(2, 0);
+    CHK_TRUE( s1.raftServer->set_priority(2, 0) == raft_server::priority_set_result::SET );
+
     TestSuite::sleep_sec(1, "set S2's priority to zero");
 
     // Stop S3, delete data.
@@ -1619,7 +1620,7 @@ int enforced_state_machine_catchup_with_term_inc_test() {
     TestSuite::sleep_sec(1, "wait for replication");
 
     // Adjust the priority of S2 to zero, to block it becoming a leader.
-    s1.raftServer->set_priority(2, 0);
+    CHK_TRUE( s1.raftServer->set_priority(2, 0) == raft_server::priority_set_result::SET );
     TestSuite::sleep_sec(1, "set S2's priority to zero");
 
     // Stop S3, delete data.

--- a/tests/unit/asio_service_test.cxx
+++ b/tests/unit/asio_service_test.cxx
@@ -32,6 +32,16 @@ using namespace raft_functional_common;
 
 static bool flag_bg_snapshot_io = false;
 
+std::ostream& operator<<(std::ostream& os, raft_server::PrioritySetResult res) {
+    if (res == raft_server::PrioritySetResult::SET)
+        os << "SET";
+    else if (res == raft_server::PrioritySetResult::IGNORED)
+        os << "IGNORED";
+    else
+        os << "BROADCAST";
+    return os;
+}
+
 namespace asio_service_test {
 
 int launch_servers(const std::vector<RaftAsioPkg*>& pkgs,
@@ -1245,11 +1255,11 @@ int leadership_transfer_test() {
     CHK_EQ(1, s3->raftServer->get_leader());
 
     // Set the priority of S2 to 10.
-    CHK_TRUE( s1->raftServer->set_priority(2, 10) == raft_server::PrioritySetResult::SET );
+    CHK_EQ( raft_server::PrioritySetResult::SET, s1->raftServer->set_priority(2, 10) );
     TestSuite::sleep_ms(500, "set priority of S2");
 
     // Set the priority of S3 to 5.
-    CHK_TRUE( s1->raftServer->set_priority(3, 5) == raft_server::PrioritySetResult::SET );
+    CHK_EQ( raft_server::PrioritySetResult::SET, s1->raftServer->set_priority(3, 5) );
     TestSuite::sleep_ms(500, "set priority of S3");
 
     // Yield the leadership to S2.
@@ -1287,7 +1297,7 @@ int leadership_transfer_test() {
     s1->raftServer->update_params(params);
 
     // Set S2's priority higher than S1
-    CHK_TRUE( s1->raftServer->set_priority(2, 100) == raft_server::PrioritySetResult::SET );
+    CHK_EQ( raft_server::PrioritySetResult::SET, s1->raftServer->set_priority(2, 100) );
 
     // Due to S3, transfer shouldn't happen.
     TestSuite::sleep_sec(2, "shutdown S3, set priority of S2, and wait");
@@ -1532,7 +1542,7 @@ int enforced_state_machine_catchup_test() {
     TestSuite::sleep_sec(1, "wait for replication");
 
     // Adjust the priority of S2 to zero, to block it becoming a leader.
-    CHK_TRUE( s1.raftServer->set_priority(2, 0) == raft_server::PrioritySetResult::SET );
+    CHK_EQ( raft_server::PrioritySetResult::SET, s1.raftServer->set_priority(2, 0) );
 
     TestSuite::sleep_sec(1, "set S2's priority to zero");
 
@@ -1620,7 +1630,7 @@ int enforced_state_machine_catchup_with_term_inc_test() {
     TestSuite::sleep_sec(1, "wait for replication");
 
     // Adjust the priority of S2 to zero, to block it becoming a leader.
-    CHK_TRUE( s1.raftServer->set_priority(2, 0) == raft_server::PrioritySetResult::SET );
+    CHK_EQ( raft_server::PrioritySetResult::SET, s1.raftServer->set_priority(2, 0) );
     TestSuite::sleep_sec(1, "set S2's priority to zero");
 
     // Stop S3, delete data.

--- a/tests/unit/raft_package_fake.hxx
+++ b/tests/unit/raft_package_fake.hxx
@@ -250,7 +250,7 @@ static INT_UNUSED launch_servers(const std::vector<RaftPkg*>& pkgs,
     return 0;
 }
 
-/// pkgs[0] becomes a leader
+/// pkgs[0] becomes leader
 static INT_UNUSED make_group(const std::vector<RaftPkg*>& pkgs) {
     size_t num_srvs = pkgs.size();
     CHK_GT(num_srvs, 0);

--- a/tests/unit/raft_package_fake.hxx
+++ b/tests/unit/raft_package_fake.hxx
@@ -250,6 +250,7 @@ static INT_UNUSED launch_servers(const std::vector<RaftPkg*>& pkgs,
     return 0;
 }
 
+/// pkgs[0] becomes a leader
 static INT_UNUSED make_group(const std::vector<RaftPkg*>& pkgs) {
     size_t num_srvs = pkgs.size();
     CHK_GT(num_srvs, 0);

--- a/tests/unit/raft_server_test.cxx
+++ b/tests/unit/raft_server_test.cxx
@@ -30,6 +30,16 @@ using namespace raft_functional_common;
 
 using raft_result = cmd_result< ptr<buffer> >;
 
+std::ostream& operator<<(std::ostream& os, raft_server::priority_set_result res) {
+    if (res == raft_server::priority_set_result::SET)
+        os << "SET";
+    else if (res == raft_server::priority_set_result::IGNORED)
+        os << "IGNORED";
+    else
+        os << "BROADCAST";
+    return os;
+}
+
 namespace raft_server_test {
 
 struct ExecArgs : TestSuite::ThreadArgs {
@@ -772,8 +782,9 @@ int multiple_config_change_test() {
     CHK_GT(0, ret->get_result_code());
 
     // Priority change is OK.
-    CHK_TRUE( s1.raftServer->set_priority(s4.getTestMgr()->get_srv_config()->get_id(), 10)
-            == raft_server::priority_set_result::SET );
+    CHK_EQ(
+        s1.raftServer->set_priority(s4.getTestMgr()->get_srv_config()->get_id(), 10),
+        raft_server::priority_set_result::SET );
 
     // Leave req/resp.
     s1.fNet->execReqResp();
@@ -893,7 +904,7 @@ int leader_election_priority_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S2 to 100.
-    CHK_TRUE( s1.raftServer->set_priority(2, 100) == raft_server::priority_set_result::SET );
+    CHK_EQ( s1.raftServer->set_priority(2, 100), raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -901,7 +912,7 @@ int leader_election_priority_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 85.
-    CHK_TRUE( s1.raftServer->set_priority(3, 85) == raft_server::priority_set_result::SET );
+    CHK_EQ( s1.raftServer->set_priority(3, 85), raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -980,19 +991,19 @@ int leader_election_with_aggressive_node_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S1 to 100.
-    CHK_TRUE( s1.raftServer->set_priority(1, 100) == raft_server::priority_set_result::SET );
+    CHK_EQ( s1.raftServer->set_priority(1, 100), raft_server::priority_set_result::SET );
     s1.fNet->execReqResp();
     s1.fNet->execReqResp();
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S2 to 50.
-    CHK_TRUE( s1.raftServer->set_priority(2, 50) == raft_server::priority_set_result::SET );
+    CHK_EQ( s1.raftServer->set_priority(2, 50), raft_server::priority_set_result::SET );
     s1.fNet->execReqResp();
     s1.fNet->execReqResp();
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 1.
-    CHK_TRUE( s1.raftServer->set_priority(3, 1) == raft_server::priority_set_result::SET );
+    CHK_EQ( s1.raftServer->set_priority(3, 1), raft_server::priority_set_result::SET );
     s1.fNet->execReqResp();
     s1.fNet->execReqResp();
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
@@ -1160,7 +1171,7 @@ int leadership_takeover_basic_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S2 to 10.
-    CHK_TRUE( s1.raftServer->set_priority(2, 10) == raft_server::priority_set_result::SET );
+    CHK_EQ( s1.raftServer->set_priority(2, 10), raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1168,7 +1179,7 @@ int leadership_takeover_basic_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 5.
-    CHK_TRUE( s1.raftServer->set_priority(3, 5) == raft_server::priority_set_result::SET );
+    CHK_EQ( s1.raftServer->set_priority(3, 5), raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1253,7 +1264,7 @@ int leadership_takeover_designated_successor_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S2 to 10.
-    CHK_TRUE( s1.raftServer->set_priority(2, 10) == raft_server::priority_set_result::SET );
+    CHK_EQ( s1.raftServer->set_priority(2, 10), raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1261,7 +1272,7 @@ int leadership_takeover_designated_successor_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 5.
-    CHK_TRUE( s1.raftServer->set_priority(3, 5) == raft_server::priority_set_result::SET );
+    CHK_EQ( s1.raftServer->set_priority(3, 5), raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1372,7 +1383,7 @@ int leadership_takeover_by_request_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S2 to 10.
-    CHK_TRUE( s1.raftServer->set_priority(2, 10) == raft_server::priority_set_result::SET );
+    CHK_EQ( s1.raftServer->set_priority(2, 10), raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1380,7 +1391,7 @@ int leadership_takeover_by_request_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 5.
-    CHK_TRUE( s1.raftServer->set_priority(3, 5) == raft_server::priority_set_result::SET );
+    CHK_EQ( s1.raftServer->set_priority(3, 5), raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1450,7 +1461,7 @@ int leadership_takeover_offline_candidate_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S2 to 10.
-    CHK_TRUE( s1.raftServer->set_priority(2, 10) == raft_server::priority_set_result::SET );
+    CHK_EQ( s1.raftServer->set_priority(2, 10), raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1458,7 +1469,7 @@ int leadership_takeover_offline_candidate_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 5.
-    CHK_TRUE( s1.raftServer->set_priority(3, 5) == raft_server::priority_set_result::SET );
+    CHK_EQ( s1.raftServer->set_priority(3, 5), raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1566,7 +1577,7 @@ int temporary_leader_test() {
     }
 
     // Set the priority of S3 to 0.
-    CHK_TRUE( s1.raftServer->set_priority(3, 0) == raft_server::priority_set_result::SET );
+    CHK_EQ( s1.raftServer->set_priority(3, 0), raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1680,7 +1691,7 @@ int priority_broadcast_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S2 to 100.
-    CHK_TRUE( s1.raftServer->set_priority(2, 100) == raft_server::priority_set_result::SET );
+    CHK_EQ( s1.raftServer->set_priority(2, 100), raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1688,7 +1699,7 @@ int priority_broadcast_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 50.
-    CHK_TRUE( s1.raftServer->set_priority(3, 50) == raft_server::priority_set_result::SET );
+    CHK_EQ( s1.raftServer->set_priority(3, 50), raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1722,14 +1733,21 @@ int priority_broadcast_test() {
     CHK_FALSE( s2.raftServer->is_leader() );
     CHK_FALSE( s3.raftServer->is_leader() );
 
-    // Setting priority on non-leader nodes should do nothing by default
-    for (int ii=1; ii<=3; ++ii) {
-        CHK_TRUE( s2.raftServer->set_priority(ii, 90) == raft_server::priority_set_result::IGNORED );
-        CHK_TRUE( s3.raftServer->set_priority(ii, 90) == raft_server::priority_set_result::IGNORED );
-    }
+    CHK_TRUE( s1.raftServer->is_leader_alive() );
+    CHK_FALSE( s2.raftServer->is_leader_alive() );
+    CHK_FALSE( s3.raftServer->is_leader_alive() );
 
-    // Send priority change reqs.
+    // Follower to leader broadcast
+    CHK_EQ( raft_server::priority_set_result::BROADCAST, s2.raftServer->set_priority(1, 101) );
     s2.fNet->execReqResp();
+
+    // Follower to follower broadcast
+    CHK_EQ( raft_server::priority_set_result::BROADCAST, s3.raftServer->set_priority(2, 102) );
+    s3.fNet->execReqResp();
+
+    // Follower to self broadcast
+    CHK_EQ( raft_server::priority_set_result::BROADCAST, s3.raftServer->set_priority(3, 103) );
+    s3.fNet->execReqResp();
 
     // Now each server's priority should be same on every other server.
     std::map<int, int> baseline;
@@ -1747,6 +1765,11 @@ int priority_broadcast_test() {
         }
     }
 
+    // Check again that priority set request from followers was applied
+    CHK_EQ( 101, baseline[1] );
+    CHK_EQ( 102, baseline[2] );
+    CHK_EQ( 103, baseline[3] );
+
     print_stats(pkgs);
 
     s1.raftServer->shutdown();
@@ -1757,6 +1780,19 @@ int priority_broadcast_test() {
 
     return 0;
 }
+
+//int priority_ignore_test() {
+//
+//    print_stats(pkgs);
+//
+//    s1.raftServer->shutdown();
+//    s2.raftServer->shutdown();
+//    s3.raftServer->shutdown();
+//
+//    f_base->destroy();
+//
+//    return 0;
+//}
 
 int custom_user_context_test() {
     reset_log_files();
@@ -2521,7 +2557,7 @@ int apply_config_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 85.
-    CHK_TRUE( s1.raftServer->set_priority(3, 85) == raft_server::priority_set_result::SET );
+    CHK_EQ( s1.raftServer->set_priority(3, 85), raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -2529,7 +2565,7 @@ int apply_config_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S4 to 100.
-    CHK_TRUE( s1.raftServer->set_priority(4, 100) == raft_server::priority_set_result::SET );
+    CHK_EQ( s1.raftServer->set_priority(4, 100), raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -3048,98 +3084,98 @@ int main(int argc, char** argv) {
     // Disable reconnection timer for deterministic test.
     debugging_options::get_instance().disable_reconn_backoff_ = true;
 
-    ts.doTest( "make group test",
-               make_group_test );
+    //ts.doTest( "make group test",
+    //           make_group_test );
 
-    ts.doTest( "init options test",
-               init_options_test );
+    //ts.doTest( "init options test",
+    //           init_options_test );
 
-    ts.doTest( "update params test",
-               update_params_test );
+    //ts.doTest( "update params test",
+    //           update_params_test );
 
-    ts.doTest( "add node error cases test",
-               add_node_error_cases_test );
+    //ts.doTest( "add node error cases test",
+    //           add_node_error_cases_test );
 
-    ts.doTest( "remove node test",
-               remove_node_test );
+    //ts.doTest( "remove node test",
+    //           remove_node_test );
 
-    ts.doTest( "remove node error cases test",
-               remove_node_error_cases_test );
+    //ts.doTest( "remove node error cases test",
+    //           remove_node_error_cases_test );
 
-    ts.doTest( "remove and then add test",
-               remove_and_then_add_test );
+    //ts.doTest( "remove and then add test",
+    //           remove_and_then_add_test );
 
-    ts.doTest( "multiple config change test",
-               multiple_config_change_test );
+    //ts.doTest( "multiple config change test",
+    //           multiple_config_change_test );
 
-    ts.doTest( "leader election basic test",
-               leader_election_basic_test );
+    //ts.doTest( "leader election basic test",
+    //           leader_election_basic_test );
 
-    ts.doTest( "leader election priority test",
-               leader_election_priority_test );
+    //ts.doTest( "leader election priority test",
+    //           leader_election_priority_test );
 
-    ts.doTest( "leader election with aggressive node test",
-               leader_election_with_aggressive_node_test );
+    //ts.doTest( "leader election with aggressive node test",
+    //           leader_election_with_aggressive_node_test );
 
-    ts.doTest( "leader election with catching-up server test",
-               leader_election_with_catching_up_server_test );
+    //ts.doTest( "leader election with catching-up server test",
+    //           leader_election_with_catching_up_server_test );
 
-    ts.doTest( "leadership takeover basic test",
-               leadership_takeover_basic_test );
+    //ts.doTest( "leadership takeover basic test",
+    //           leadership_takeover_basic_test );
 
-    ts.doTest( "leadership takeover with designated successor test",
-               leadership_takeover_designated_successor_test );
+    //ts.doTest( "leadership takeover with designated successor test",
+    //           leadership_takeover_designated_successor_test );
 
-    ts.doTest( "leadership takeover by request test",
-               leadership_takeover_by_request_test );
+    //ts.doTest( "leadership takeover by request test",
+    //           leadership_takeover_by_request_test );
 
-    ts.doTest( "leadership takeover with offline candidate test",
-               leadership_takeover_offline_candidate_test );
+    //ts.doTest( "leadership takeover with offline candidate test",
+    //           leadership_takeover_offline_candidate_test );
 
-    ts.doTest( "temporary leader test",
-               temporary_leader_test );
+    //ts.doTest( "temporary leader test",
+    //           temporary_leader_test );
 
     ts.doTest( "priority broadcast test",
                priority_broadcast_test );
 
-    ts.doTest( "custom user context test",
-               custom_user_context_test );
+    //ts.doTest( "custom user context test",
+    //           custom_user_context_test );
 
-    ts.doTest( "follower reconnect test",
-               follower_reconnect_test );
+    //ts.doTest( "follower reconnect test",
+    //           follower_reconnect_test );
 
-    ts.doTest( "snapshot basic test",
-               snapshot_basic_test );
+    //ts.doTest( "snapshot basic test",
+    //           snapshot_basic_test );
 
-    ts.doTest( "snapshot manual creation test",
-               snapshot_manual_creation_test );
+    //ts.doTest( "snapshot manual creation test",
+    //           snapshot_manual_creation_test );
 
-    ts.doTest( "snapshot randomized creation test",
-               snapshot_randomized_creation_test );
+    //ts.doTest( "snapshot randomized creation test",
+    //           snapshot_randomized_creation_test );
 
-    ts.doTest( "join empty node test",
-               join_empty_node_test );
+    //ts.doTest( "join empty node test",
+    //           join_empty_node_test );
 
-    ts.doTest( "async append handler test",
-               async_append_handler_test );
+    //ts.doTest( "async append handler test",
+    //           async_append_handler_test );
 
-    ts.doTest( "async append handler cancel test",
-               async_append_handler_cancel_test );
+    //ts.doTest( "async append handler cancel test",
+    //           async_append_handler_cancel_test );
 
-    ts.doTest( "apply config log entry test",
-               apply_config_test );
+    //ts.doTest( "apply config log entry test",
+    //           apply_config_test );
 
-    ts.doTest( "custom term counter test",
-               custom_term_counter_test );
+    //ts.doTest( "custom term counter test",
+    //           custom_term_counter_test );
 
-    ts.doTest( "config log replay test",
-               config_log_replay_test );
+    //ts.doTest( "config log replay test",
+    //           config_log_replay_test );
 
-    ts.doTest( "full consensus test",
-               full_consensus_synth_test );
+    //ts.doTest( "full consensus test",
+    //           full_consensus_synth_test );
 
-    ts.doTest( "extended append_entries API test",
-               extended_append_entries_api_test );
+    //ts.doTest( "extended append_entries API test",
+    //           extended_append_entries_api_test );
 
 #ifdef ENABLE_RAFT_STATS
     _msg("raft stats: ENABLED\n");

--- a/tests/unit/raft_server_test.cxx
+++ b/tests/unit/raft_server_test.cxx
@@ -30,10 +30,10 @@ using namespace raft_functional_common;
 
 using raft_result = cmd_result< ptr<buffer> >;
 
-std::ostream& operator<<(std::ostream& os, raft_server::priority_set_result res) {
-    if (res == raft_server::priority_set_result::SET)
+std::ostream& operator<<(std::ostream& os, raft_server::PrioritySetResult res) {
+    if (res == raft_server::PrioritySetResult::SET)
         os << "SET";
-    else if (res == raft_server::priority_set_result::IGNORED)
+    else if (res == raft_server::PrioritySetResult::IGNORED)
         os << "IGNORED";
     else
         os << "BROADCAST";
@@ -783,7 +783,7 @@ int multiple_config_change_test() {
 
     // Priority change is OK.
     CHK_EQ(
-        raft_server::priority_set_result::SET,
+        raft_server::PrioritySetResult::SET,
         s1.raftServer->set_priority(s4.getTestMgr()->get_srv_config()->get_id(), 10));
 
     // Leave req/resp.
@@ -904,7 +904,7 @@ int leader_election_priority_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S2 to 100.
-    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(2, 100) );
+    CHK_EQ( raft_server::PrioritySetResult::SET, s1.raftServer->set_priority(2, 100) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -912,7 +912,7 @@ int leader_election_priority_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 85.
-    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(3, 85) );
+    CHK_EQ( raft_server::PrioritySetResult::SET, s1.raftServer->set_priority(3, 85) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -991,19 +991,19 @@ int leader_election_with_aggressive_node_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S1 to 100.
-    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(1, 100) );
+    CHK_EQ( raft_server::PrioritySetResult::SET, s1.raftServer->set_priority(1, 100) );
     s1.fNet->execReqResp();
     s1.fNet->execReqResp();
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S2 to 50.
-    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(2, 50) );
+    CHK_EQ( raft_server::PrioritySetResult::SET, s1.raftServer->set_priority(2, 50) );
     s1.fNet->execReqResp();
     s1.fNet->execReqResp();
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 1.
-    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(3, 1) );
+    CHK_EQ( raft_server::PrioritySetResult::SET, s1.raftServer->set_priority(3, 1) );
     s1.fNet->execReqResp();
     s1.fNet->execReqResp();
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
@@ -1072,8 +1072,8 @@ int leader_election_with_catching_up_server_test() {
 
     // Set priority of S1 to 80 and S2 to 100.
     // Each server thinks it's a leader
-    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(1, 80) );
-    CHK_EQ( raft_server::priority_set_result::SET, s2.raftServer->set_priority(2, 100) );
+    CHK_EQ( raft_server::PrioritySetResult::SET, s1.raftServer->set_priority(1, 80) );
+    CHK_EQ( raft_server::PrioritySetResult::SET, s2.raftServer->set_priority(2, 100) );
 
     // Append logs to S1 to trigger log compaction.
     for (auto& entry: pkgs) {
@@ -1165,7 +1165,7 @@ int leadership_takeover_basic_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S2 to 10.
-    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(2, 10) );
+    CHK_EQ( raft_server::PrioritySetResult::SET, s1.raftServer->set_priority(2, 10) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1173,7 +1173,7 @@ int leadership_takeover_basic_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 5.
-    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(3, 5) );
+    CHK_EQ( raft_server::PrioritySetResult::SET, s1.raftServer->set_priority(3, 5) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1258,7 +1258,7 @@ int leadership_takeover_designated_successor_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S2 to 10.
-    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(2, 10) );
+    CHK_EQ( raft_server::PrioritySetResult::SET, s1.raftServer->set_priority(2, 10) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1266,7 +1266,7 @@ int leadership_takeover_designated_successor_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 5.
-    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(3, 5) );
+    CHK_EQ( raft_server::PrioritySetResult::SET, s1.raftServer->set_priority(3, 5) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1377,7 +1377,7 @@ int leadership_takeover_by_request_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S2 to 10.
-    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(2, 10) );
+    CHK_EQ( raft_server::PrioritySetResult::SET, s1.raftServer->set_priority(2, 10) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1385,7 +1385,7 @@ int leadership_takeover_by_request_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 5.
-    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(3, 5) );
+    CHK_EQ( raft_server::PrioritySetResult::SET, s1.raftServer->set_priority(3, 5) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1455,7 +1455,7 @@ int leadership_takeover_offline_candidate_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S2 to 10.
-    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(2, 10) );
+    CHK_EQ( raft_server::PrioritySetResult::SET, s1.raftServer->set_priority(2, 10) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1463,7 +1463,7 @@ int leadership_takeover_offline_candidate_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 5.
-    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(3, 5) );
+    CHK_EQ( raft_server::PrioritySetResult::SET, s1.raftServer->set_priority(3, 5) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1571,7 +1571,7 @@ int temporary_leader_test() {
     }
 
     // Set the priority of S3 to 0.
-    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(3, 0) );
+    CHK_EQ( raft_server::PrioritySetResult::SET, s1.raftServer->set_priority(3, 0) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1692,7 +1692,7 @@ int priority_broadcast_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S2 to 100.
-    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(2, 100) );
+    CHK_EQ( raft_server::PrioritySetResult::SET, s1.raftServer->set_priority(2, 100) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1700,7 +1700,7 @@ int priority_broadcast_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 50.
-    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(3, 50) );
+    CHK_EQ( raft_server::PrioritySetResult::SET, s1.raftServer->set_priority(3, 50) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1739,17 +1739,17 @@ int priority_broadcast_test() {
     CHK_FALSE( s3.raftServer->is_leader_alive() );
 
     // Follower to leader broadcast
-    CHK_EQ( raft_server::priority_set_result::BROADCAST, s2.raftServer->set_priority(1, 101) );
+    CHK_EQ( raft_server::PrioritySetResult::BROADCAST, s2.raftServer->set_priority(1, 101) );
     s2.fNet->execReqResp();
     CHK_Z( check_priorities(pkgs, {101, 100, 50}) );
 
     // Follower to follower broadcast
-    CHK_EQ( raft_server::priority_set_result::BROADCAST, s3.raftServer->set_priority(2, 102) );
+    CHK_EQ( raft_server::PrioritySetResult::BROADCAST, s3.raftServer->set_priority(2, 102) );
     s3.fNet->execReqResp();
     CHK_Z( check_priorities(pkgs, {101, 102, 50}) );
 
     // Follower to self broadcast
-    CHK_EQ( raft_server::priority_set_result::BROADCAST, s3.raftServer->set_priority(3, 103) );
+    CHK_EQ( raft_server::PrioritySetResult::BROADCAST, s3.raftServer->set_priority(3, 103) );
     s3.fNet->execReqResp();
     CHK_Z( check_priorities(pkgs, {101, 102, 103}) );
 
@@ -1780,18 +1780,18 @@ int priority_broadcast_with_live_leader_test() {
     CHK_Z( launch_servers( pkgs ) );
     CHK_Z( make_group( pkgs ) );
 
-    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(1, 100) );
+    CHK_EQ( raft_server::PrioritySetResult::SET, s1.raftServer->set_priority(1, 100) );
     s1.fNet->execReqResp(); // Send priority change reqs.
     s1.fNet->execReqResp(); // Send reqs again for commit.
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
-    CHK_EQ( raft_server::priority_set_result::IGNORED, s2.raftServer->set_priority(1, 1000) );
-    CHK_EQ( raft_server::priority_set_result::IGNORED, s3.raftServer->set_priority(1, 1000) );
+    CHK_EQ( raft_server::PrioritySetResult::IGNORED, s2.raftServer->set_priority(1, 1000) );
+    CHK_EQ( raft_server::PrioritySetResult::IGNORED, s3.raftServer->set_priority(1, 1000) );
 
-    CHK_EQ( raft_server::priority_set_result::BROADCAST, s2.raftServer->set_priority(3, 100, true) );
+    CHK_EQ( raft_server::PrioritySetResult::BROADCAST, s2.raftServer->set_priority(3, 100, true) );
     s2.fNet->execReqResp();
 
-    CHK_EQ( raft_server::priority_set_result::BROADCAST, s3.raftServer->set_priority(2, 100, true) );
+    CHK_EQ( raft_server::PrioritySetResult::BROADCAST, s3.raftServer->set_priority(2, 100, true) );
     s3.fNet->execReqResp();
 
     CHK_Z( check_priorities(pkgs, {100, 100, 100}) );
@@ -2570,7 +2570,7 @@ int apply_config_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 85.
-    CHK_EQ( s1.raftServer->set_priority(3, 85), raft_server::priority_set_result::SET );
+    CHK_EQ( s1.raftServer->set_priority(3, 85), raft_server::PrioritySetResult::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -2578,7 +2578,7 @@ int apply_config_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S4 to 100.
-    CHK_EQ( s1.raftServer->set_priority(4, 100), raft_server::priority_set_result::SET );
+    CHK_EQ( s1.raftServer->set_priority(4, 100), raft_server::PrioritySetResult::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.

--- a/tests/unit/raft_server_test.cxx
+++ b/tests/unit/raft_server_test.cxx
@@ -1668,10 +1668,12 @@ int temporary_leader_test() {
     return 0;
 }
 
-int check_priorities(const std::vector<RaftPkg*>& pkgs, const std::vector<int>& priorities) {
+int check_priorities(const std::vector<RaftPkg*>& pkgs,
+                     const std::vector<int>& priorities) {
     for (auto& entry: pkgs)
         for (size_t ii=1; ii<=pkgs.size(); ++ii)
-            CHK_EQ( priorities[ii - 1], entry->raftServer->get_srv_config(ii)->get_priority() );
+            CHK_EQ( priorities[ii - 1],
+                    entry->raftServer->get_srv_config(ii)->get_priority() );
     return 0;
 }
 
@@ -1739,17 +1741,20 @@ int priority_broadcast_test() {
     CHK_FALSE( s3.raftServer->is_leader_alive() );
 
     // Follower to leader broadcast
-    CHK_EQ( raft_server::PrioritySetResult::BROADCAST, s2.raftServer->set_priority(1, 101) );
+    CHK_EQ( raft_server::PrioritySetResult::BROADCAST,
+            s2.raftServer->set_priority(1, 101) );
     s2.fNet->execReqResp();
     CHK_Z( check_priorities(pkgs, {101, 100, 50}) );
 
     // Follower to follower broadcast
-    CHK_EQ( raft_server::PrioritySetResult::BROADCAST, s3.raftServer->set_priority(2, 102) );
+    CHK_EQ( raft_server::PrioritySetResult::BROADCAST,
+            s3.raftServer->set_priority(2, 102) );
     s3.fNet->execReqResp();
     CHK_Z( check_priorities(pkgs, {101, 102, 50}) );
 
     // Follower to self broadcast
-    CHK_EQ( raft_server::PrioritySetResult::BROADCAST, s3.raftServer->set_priority(3, 103) );
+    CHK_EQ( raft_server::PrioritySetResult::BROADCAST,
+            s3.raftServer->set_priority(3, 103) );
     s3.fNet->execReqResp();
     CHK_Z( check_priorities(pkgs, {101, 102, 103}) );
 
@@ -1785,13 +1790,17 @@ int priority_broadcast_with_live_leader_test() {
     s1.fNet->execReqResp(); // Send reqs again for commit.
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
-    CHK_EQ( raft_server::PrioritySetResult::IGNORED, s2.raftServer->set_priority(1, 1000) );
-    CHK_EQ( raft_server::PrioritySetResult::IGNORED, s3.raftServer->set_priority(1, 1000) );
+    CHK_EQ( raft_server::PrioritySetResult::IGNORED,
+            s2.raftServer->set_priority(1, 1000) );
+    CHK_EQ( raft_server::PrioritySetResult::IGNORED,
+            s3.raftServer->set_priority(1, 1000) );
 
-    CHK_EQ( raft_server::PrioritySetResult::BROADCAST, s2.raftServer->set_priority(3, 100, true) );
+    CHK_EQ( raft_server::PrioritySetResult::BROADCAST,
+            s2.raftServer->set_priority(3, 100, true) );
     s2.fNet->execReqResp();
 
-    CHK_EQ( raft_server::PrioritySetResult::BROADCAST, s3.raftServer->set_priority(2, 100, true) );
+    CHK_EQ( raft_server::PrioritySetResult::BROADCAST,
+            s3.raftServer->set_priority(2, 100, true) );
     s3.fNet->execReqResp();
 
     CHK_Z( check_priorities(pkgs, {100, 100, 100}) );

--- a/tests/unit/raft_server_test.cxx
+++ b/tests/unit/raft_server_test.cxx
@@ -783,8 +783,8 @@ int multiple_config_change_test() {
 
     // Priority change is OK.
     CHK_EQ(
-        s1.raftServer->set_priority(s4.getTestMgr()->get_srv_config()->get_id(), 10),
-        raft_server::priority_set_result::SET );
+        raft_server::priority_set_result::SET,
+        s1.raftServer->set_priority(s4.getTestMgr()->get_srv_config()->get_id(), 10));
 
     // Leave req/resp.
     s1.fNet->execReqResp();
@@ -904,7 +904,7 @@ int leader_election_priority_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S2 to 100.
-    CHK_EQ( s1.raftServer->set_priority(2, 100), raft_server::priority_set_result::SET );
+    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(2, 100) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -912,7 +912,7 @@ int leader_election_priority_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 85.
-    CHK_EQ( s1.raftServer->set_priority(3, 85), raft_server::priority_set_result::SET );
+    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(3, 85) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -991,19 +991,19 @@ int leader_election_with_aggressive_node_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S1 to 100.
-    CHK_EQ( s1.raftServer->set_priority(1, 100), raft_server::priority_set_result::SET );
+    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(1, 100) );
     s1.fNet->execReqResp();
     s1.fNet->execReqResp();
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S2 to 50.
-    CHK_EQ( s1.raftServer->set_priority(2, 50), raft_server::priority_set_result::SET );
+    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(2, 50) );
     s1.fNet->execReqResp();
     s1.fNet->execReqResp();
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 1.
-    CHK_EQ( s1.raftServer->set_priority(3, 1), raft_server::priority_set_result::SET );
+    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(3, 1) );
     s1.fNet->execReqResp();
     s1.fNet->execReqResp();
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
@@ -1071,15 +1071,9 @@ int leader_election_with_catching_up_server_test() {
     CHK_Z( launch_servers( pkgs ) );
 
     // Set priority of S1 to 80 and S2 to 100.
-    auto s1_prio_ret = s1.raftServer->set_priority(1, 80);
-    auto s2_prio_ret = s2.raftServer->set_priority(2, 100);
-
-    // Leader will apply priority change, follower will ignore it.
-    CHK_TRUE(
-        (s1_prio_ret == raft_server::priority_set_result::SET
-             && s2_prio_ret == raft_server::priority_set_result::IGNORED)
-        || (s2_prio_ret == raft_server::priority_set_result::SET
-             && s1_prio_ret == raft_server::priority_set_result::IGNORED));
+    // Each server thinks it's a leader
+    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(1, 80) );
+    CHK_EQ( raft_server::priority_set_result::SET, s2.raftServer->set_priority(2, 100) );
 
     // Append logs to S1 to trigger log compaction.
     for (auto& entry: pkgs) {
@@ -1171,7 +1165,7 @@ int leadership_takeover_basic_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S2 to 10.
-    CHK_EQ( s1.raftServer->set_priority(2, 10), raft_server::priority_set_result::SET );
+    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(2, 10) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1179,7 +1173,7 @@ int leadership_takeover_basic_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 5.
-    CHK_EQ( s1.raftServer->set_priority(3, 5), raft_server::priority_set_result::SET );
+    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(3, 5) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1264,7 +1258,7 @@ int leadership_takeover_designated_successor_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S2 to 10.
-    CHK_EQ( s1.raftServer->set_priority(2, 10), raft_server::priority_set_result::SET );
+    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(2, 10) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1272,7 +1266,7 @@ int leadership_takeover_designated_successor_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 5.
-    CHK_EQ( s1.raftServer->set_priority(3, 5), raft_server::priority_set_result::SET );
+    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(3, 5) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1383,7 +1377,7 @@ int leadership_takeover_by_request_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S2 to 10.
-    CHK_EQ( s1.raftServer->set_priority(2, 10), raft_server::priority_set_result::SET );
+    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(2, 10) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1391,7 +1385,7 @@ int leadership_takeover_by_request_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 5.
-    CHK_EQ( s1.raftServer->set_priority(3, 5), raft_server::priority_set_result::SET );
+    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(3, 5) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1461,7 +1455,7 @@ int leadership_takeover_offline_candidate_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S2 to 10.
-    CHK_EQ( s1.raftServer->set_priority(2, 10), raft_server::priority_set_result::SET );
+    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(2, 10) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1469,7 +1463,7 @@ int leadership_takeover_offline_candidate_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 5.
-    CHK_EQ( s1.raftServer->set_priority(3, 5), raft_server::priority_set_result::SET );
+    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(3, 5) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1577,7 +1571,7 @@ int temporary_leader_test() {
     }
 
     // Set the priority of S3 to 0.
-    CHK_EQ( s1.raftServer->set_priority(3, 0), raft_server::priority_set_result::SET );
+    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(3, 0) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1674,6 +1668,13 @@ int temporary_leader_test() {
     return 0;
 }
 
+int check_priorities(const std::vector<RaftPkg*>& pkgs, const std::vector<int>& priorities) {
+    for (auto& entry: pkgs)
+        for (size_t ii=1; ii<=pkgs.size(); ++ii)
+            CHK_EQ( priorities[ii - 1], entry->raftServer->get_srv_config(ii)->get_priority() );
+    return 0;
+}
+
 int priority_broadcast_test() {
     reset_log_files();
     ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
@@ -1691,7 +1692,7 @@ int priority_broadcast_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S2 to 100.
-    CHK_EQ( s1.raftServer->set_priority(2, 100), raft_server::priority_set_result::SET );
+    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(2, 100) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1699,7 +1700,7 @@ int priority_broadcast_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 50.
-    CHK_EQ( s1.raftServer->set_priority(3, 50), raft_server::priority_set_result::SET );
+    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(3, 50) );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1740,35 +1741,17 @@ int priority_broadcast_test() {
     // Follower to leader broadcast
     CHK_EQ( raft_server::priority_set_result::BROADCAST, s2.raftServer->set_priority(1, 101) );
     s2.fNet->execReqResp();
+    CHK_Z( check_priorities(pkgs, {101, 100, 50}) );
 
     // Follower to follower broadcast
     CHK_EQ( raft_server::priority_set_result::BROADCAST, s3.raftServer->set_priority(2, 102) );
     s3.fNet->execReqResp();
+    CHK_Z( check_priorities(pkgs, {101, 102, 50}) );
 
     // Follower to self broadcast
     CHK_EQ( raft_server::priority_set_result::BROADCAST, s3.raftServer->set_priority(3, 103) );
     s3.fNet->execReqResp();
-
-    // Now each server's priority should be same on every other server.
-    std::map<int, int> baseline;
-    for (auto& entry: pkgs) {
-        RaftPkg* rr = entry;
-        for (int ii=1; ii<=3; ++ii) {
-            ptr<srv_config> sc = rr->raftServer->get_srv_config(ii);
-            if (rr == &s1) {
-                // The first node: add to baseline
-                baseline.insert( std::make_pair(ii, sc->get_priority()) );
-            } else {
-                // Otherwise: priority should be the same as baseline.
-                CHK_EQ( baseline[ii], sc->get_priority() );
-            }
-        }
-    }
-
-    // Check again that priority set request from followers was applied
-    CHK_EQ( 101, baseline[1] );
-    CHK_EQ( 102, baseline[2] );
-    CHK_EQ( 103, baseline[3] );
+    CHK_Z( check_priorities(pkgs, {101, 102, 103}) );
 
     print_stats(pkgs);
 
@@ -1781,18 +1764,48 @@ int priority_broadcast_test() {
     return 0;
 }
 
-//int priority_ignore_test() {
-//
-//    print_stats(pkgs);
-//
-//    s1.raftServer->shutdown();
-//    s2.raftServer->shutdown();
-//    s3.raftServer->shutdown();
-//
-//    f_base->destroy();
-//
-//    return 0;
-//}
+int priority_broadcast_with_live_leader_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    CHK_Z( launch_servers( pkgs ) );
+    CHK_Z( make_group( pkgs ) );
+
+    CHK_EQ( raft_server::priority_set_result::SET, s1.raftServer->set_priority(1, 100) );
+    s1.fNet->execReqResp(); // Send priority change reqs.
+    s1.fNet->execReqResp(); // Send reqs again for commit.
+    CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+
+    CHK_EQ( raft_server::priority_set_result::IGNORED, s2.raftServer->set_priority(1, 1000) );
+    CHK_EQ( raft_server::priority_set_result::IGNORED, s3.raftServer->set_priority(1, 1000) );
+
+    CHK_EQ( raft_server::priority_set_result::BROADCAST, s2.raftServer->set_priority(3, 100, true) );
+    s2.fNet->execReqResp();
+
+    CHK_EQ( raft_server::priority_set_result::BROADCAST, s3.raftServer->set_priority(2, 100, true) );
+    s3.fNet->execReqResp();
+
+    CHK_Z( check_priorities(pkgs, {100, 100, 100}) );
+
+    print_stats(pkgs);
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+
+    f_base->destroy();
+
+    return 0;
+}
 
 int custom_user_context_test() {
     reset_log_files();
@@ -3084,98 +3097,101 @@ int main(int argc, char** argv) {
     // Disable reconnection timer for deterministic test.
     debugging_options::get_instance().disable_reconn_backoff_ = true;
 
-    //ts.doTest( "make group test",
-    //           make_group_test );
+    ts.doTest( "make group test",
+               make_group_test );
 
-    //ts.doTest( "init options test",
-    //           init_options_test );
+    ts.doTest( "init options test",
+               init_options_test );
 
-    //ts.doTest( "update params test",
-    //           update_params_test );
+    ts.doTest( "update params test",
+               update_params_test );
 
-    //ts.doTest( "add node error cases test",
-    //           add_node_error_cases_test );
+    ts.doTest( "add node error cases test",
+               add_node_error_cases_test );
 
-    //ts.doTest( "remove node test",
-    //           remove_node_test );
+    ts.doTest( "remove node test",
+               remove_node_test );
 
-    //ts.doTest( "remove node error cases test",
-    //           remove_node_error_cases_test );
+    ts.doTest( "remove node error cases test",
+               remove_node_error_cases_test );
 
-    //ts.doTest( "remove and then add test",
-    //           remove_and_then_add_test );
+    ts.doTest( "remove and then add test",
+               remove_and_then_add_test );
 
-    //ts.doTest( "multiple config change test",
-    //           multiple_config_change_test );
+    ts.doTest( "multiple config change test",
+               multiple_config_change_test );
 
-    //ts.doTest( "leader election basic test",
-    //           leader_election_basic_test );
+    ts.doTest( "leader election basic test",
+               leader_election_basic_test );
 
-    //ts.doTest( "leader election priority test",
-    //           leader_election_priority_test );
+    ts.doTest( "leader election priority test",
+               leader_election_priority_test );
 
-    //ts.doTest( "leader election with aggressive node test",
-    //           leader_election_with_aggressive_node_test );
+    ts.doTest( "leader election with aggressive node test",
+               leader_election_with_aggressive_node_test );
 
-    //ts.doTest( "leader election with catching-up server test",
-    //           leader_election_with_catching_up_server_test );
+    ts.doTest( "leader election with catching-up server test",
+               leader_election_with_catching_up_server_test );
 
-    //ts.doTest( "leadership takeover basic test",
-    //           leadership_takeover_basic_test );
+    ts.doTest( "leadership takeover basic test",
+               leadership_takeover_basic_test );
 
-    //ts.doTest( "leadership takeover with designated successor test",
-    //           leadership_takeover_designated_successor_test );
+    ts.doTest( "leadership takeover with designated successor test",
+               leadership_takeover_designated_successor_test );
 
-    //ts.doTest( "leadership takeover by request test",
-    //           leadership_takeover_by_request_test );
+    ts.doTest( "leadership takeover by request test",
+               leadership_takeover_by_request_test );
 
-    //ts.doTest( "leadership takeover with offline candidate test",
-    //           leadership_takeover_offline_candidate_test );
+    ts.doTest( "leadership takeover with offline candidate test",
+               leadership_takeover_offline_candidate_test );
 
-    //ts.doTest( "temporary leader test",
-    //           temporary_leader_test );
+    ts.doTest( "temporary leader test",
+               temporary_leader_test );
 
     ts.doTest( "priority broadcast test",
                priority_broadcast_test );
 
-    //ts.doTest( "custom user context test",
-    //           custom_user_context_test );
+    ts.doTest( "priority broadcast with live leader test",
+               priority_broadcast_with_live_leader_test );
 
-    //ts.doTest( "follower reconnect test",
-    //           follower_reconnect_test );
+    ts.doTest( "custom user context test",
+               custom_user_context_test );
 
-    //ts.doTest( "snapshot basic test",
-    //           snapshot_basic_test );
+    ts.doTest( "follower reconnect test",
+               follower_reconnect_test );
 
-    //ts.doTest( "snapshot manual creation test",
-    //           snapshot_manual_creation_test );
+    ts.doTest( "snapshot basic test",
+               snapshot_basic_test );
 
-    //ts.doTest( "snapshot randomized creation test",
-    //           snapshot_randomized_creation_test );
+    ts.doTest( "snapshot manual creation test",
+               snapshot_manual_creation_test );
 
-    //ts.doTest( "join empty node test",
-    //           join_empty_node_test );
+    ts.doTest( "snapshot randomized creation test",
+               snapshot_randomized_creation_test );
 
-    //ts.doTest( "async append handler test",
-    //           async_append_handler_test );
+    ts.doTest( "join empty node test",
+               join_empty_node_test );
 
-    //ts.doTest( "async append handler cancel test",
-    //           async_append_handler_cancel_test );
+    ts.doTest( "async append handler test",
+               async_append_handler_test );
 
-    //ts.doTest( "apply config log entry test",
-    //           apply_config_test );
+    ts.doTest( "async append handler cancel test",
+               async_append_handler_cancel_test );
 
-    //ts.doTest( "custom term counter test",
-    //           custom_term_counter_test );
+    ts.doTest( "apply config log entry test",
+               apply_config_test );
 
-    //ts.doTest( "config log replay test",
-    //           config_log_replay_test );
+    ts.doTest( "custom term counter test",
+               custom_term_counter_test );
 
-    //ts.doTest( "full consensus test",
-    //           full_consensus_synth_test );
+    ts.doTest( "config log replay test",
+               config_log_replay_test );
 
-    //ts.doTest( "extended append_entries API test",
-    //           extended_append_entries_api_test );
+    ts.doTest( "full consensus test",
+               full_consensus_synth_test );
+
+    ts.doTest( "extended append_entries API test",
+               extended_append_entries_api_test );
 
 #ifdef ENABLE_RAFT_STATS
     _msg("raft stats: ENABLED\n");

--- a/tests/unit/raft_server_test.cxx
+++ b/tests/unit/raft_server_test.cxx
@@ -772,7 +772,8 @@ int multiple_config_change_test() {
     CHK_GT(0, ret->get_result_code());
 
     // Priority change is OK.
-    s1.raftServer->set_priority(s4.getTestMgr()->get_srv_config()->get_id(), 10);
+    CHK_TRUE( s1.raftServer->set_priority(s4.getTestMgr()->get_srv_config()->get_id(), 10)
+            == raft_server::priority_set_result::SET );
 
     // Leave req/resp.
     s1.fNet->execReqResp();
@@ -892,7 +893,7 @@ int leader_election_priority_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S2 to 100.
-    s1.raftServer->set_priority(2, 100);
+    CHK_TRUE( s1.raftServer->set_priority(2, 100) == raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -900,7 +901,7 @@ int leader_election_priority_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 85.
-    s1.raftServer->set_priority(3, 85);
+    CHK_TRUE( s1.raftServer->set_priority(3, 85) == raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -979,19 +980,19 @@ int leader_election_with_aggressive_node_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S1 to 100.
-    s1.raftServer->set_priority(1, 100);
+    CHK_TRUE( s1.raftServer->set_priority(1, 100) == raft_server::priority_set_result::SET );
     s1.fNet->execReqResp();
     s1.fNet->execReqResp();
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S2 to 50.
-    s1.raftServer->set_priority(2, 50);
+    CHK_TRUE( s1.raftServer->set_priority(2, 50) == raft_server::priority_set_result::SET );
     s1.fNet->execReqResp();
     s1.fNet->execReqResp();
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 1.
-    s1.raftServer->set_priority(3, 1);
+    CHK_TRUE( s1.raftServer->set_priority(3, 1) == raft_server::priority_set_result::SET );
     s1.fNet->execReqResp();
     s1.fNet->execReqResp();
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
@@ -1059,8 +1060,15 @@ int leader_election_with_catching_up_server_test() {
     CHK_Z( launch_servers( pkgs ) );
 
     // Set priority of S1 to 80 and S2 to 100.
-    s1.raftServer->set_priority(1, 80);
-    s2.raftServer->set_priority(2, 100);
+    auto s1_prio_ret = s1.raftServer->set_priority(1, 80);
+    auto s2_prio_ret = s2.raftServer->set_priority(2, 100);
+
+    // Leader will apply priority change, follower will ignore it.
+    CHK_TRUE(
+        (s1_prio_ret == raft_server::priority_set_result::SET
+             && s2_prio_ret == raft_server::priority_set_result::IGNORED)
+        || (s2_prio_ret == raft_server::priority_set_result::SET
+             && s1_prio_ret == raft_server::priority_set_result::IGNORED));
 
     // Append logs to S1 to trigger log compaction.
     for (auto& entry: pkgs) {
@@ -1152,7 +1160,7 @@ int leadership_takeover_basic_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S2 to 10.
-    s1.raftServer->set_priority(2, 10);
+    CHK_TRUE( s1.raftServer->set_priority(2, 10) == raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1160,7 +1168,7 @@ int leadership_takeover_basic_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 5.
-    s1.raftServer->set_priority(3, 5);
+    CHK_TRUE( s1.raftServer->set_priority(3, 5) == raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1245,7 +1253,7 @@ int leadership_takeover_designated_successor_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S2 to 10.
-    s1.raftServer->set_priority(2, 10);
+    CHK_TRUE( s1.raftServer->set_priority(2, 10) == raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1253,7 +1261,7 @@ int leadership_takeover_designated_successor_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 5.
-    s1.raftServer->set_priority(3, 5);
+    CHK_TRUE( s1.raftServer->set_priority(3, 5) == raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1364,7 +1372,7 @@ int leadership_takeover_by_request_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S2 to 10.
-    s1.raftServer->set_priority(2, 10);
+    CHK_TRUE( s1.raftServer->set_priority(2, 10) == raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1372,7 +1380,7 @@ int leadership_takeover_by_request_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 5.
-    s1.raftServer->set_priority(3, 5);
+    CHK_TRUE( s1.raftServer->set_priority(3, 5) == raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1442,7 +1450,7 @@ int leadership_takeover_offline_candidate_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S2 to 10.
-    s1.raftServer->set_priority(2, 10);
+    CHK_TRUE( s1.raftServer->set_priority(2, 10) == raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1450,7 +1458,7 @@ int leadership_takeover_offline_candidate_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 5.
-    s1.raftServer->set_priority(3, 5);
+    CHK_TRUE( s1.raftServer->set_priority(3, 5) == raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1558,7 +1566,7 @@ int temporary_leader_test() {
     }
 
     // Set the priority of S3 to 0.
-    s1.raftServer->set_priority(3, 0);
+    CHK_TRUE( s1.raftServer->set_priority(3, 0) == raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1672,7 +1680,7 @@ int priority_broadcast_test() {
     CHK_Z( make_group( pkgs ) );
 
     // Set the priority of S2 to 100.
-    s1.raftServer->set_priority(2, 100);
+    CHK_TRUE( s1.raftServer->set_priority(2, 100) == raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1680,7 +1688,7 @@ int priority_broadcast_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 50.
-    s1.raftServer->set_priority(3, 50);
+    CHK_TRUE( s1.raftServer->set_priority(3, 50) == raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -1714,12 +1722,16 @@ int priority_broadcast_test() {
     CHK_FALSE( s2.raftServer->is_leader() );
     CHK_FALSE( s3.raftServer->is_leader() );
 
-    // Set priority on non-leader node.
-    s2.raftServer->set_priority(1, 90);
+    // Setting priority on non-leader nodes should do nothing by default
+    for (int ii=1; ii<=3; ++ii) {
+        CHK_TRUE( s2.raftServer->set_priority(ii, 90) == raft_server::priority_set_result::IGNORED );
+        CHK_TRUE( s3.raftServer->set_priority(ii, 90) == raft_server::priority_set_result::IGNORED );
+    }
+
     // Send priority change reqs.
     s2.fNet->execReqResp();
 
-    // Now all servers should have the same priorities.
+    // Now each server's priority should be same on every other server.
     std::map<int, int> baseline;
     for (auto& entry: pkgs) {
         RaftPkg* rr = entry;
@@ -2509,7 +2521,7 @@ int apply_config_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S3 to 85.
-    s1.raftServer->set_priority(3, 85);
+    CHK_TRUE( s1.raftServer->set_priority(3, 85) == raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.
@@ -2517,7 +2529,7 @@ int apply_config_test() {
     CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
 
     // Set the priority of S4 to 100.
-    s1.raftServer->set_priority(4, 100);
+    CHK_TRUE( s1.raftServer->set_priority(4, 100) == raft_server::priority_set_result::SET );
     // Send priority change reqs.
     s1.fNet->execReqResp();
     // Send reqs again for commit.


### PR DESCRIPTION
`set_priority` is a bit inconsistent with `add_srv` and `remove_srv`.
If you invoke the latter two on a follower, the request will be
forwarded to leader. You can wait on the request and check whether it was accepted or not. 
Unfortunately, there are no such guarantees for `set_priority`.
If you invoke it on a follower, and there is a live leader, function would quit. 
I want to know the result of `set_priority`, so changes are proposed that change its return type.