### PR TITLE
Add a new API to get the index at becoming leader

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -475,6 +475,20 @@ public:
     { return is_leader() ? get_committed_log_idx() : leader_commit_index_.load(); }
 
     /**
+     * Get the log index of the first config when this server became a leader.
+     * This API can be used for checking if the state machine is fully caught up
+     * with the latest log after a leader election, so that the new leader can
+     * guarantee strong consistency.
+     *
+     * It will return 0 if this server is not a leader.
+     *
+     * @return The log index of the first config when this server became a leader.
+     */
+    uint64_t get_log_idx_at_becoming_leader() const {
+        return index_at_becoming_leader_;
+    }
+
+    /**
      * Calculate the log index to be committed
      * from current peers' matched indexes.
      *
@@ -1102,6 +1116,13 @@ protected:
      * index is less than this number.
      */
     std::atomic<ulong> lagging_sm_target_index_;
+
+    /**
+     * If this server is the current leader, this will indicate
+     * the log index of the first config it appended as a leader.
+     * Otherwise (if non-leader), the value will be 0.
+     */
+    std::atomic<uint64_t> index_at_becoming_leader_;
 
     /**
      * (Read-only)

--- a/src/handle_join_leave.cxx
+++ b/src/handle_join_leave.cxx
@@ -166,6 +166,7 @@ ptr<resp_msg> raft_server::handle_join_cluster_req(req_msg& req) {
     p_in("got join cluster req from leader %d", req.get_src());
     catching_up_ = true;
     role_ = srv_role::follower;
+    index_at_becoming_leader_ = 0;
     leader_ = req.get_src();
 
     if (reset_commit_idx) {

--- a/src/handle_vote.cxx
+++ b/src/handle_vote.cxx
@@ -125,6 +125,7 @@ void raft_server::request_prevote() {
     hb_alive_ = false;
     leader_ = -1;
     role_ = srv_role::candidate;
+    index_at_becoming_leader_ = 0;
     pre_vote_.reset(state_->get_term());
     // Count for myself.
     pre_vote_.dead_++;
@@ -216,6 +217,7 @@ void raft_server::initiate_vote(bool force_vote) {
         state_->inc_term();
         state_->set_voted_for(-1);
         role_ = srv_role::candidate;
+        index_at_becoming_leader_ = 0;
         votes_granted_ = 0;
         votes_responded_ = 0;
         election_completed_ = false;


### PR DESCRIPTION
* When a new leader is elected, the new leader's state machine may not fully catch up with the latest log index. In such a case, there will be a small time window for the leader's state machine to return stale data while it lags behind the latest log index.

* To check whether the state machine is lagging behind the latest log index when it became a leader, added a new API.