### PR TITLE
Add a new API to reset the whole state machine.

### DIFF
--- a/examples/calculator/calc_state_machine.hxx
+++ b/examples/calculator/calc_state_machine.hxx
@@ -179,6 +179,8 @@ public:
 
         ptr<snapshot_ctx> ctx = entry->second;
         cur_value_ = ctx->value_;
+        // Now the last committed_idx is the snapshot's last log index.
+        last_committed_idx_ = s.get_last_log_idx();
         return true;
     }
 
@@ -211,6 +213,10 @@ public:
             // Create a snapshot in an asynchronous way (in a different thread).
             create_snapshot_async(s, when_done);
         }
+    }
+
+    void reset() override {
+        cur_value_ = 0;
     }
 
     int64_t get_current_value() const { return cur_value_; }

--- a/examples/echo/echo_state_machine.hxx
+++ b/examples/echo/echo_state_machine.hxx
@@ -110,6 +110,8 @@ public:
             ptr<buffer> snp_buf = s.serialize();
             last_snapshot_ = snapshot::deserialize(*snp_buf);
         }
+        // Now the last committed_idx is the snapshot's last log index.
+        last_committed_idx_ = s.get_last_log_idx();
         return true;
     }
 
@@ -138,6 +140,10 @@ public:
         ptr<std::exception> except(nullptr);
         bool ret = true;
         when_done(ret, except);
+    }
+
+    void reset() override {
+        // echo state machine has no state to reset.
     }
 
 private:

--- a/include/libnuraft/state_machine.hxx
+++ b/include/libnuraft/state_machine.hxx
@@ -328,6 +328,12 @@ public:
     virtual bool allow_leadership_transfer() { return true; }
 
     /**
+     * Reset the state machine clearing all data and related state,
+     * should be invoked before follower apply snapshot from leader.
+     */
+    virtual void reset(){};
+
+    /**
      * Parameters for `adjust_commit_index` API.
      */
     struct adjust_commit_index_params {

--- a/src/handle_snapshot_sync.cxx
+++ b/src/handle_snapshot_sync.cxx
@@ -559,6 +559,8 @@ bool raft_server::handle_snapshot_sync_req(snapshot_sync_req& req, std::unique_l
             stop_election_timer();
             p_in("successfully compact the log store, will now ask the "
                  "statemachine to apply the snapshot");
+            p_in("firstly reset the statemachine");
+            state_machine_->reset();
             if (!state_machine_->apply_snapshot(req.get_snapshot())) {
                 // LCOV_EXCL_START
                 p_er("failed to apply the snapshot after log compacted, "


### PR DESCRIPTION
### Use case

If a node leave cluster for a long time, when it startup it wil first load local data into memory then it will receive the `append_entry` request from leader and leader will check data ga. If the gap can not satisfied by log, leader will send sanpshot.The newly startup node reveive the sanpshot and load it into memory.

But it should clear data in memory first, if not inconsistence may occur, details see [here](https://github.com/JDRaftKeeper/RaftKeeper/pull/100).

I think it is better to add a new reset API.

