### PR TITLE
Fix GCC 13 compile errors

### DIFF
--- a/include/libnuraft/asio_service_options.hxx
+++ b/include/libnuraft/asio_service_options.hxx
@@ -17,6 +17,7 @@ limitations under the License.
 
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <string>
 #include <system_error>

--- a/include/libnuraft/callback.hxx
+++ b/include/libnuraft/callback.hxx
@@ -18,6 +18,7 @@ limitations under the License.
 #ifndef _CALLBACK_H_
 #define _CALLBACK_H_
 
+#include <cstdint>
 #include <functional>
 #include <string>
 


### PR DESCRIPTION
Hi, this MR is meant to fix compilation issues with gcc 13 (added missing headers).

I'd also suggest to qualify `uint64_t` and similar types/entities in C++ code with `std::`, for the rationale see https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2340r1.html