### PR TITLE
Support CRC validation on entire message

### DIFF
--- a/include/libnuraft/asio_service_options.hxx
+++ b/include/libnuraft/asio_service_options.hxx
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <string>
 #include <system_error>
 
@@ -27,6 +28,7 @@ typedef struct ssl_ctx_st SSL_CTX;
 
 namespace nuraft {
 
+class buffer;
 class req_msg;
 class resp_msg;
 
@@ -120,6 +122,8 @@ struct asio_service_options {
         , verify_sn_(nullptr)
         , custom_resolver_(nullptr)
         , replicate_log_timestamp_(false)
+        , crc_on_entire_message_(false)
+        , corrupted_msg_handler_(nullptr)
         {}
 
     /**
@@ -243,6 +247,21 @@ struct asio_service_options {
      * this flag.
      */
     bool replicate_log_timestamp_;
+
+    /**
+     * If `true`, NuRaft will validate the entire message with CRC.
+     * Otherwise, it validates the header part only.
+     */
+    bool crc_on_entire_message_;
+
+    /**
+     * Callback function that will be invoked when the received message is corrupted.
+     * The first `buffer` contains the raw binary of message header,
+     * and the second `buffer` contains the user payload including metadata,
+     * if it is not null.
+     */
+    std::function< void( std::shared_ptr<buffer>,
+                         std::shared_ptr<buffer> ) > corrupted_msg_handler_;
 };
 
 }

--- a/tests/unit/raft_package_asio.hxx
+++ b/tests/unit/raft_package_asio.hxx
@@ -54,6 +54,7 @@ public:
         , alwaysInvokeCb(true)
         , useCustomResolver(false)
         , useLogTimestamp(false)
+        , useCrcOnEntireMessage(false)
         , myLogWrapper(nullptr)
         , myLog(nullptr)
         {}
@@ -72,6 +73,10 @@ public:
         readRespMeta = read_resp_meta;
         writeRespMeta = write_resp_meta;
         alwaysInvokeCb = always_invoke_cb;
+    }
+
+    void setCrcOnEntireMessage(bool to) {
+        useCrcOnEntireMessage = to;
     }
 
     static bool verifySn(const std::string& sn) {
@@ -115,6 +120,15 @@ public:
                     } else {
                         when_done("127.0.0.1", "20030", std::error_code());
                     }
+                };
+        }
+
+        if (useCrcOnEntireMessage) {
+            asio_opt.crc_on_entire_message_ = true;
+            asio_opt.corrupted_msg_handler_ =
+                [&](ptr<buffer> header, ptr<buffer> ctx){
+                    abort();
+                    return;
                 };
         }
 
@@ -256,6 +270,8 @@ public:
     bool useCustomResolver;
 
     bool useLogTimestamp;
+
+    bool useCrcOnEntireMessage;
 
     ptr<logger_wrapper> myLogWrapper;
     ptr<logger> myLog;


### PR DESCRIPTION
* So far, CRC validation has been done on the message header, excluding the user payload like log entries.

* Added a new Asio service option to enable CRC validation on the entire message. It is disabled by default for backward compatibility.

* Also added a callback function that can be invoked on any corrupted message, so as to do more investigation on user application side.

* Removed direct buffer get/put API calls, instead refactored the code with `buffer_serializer`.