### PR TITLE
Add optional CRC per log entry.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,7 @@ set(RAFT_CORE
     ${ROOT_SRC}/handle_user_cmd.cxx
     ${ROOT_SRC}/handle_vote.cxx
     ${ROOT_SRC}/launcher.cxx
+    ${ROOT_SRC}/log_entry.cxx
     ${ROOT_SRC}/peer.cxx
     ${ROOT_SRC}/raft_server.cxx
     ${ROOT_SRC}/snapshot.cxx

--- a/examples/in_memory_log_store.cxx
+++ b/examples/in_memory_log_store.cxx
@@ -54,7 +54,8 @@ ptr<log_entry> inmem_log_store::make_clone(const ptr<log_entry>& entry) {
                            ( entry->get_term(),
                              buffer::clone( entry->get_buf() ),
                              entry->get_val_type(),
-                             entry->get_timestamp() );
+                             entry->get_timestamp(),
+                             entry->get_crc32() );
     return clone;
 }
 

--- a/examples/in_memory_log_store.cxx
+++ b/examples/in_memory_log_store.cxx
@@ -55,7 +55,9 @@ ptr<log_entry> inmem_log_store::make_clone(const ptr<log_entry>& entry) {
                              buffer::clone( entry->get_buf() ),
                              entry->get_val_type(),
                              entry->get_timestamp(),
-                             entry->get_crc32() );
+                             entry->has_crc32(),
+                             entry->get_crc32(),
+                             false );
     return clone;
 }
 

--- a/include/libnuraft/asio_service_options.hxx
+++ b/include/libnuraft/asio_service_options.hxx
@@ -123,6 +123,7 @@ struct asio_service_options {
         , custom_resolver_(nullptr)
         , replicate_log_timestamp_(false)
         , crc_on_entire_message_(false)
+        , crc_on_payload_(false)
         , corrupted_msg_handler_(nullptr)
         {}
 
@@ -243,7 +244,7 @@ struct asio_service_options {
      * restore the timestamp when it reads log entries.
      *
      * This feature is not backward compatible. To enable this feature, there
-     * should not be any member running with old version before supprting
+     * should not be any member running with old version before supporting
      * this flag.
      */
     bool replicate_log_timestamp_;
@@ -257,7 +258,7 @@ struct asio_service_options {
     /**
      * If `true`, each log entry will contain a CRC checksum of the entry's
      * payload.
-     * 
+     *
      * To support this feature, the log store implementation should be able to
      * store and retrieve the CRC checksum when it reads log entries.
      *

--- a/include/libnuraft/asio_service_options.hxx
+++ b/include/libnuraft/asio_service_options.hxx
@@ -255,6 +255,19 @@ struct asio_service_options {
     bool crc_on_entire_message_;
 
     /**
+     * If `true`, each log entry will contain a CRC checksum of the entry's
+     * payload.
+     * 
+     * To support this feature, the log store implementation should be able to
+     * store and retrieve the CRC checksum when it reads log entries.
+     *
+     * This feature is not backward compatible. To enable this feature, there
+     * should not be any member running with the old version before supporting
+     * this flag.
+     */
+    bool crc_on_payload_;
+
+    /**
      * Callback function that will be invoked when the received message is corrupted.
      * The first `buffer` contains the raw binary of message header,
      * and the second `buffer` contains the user payload including metadata,

--- a/include/libnuraft/log_entry.hxx
+++ b/include/libnuraft/log_entry.hxx
@@ -41,14 +41,15 @@ public:
               const ptr<buffer>& buff,
               log_val_type value_type = log_val_type::app_log,
               uint64_t log_timestamp = 0,
-              uint32_t crc32 = 0)
+              uint32_t crc32 = 0,
+              bool compute_crc = true)
         : term_(term)
         , value_type_(value_type)
         , buff_(buff)
         , timestamp_us_(log_timestamp)
         , crc32_(crc32)
         {
-            if (!buff_ && crc32 == 0) {
+            if (!buff_ && crc32 == 0 && compute_crc) {
                 crc32_ = crc32_8( buff->data_begin(),
                                   buff->size(),
                                   0 );

--- a/include/libnuraft/log_entry.hxx
+++ b/include/libnuraft/log_entry.hxx
@@ -23,7 +23,6 @@ limitations under the License.
 
 #include "basic_types.hxx"
 #include "buffer.hxx"
-#include "crc32.hxx"
 #include "log_val_type.hxx"
 #include "ptr.hxx"
 #include <cstdint>
@@ -41,20 +40,9 @@ public:
               const ptr<buffer>& buff,
               log_val_type value_type = log_val_type::app_log,
               uint64_t log_timestamp = 0,
+              bool has_crc32 = false,
               uint32_t crc32 = 0,
-              bool compute_crc = true)
-        : term_(term)
-        , value_type_(value_type)
-        , buff_(buff)
-        , timestamp_us_(log_timestamp)
-        , crc32_(crc32)
-        {
-            if (!buff_ && crc32 == 0 && compute_crc) {
-                crc32_ = crc32_8( buff->data_begin(),
-                                  buff->size(),
-                                  0 );
-            }
-        }
+              bool compute_crc = true);
 
     __nocopy__(log_entry);
 
@@ -101,6 +89,10 @@ public:
 
     void set_timestamp(uint64_t t) {
         timestamp_us_ = t;
+    }
+
+    bool has_crc32() const {
+        return has_crc32_;
     }
 
     uint32_t get_crc32() const {
@@ -163,6 +155,7 @@ private:
      * CRC32 checksum of this log entry.
      * Used only when `crc_on_payload` in `asio_service_options` is set.
      */
+    bool has_crc32_;
     uint32_t crc32_;
 };
 

--- a/include/libnuraft/log_entry.hxx
+++ b/include/libnuraft/log_entry.hxx
@@ -23,8 +23,10 @@ limitations under the License.
 
 #include "basic_types.hxx"
 #include "buffer.hxx"
+#include "crc32.hxx"
 #include "log_val_type.hxx"
 #include "ptr.hxx"
+#include <cstdint>
 
 #ifdef _NO_EXCEPTION
 #include <cassert>
@@ -38,12 +40,20 @@ public:
     log_entry(ulong term,
               const ptr<buffer>& buff,
               log_val_type value_type = log_val_type::app_log,
-              uint64_t log_timestamp = 0)
+              uint64_t log_timestamp = 0,
+              uint32_t crc32 = 0)
         : term_(term)
         , value_type_(value_type)
         , buff_(buff)
         , timestamp_us_(log_timestamp)
-        {}
+        , crc32_(crc32)
+        {
+            if (!buff_ && crc32 == 0) {
+                crc32_ = crc32_8( buff->data_begin(),
+                                  buff->size(),
+                                  0 );
+            }
+        }
 
     __nocopy__(log_entry);
 
@@ -92,6 +102,14 @@ public:
         timestamp_us_ = t;
     }
 
