### PR TITLE
ServerJoinFailed callback

### DIFF
--- a/include/libnuraft/callback.hxx
+++ b/include/libnuraft/callback.hxx
@@ -188,6 +188,12 @@ public:
          * ctx: null
          */
         AutoAdjustQuorum = 24,
+
+        /**
+         * Adding a server failed due to RPC errors and timeout expiry.
+         * ctx: null
+         */
+        ServerJoinFailed = 25
     };
 
     struct Param {

--- a/src/handle_join_leave.cxx
+++ b/src/handle_join_leave.cxx
@@ -95,6 +95,10 @@ ptr<resp_msg> raft_server::handle_add_srv_req(req_msg& req) {
         // Otherwise: activity timeout, reset the server.
         p_wn("activity timeout (last activity %" PRIu64 " ms ago), start over",
              last_active_ms);
+
+        cb_func::Param param(id_, leader_, srv_to_join_->get_id());
+        invoke_callback(cb_func::ServerJoinFailed, &param);
+
         reset_srv_to_join();
     }
 

--- a/src/handle_join_leave.cxx
+++ b/src/handle_join_leave.cxx
@@ -596,6 +596,9 @@ void raft_server::handle_join_leave_rpc_err(msg_type t_msg, ptr<peer> p) {
               p->get_id() );
         config_changing_ = false;
         reset_srv_to_join();
+
+        cb_func::Param param(id_, leader_, p->get_id());
+        invoke_callback(cb_func::ServerJoinFailed, &param);
     }
 }
 

--- a/tests/unit/raft_package_fake.hxx
+++ b/tests/unit/raft_package_fake.hxx
@@ -230,12 +230,13 @@ static cb_func::ReturnCode ATTR_UNUSED cb_default(
 
 static INT_UNUSED launch_servers(const std::vector<RaftPkg*>& pkgs,
                                  raft_params* custom_params = nullptr,
-                                 bool restart = false) {
+                                 bool restart = false,
+                                 cb_func::func_type callback = cb_default) {
     size_t num_srvs = pkgs.size();
     CHK_GT(num_srvs, 0);
 
     raft_server::init_options opt(false, true, true);
-    opt.raft_callback_ = cb_default;
+    opt.raft_callback_ = callback;
 
     for (size_t ii = 0; ii < num_srvs; ++ii) {
         RaftPkg* ff = pkgs[ii];


### PR DESCRIPTION
If we `add_srv`, what we can check is that a command was accepted. However, the only way to check whether it was applied is to query replica's config. In case of server not being added (e.g. non-existent host) we will never find this server in a config.
This PR proposes a way to handle such corner cases without relying on some arbitrary timeouts

Note we don't need a ServerLeaveFailed callback as a server that fails to be removed gracefully is still removed.