### PR TITLE
Export CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,8 +324,25 @@ endif()
 
 
 # === Install Targets ===
-install(TARGETS static_lib ARCHIVE DESTINATION lib)
-install(TARGETS shared_lib LIBRARY DESTINATION lib)
+install(TARGETS shared_lib static_lib
+    EXPORT nuraft-targets
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+)
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/libnuraft DESTINATION include)
 
+install(EXPORT nuraft-targets
+    FILE NuRaftTargets.cmake
+    NAMESPACE NuRaft::
+    DESTINATION lib/cmake/NuRaft
+)
 
+include(CMakePackageConfigHelpers)
+configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/NuRaftConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/NuRaftConfig.cmake"
+    INSTALL_DESTINATION lib/cmake/NuRaft
+)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/NuRaftConfig.cmake"
+    DESTINATION lib/cmake/NuRaft
+)

--- a/NuRaftConfig.cmake.in
+++ b/NuRaftConfig.cmake.in
@@ -1,0 +1,11 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+set(DISABLE_OPENSSL @DISABLE_OPENSSL@)
+
+if (NOT DISABLE_OPENSSL)
+    find_dependency(OpenSSL)
+endif ()
+
+include("${CMAKE_CURRENT_LIST_DIR}/NuRaftTargets.cmake")


### PR DESCRIPTION
This exports both the shared and static library targets. A downstream project can use then use them as follows:

```cmake
find_package(NuRaft REQUIRED)
target_link_libraries(downstream_target PRIVATE NuRaft::static_lib)
```

Closes #450