### PR TITLE
Make callback be able to reject auto quorum size adjustment

### DIFF
--- a/include/libnuraft/callback.hxx
+++ b/include/libnuraft/callback.hxx
@@ -181,6 +181,13 @@ public:
          * ctx: pointer to `resp_msg` instance.
          */
         ReceivedAppendEntriesResp = 23,
+
+        /**
+         * When cluster size is 2 and `auto_adjust_quorum_for_small_cluster_` is on,
+         * this server attempts to adjust the quorum size to 1.
+         * ctx: null
+         */
+        AutoAdjustQuorum = 24,
     };
 
     struct Param {

--- a/src/handle_vote.cxx
+++ b/src/handle_vote.cxx
@@ -107,10 +107,19 @@ void raft_server::request_prevote() {
         // 2-node cluster's pre-vote failed due to offline node.
         p_wn("2-node cluster's pre-vote is failing long time, "
              "adjust quorum to 1");
-        ptr<raft_params> clone = cs_new<raft_params>(*params);
-        clone->custom_commit_quorum_size_ = 1;
-        clone->custom_election_quorum_size_ = 1;
-        ctx_->set_params(clone);
+
+        cb_func::Param cb_param(id_, leader_, -1);
+        CbReturnCode rc =
+            ctx_->cb_func_.call(cb_func::AutoAdjustQuorum, &cb_param);
+        if (rc == CbReturnCode::ReturnNull) {
+            // Callback function rejected the adjustment.
+            p_wn("quorum size adjustment was declined by callback");
+        } else {
+            ptr<raft_params> clone = cs_new<raft_params>(*params);
+            clone->custom_commit_quorum_size_ = 1;
+            clone->custom_election_quorum_size_ = 1;
+            ctx_->set_params(clone);
+        }
     }
 
     hb_alive_ = false;


### PR DESCRIPTION
* When cluster size is 2 and `auto_adjust_quorum_for_small_cluster_` is on, the quorum size will be automatically adjusted to 1 when the other member is not responding. In such a case, we want to ask callback function whether we can adjust the quorum size or not.