### PR TITLE
Pass original request and response to meta callback

### DIFF
--- a/include/libnuraft/asio_service_options.hxx
+++ b/include/libnuraft/asio_service_options.hxx
@@ -27,6 +27,9 @@ typedef struct ssl_ctx_st SSL_CTX;
 
 namespace nuraft {
 
+class req_msg;
+class resp_msg;
+
 /**
  * Parameters for meta callback functions in `options`.
  */
@@ -37,31 +40,59 @@ struct asio_service_meta_cb_params {
                                 uint64_t t = 0,
                                 uint64_t lt = 0,
                                 uint64_t li = 0,
-                                uint64_t ci = 0)
+                                uint64_t ci = 0,
+                                req_msg* req = nullptr,
+                                resp_msg* resp = nullptr)
         : msg_type_(m), src_id_(s), dst_id_(d)
         , term_(t), log_term_(lt), log_idx_(li), commit_idx_(ci)
+        , req_(req), resp_(resp)
         {}
 
-    // Type of request.
+    /**
+     * Type of request.
+     */
     int msg_type_;
 
-    // Source server ID that sends request.
+    /**
+     * Source server ID that sends request.
+     */
     int src_id_;
 
-    // Destination server ID that sends response.
+    /**
+     * Destination server ID that sends response.
+     */
     int dst_id_;
 
-    // Term of source server.
+    /**
+     * Term of source server.
+     */
     uint64_t term_;
 
-    // Term of the corresponding log.
+    /**
+     * Term of the corresponding log.
+     */
     uint64_t log_term_;
 
-    // Log index number.
+    /**
+     * Log index number.
+     */
     uint64_t log_idx_;
 
-    // Last committed index number.
+    /**
+     * Last committed index number.
+     */
     uint64_t commit_idx_;
+
+    /**
+     * Pointer to request instance.
+     */
+    req_msg* req_;
+
+    /**
+     * Pointer to response instance.
+     * Will be given for `read_resp_meta_` and `write_resp_meta_` only.
+     */
+    resp_msg* resp_;
 };
 
 /**

--- a/tests/unit/asio_service_test.cxx
+++ b/tests/unit/asio_service_test.cxx
@@ -279,6 +279,14 @@ std::string test_write_req_meta( std::atomic<size_t>* count,
         _msg("%10s %s %20s\n", "write req", key, value.c_str());
     }
 
+    // `req_` should be given, while `resp_` should be null.
+    auto chk_req_resp = [&]() {
+        CHK_NONNULL(params.req_);
+        CHK_NULL(params.resp_);
+        return 0;
+    };
+    if (chk_req_resp() != 0) return std::string();
+
     if (count) (*count)++;
     return value;
 }
@@ -299,6 +307,14 @@ bool test_read_req_meta( std::atomic<size_t>* count,
     if (dbg_print_ctx) {
         _msg("%10s %s %20s\n", "read req", key, meta.c_str());
     }
+
+    // `req_` should be given, while `resp_` should be null.
+    auto chk_req_resp = [&]() {
+        CHK_NONNULL(params.req_);
+        CHK_NULL(params.resp_);
+        return 0;
+    };
+    if (chk_req_resp() != 0) return false;
 
     std::string META;
     {   std::lock_guard<std::mutex> l(req_map_lock);
@@ -332,6 +348,14 @@ std::string test_write_resp_meta( std::atomic<size_t>* count,
         _msg("%10s %s %20s\n", "write resp", key, value.c_str());
     }
 
+    // `req_` and `resp_` should be given.
+    auto chk_req_resp = [&]() {
+        CHK_NONNULL(params.req_);
+        CHK_NONNULL(params.resp_);
+        return 0;
+    };
+    if (chk_req_resp() != 0) return std::string();
+
     if (count) (*count)++;
     return value;
 }
@@ -351,6 +375,14 @@ bool test_read_resp_meta( std::atomic<size_t>* count,
     if (dbg_print_ctx) {
         _msg("%10s %s %20s\n", "read resp", key, meta.c_str());
     }
+
+    // `req_` and `resp_` should be given.
+    auto chk_req_resp = [&]() {
+        CHK_NONNULL(params.req_);
+        CHK_NONNULL(params.resp_);
+        return 0;
+    };
+    if (chk_req_resp() != 0) return false;
 
     std::string META;
     {   std::lock_guard<std::mutex> l(resp_map_lock);


### PR DESCRIPTION
* It will be useful to pass the original request or response to meta callback functions.