+    uint32_t get_crc32() const {
+        return crc32_;
+    }
+
+    void set_crc32(uint32_t crc) {
+        crc32_ = crc;
+    }
+
     ptr<buffer> serialize() {
         buff_->pos(0);
         ptr<buffer> buf = buffer::alloc( sizeof(ulong) +
@@ -135,10 +153,16 @@ private:
 
     /**
      * The timestamp (since epoch) when this log entry was generated
-     * in microseconds. Used only when `log_entry_timestamp_` in
+     * in microseconds. Used only when `replicate_log_timestamp_` in
      * `asio_service_options` is set.
      */
     uint64_t timestamp_us_;
+
+    /**
+     * CRC32 checksum of this log entry.
+     * Used only when `crc_on_payload` in `asio_service_options` is set.
+     */
+    uint32_t crc32_;
 };
 
 }

--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -639,7 +639,7 @@ private:
                 ptr<buffer> buf( buffer::alloc(val_size) );
                 ss.get_buffer(buf);
                 ptr<log_entry> entry(
-                    cs_new<log_entry>(term, buf, val_type, timestamp, crc32) );
+                    cs_new<log_entry>(term, buf, val_type, timestamp, crc32, false) );
 
                 if ((flags_ & CRC_ON_PAYLOAD) && crc32 != 0) {
                     // Verify CRC.

--- a/src/log_entry.cxx
+++ b/src/log_entry.cxx
@@ -1,0 +1,26 @@
+#include "crc32.hxx"
+#include "log_entry.hxx"
+
+namespace nuraft {
+log_entry::log_entry(ulong term,
+                     const ptr<buffer>& buff,
+                     log_val_type value_type,
+                     uint64_t log_timestamp,
+                     bool has_crc32,
+                     uint32_t crc32,
+                     bool compute_crc)
+    : term_(term)
+    , value_type_(value_type)
+    , buff_(buff)
+    , timestamp_us_(log_timestamp)
+    , has_crc32_(has_crc32)
+    , crc32_(crc32)
+    {
+        if (!buff_ && !has_crc32 && compute_crc) {
+            has_crc32_ = true;
+            crc32_ = crc32_8( buff->data_begin(),
+                              buff->size(),
+                              0 );
+        }
+    }
+}

--- a/tests/unit/raft_package_asio.hxx
+++ b/tests/unit/raft_package_asio.hxx
@@ -125,6 +125,7 @@ public:
 
         if (useCrcOnEntireMessage) {
             asio_opt.crc_on_entire_message_ = true;
+            asio_opt.crc_on_payload_ = true;
             asio_opt.corrupted_msg_handler_ =
                 [&](ptr<buffer> header, ptr<buffer> ctx){
                     abort();


### PR DESCRIPTION
Add an option to replicate and verify per-log-entry CRC checksums.

The log entry's checksum is computed when the entry is first created on the leader, and then stored in the log store and replicated over the network. On receive, if the checksum is sent, it is verified.