### PR TITLE
Fix to bug on snapshot ctx of removed member

### DIFF
--- a/src/handle_join_leave.cxx
+++ b/src/handle_join_leave.cxx
@@ -564,9 +564,7 @@ void raft_server::handle_join_leave_rpc_err(msg_type t_msg, ptr<peer> p) {
         if (peers_.size() == 1) {
             peer_itor pit = peers_.find(p->get_id());
             if (pit != peers_.end()) {
-                pit->second->enable_hb(false);
-                peers_.erase(pit);
-                p_in("server %d is removed from cluster", p->get_id());
+                remove_peer_from_peers(pit->second);
             } else {
                 p_in("peer %d cannot be found, no action for removing",
                      p->get_id());

--- a/src/handle_timeout.cxx
+++ b/src/handle_timeout.cxx
@@ -148,6 +148,7 @@ void raft_server::handle_hb_timeout(int32 srv_id) {
             if (p->is_hb_enabled()) {
                 // Schedule another heartbeat if heartbeat is still enabled
                 schedule_task(p->get_hb_task(), p->get_current_hb_interval());
+                p_tr("reschedule heartbeat for peer %d", p->get_id());
             } else {
                 p_db("heartbeat is disabled for peer %d", p->get_id());
             }


### PR DESCRIPTION
* If a member receiving snapshot is not responding, and then removed by the rpc error handler, its snapshot ctx is kept open and will never be closed.

* To avoid such an issue, rpc error handler should explicitly destroy the snapshot ctx of the removed member.