### PR TITLE
Extract the public interface class global_mgr, so users can implement their own global_mgr functionality to optimize multi raft instance.

### DIFF
--- a/include/libnuraft/global_mgr.hxx
+++ b/include/libnuraft/global_mgr.hxx
@@ -37,6 +37,41 @@ class asio_service;
 class logger;
 class raft_server;
 
+class global_mgr {
+    __interface_body__(global_mgr);
+
+public :
+    /**
+     * This function is called by the constructor of `raft_server`.
+     *
+     * @param server Raft server instance.
+     */
+    virtual void init_raft_server(raft_server* server) = 0;
+
+    /**
+     * This function is called by the destructor of `raft_server`.
+     *
+     * @param server Raft server instance.
+     */
+    virtual void close_raft_server(raft_server* server) = 0;
+
+    /**
+     * Request `append_entries` for the given server.
+     *
+     * @param server Raft server instance to request `append_entries`.
+     */
+    virtual void request_append(ptr<raft_server> server) = 0;
+
+    /**
+     * Request background commit execution for the given server.
+     *
+     * @param server Raft server instance to execute commit.
+     */
+    virtual void request_commit(ptr<raft_server> server) = 0;
+
+};
+
+
 /**
  * Configurations for the initialization of `nuraft_global_mgr`.
  */
@@ -68,11 +103,11 @@ struct nuraft_global_config {
 
 static nuraft_global_config __DEFAULT_NURAFT_GLOBAL_CONFIG;
 
-class nuraft_global_mgr {
+class nuraft_global_mgr : public global_mgr {
 public:
     nuraft_global_mgr();
 
-    ~nuraft_global_mgr();
+    virtual ~nuraft_global_mgr();
 
     __nocopy__(nuraft_global_mgr);
 public:
@@ -125,28 +160,28 @@ public:
      *
      * @param server Raft server instance.
      */
-    void init_raft_server(raft_server* server);
+    virtual void init_raft_server(raft_server* server) __override__;
 
     /**
      * This function is called by the destructor of `raft_server`.
      *
      * @param server Raft server instance.
      */
-    void close_raft_server(raft_server* server);
+    virtual void close_raft_server(raft_server* server) __override__;
 
     /**
      * Request `append_entries` for the given server.
      *
      * @param server Raft server instance to request `append_entries`.
      */
-    void request_append(ptr<raft_server> server);
+    virtual void request_append(ptr<raft_server> server) __override__;
 
     /**
      * Request background commit execution for the given server.
      *
      * @param server Raft server instance to execute commit.
      */
-    void request_commit(ptr<raft_server> server);
+    virtual void request_commit(ptr<raft_server> server) __override__;
 
 private:
     struct worker_handle;

--- a/include/libnuraft/raft_params.hxx
+++ b/include/libnuraft/raft_params.hxx
@@ -28,6 +28,8 @@ limitations under the License.
 
 namespace nuraft {
 
+class global_mgr;
+
 struct raft_params {
     enum return_method_type {
         /**
@@ -97,6 +99,7 @@ struct raft_params {
         , use_bg_thread_for_snapshot_io_(false)
         , use_full_consensus_among_healthy_members_(false)
         , parallel_log_appending_(false)
+        , global_mgr_(nullptr)
         {}
 
     /**
@@ -604,6 +607,9 @@ public:
      * before returning the response.
      */
     bool parallel_log_appending_;
+
+
+    global_mgr * global_mgr_;
 };
 
 }

--- a/src/handle_client_request.cxx
+++ b/src/handle_client_request.cxx
@@ -67,7 +67,7 @@ void raft_server::request_append_entries_for_all() {
     ptr<raft_params> params = ctx_->get_params();
     if (params->use_bg_thread_for_urgent_commit_) {
         // Let background generate request (some delay may happen).
-        nuraft_global_mgr* mgr = nuraft_global_mgr::get_instance();
+        global_mgr* mgr = params->global_mgr_;
         if (mgr) {
             // Global thread pool exists, request it.
             p_tr("found global thread pool");

--- a/src/handle_commit.cxx
+++ b/src/handle_commit.cxx
@@ -65,7 +65,7 @@ void raft_server::commit(ulong target_idx) {
     if ( log_store_->next_slot() - 1 > sm_commit_index_ &&
          quick_commit_index_ > sm_commit_index_ ) {
 
-        nuraft_global_mgr* mgr = nuraft_global_mgr::get_instance();
+        global_mgr* mgr = ctx_->get_params()->global_mgr_;
         if (mgr) {
             // Global thread pool exists, request it.
             p_tr("request commit to global thread pool");
@@ -902,7 +902,7 @@ void raft_server::resume_state_machine_execution() {
           sm_commit_exec_in_progress_ ? "RUNNING" : "SLEEPING" );
     sm_commit_paused_ = false;
 
-    nuraft_global_mgr* mgr = nuraft_global_mgr::get_instance();
+    global_mgr* mgr = ctx_->get_params()->global_mgr_;
     if (mgr) {
         // Global mgr.
         mgr->request_commit( this->shared_from_this() );

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -264,7 +264,10 @@ raft_server::raft_server(context* ctx, const init_options& opt)
 void raft_server::start_server(bool skip_initial_election_timeout)
 {
     ptr<raft_params> params = ctx_->get_params();
-    nuraft_global_mgr* mgr = nuraft_global_mgr::get_instance();
+    global_mgr* mgr = params->global_mgr_;
+    if (nullptr == mgr) {
+        mgr = nuraft_global_mgr::get_instance();
+    }
     if (mgr) {
         p_in("global manager is detected. will use shared thread pool");
         commit_bg_stopped_ = true;
@@ -437,7 +440,7 @@ void raft_server::stop_server() {
 }
 
 void raft_server::cancel_global_requests() {
-    nuraft_global_mgr* mgr = nuraft_global_mgr::get_instance();
+    global_mgr* mgr = ctx_->get_params()->global_mgr_;
     if (mgr) {
         mgr->close_raft_server(this);
     }


### PR DESCRIPTION
Extract the public interface class global_mgr, 
so users can implement their own global_mgr functionality to optimize multi raft instance.
