### PR TITLE
Fix public usage requirements on CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,6 +276,20 @@ set_target_properties(static_lib PROPERTIES OUTPUT_NAME ${LIBRARY_NAME} CLEAN_DI
 
 add_library(shared_lib SHARED ${STATIC_LIB_SRC})
 set_target_properties(shared_lib PROPERTIES OUTPUT_NAME ${LIBRARY_NAME} CLEAN_DIRECT_OUTPUT 1)
+
+# Include directories are necessary for dependents to use the targets.
+target_include_directories(static_lib
+    PUBLIC
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include>
+)
+
+target_include_directories(static_lib
+    PUBLIC
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include>
+)
+
 if (APPLE)
     target_link_libraries(shared_lib ${LIBRARIES})
 endif ()


### PR DESCRIPTION
This adds the include directory to the public includes for both the static and shared targets. It is necessary to do it for both the build and install interfaces, because the build interface will be used if the project is added as a submodule, but the install interface will be used if the project was added using a config.

Fixes #460.