### PR TITLE
Fix `executor_type` in `mock_ssl`.

### DIFF
--- a/src/mock_ssl.hxx
+++ b/src/mock_ssl.hxx
@@ -28,8 +28,8 @@ public:
 
 class mock_ssl_socket {
 public:
-    using executor_type = int;
     using lowest_layer_type = asio::ip::tcp::socket;
+    using executor_type = lowest_layer_type::executor_type;
 
     mock_ssl_socket(asio::ip::tcp::socket& tcp_socket,
                     mock_ssl_context& context)


### PR DESCRIPTION
* Instead of `int`, use the definition from Asio.

* Resolves #238 