### PR TITLE
Avoid snapshot creation index inversion

### DIFF
--- a/include/libnuraft/callback.hxx
+++ b/include/libnuraft/callback.hxx
@@ -193,7 +193,13 @@ public:
          * Adding a server failed due to RPC errors and timeout expiry.
          * ctx: null
          */
-        ServerJoinFailed = 25
+        ServerJoinFailed = 25,
+
+        /**
+         * Snapshot creation begins.
+         * ctx: pointer to `uint64_t` (committed_idx).
+         */
+        SnapshotCreationBegin = 26
     };
 
     struct Param {

--- a/tests/unit/raft_functional_common.hxx
+++ b/tests/unit/raft_functional_common.hxx
@@ -46,6 +46,7 @@ public:
         , lastCommittedConfigIdx(0)
         , targetSnpReadFailures(0)
         , snpDelayMs(0)
+        , numSnapshotCreations(0)
         , myLog(logger)
     {
         (void)myLog;
@@ -241,6 +242,7 @@ public:
             // NOTE: We only handle logical snapshot.
             ptr<buffer> snp_buf = s.serialize();
             lastSnapshot = snapshot::deserialize(*snp_buf);
+            numSnapshotCreations++;
         }
         ptr<std::exception> except(nullptr);
         bool ret = true;
@@ -372,6 +374,10 @@ public:
         serversForCommit = src;
     }
 
+    uint64_t getNumSnapshotCreations() const {
+        return numSnapshotCreations;
+    }
+
 private:
     std::map<uint64_t, ptr<buffer>> preCommits;
     std::map<uint64_t, ptr<buffer>> commits;
@@ -397,6 +403,8 @@ private:
      */
     std::list<int> serversForCommit;
     mutable std::mutex serversForCommitLock;
+
+    std::atomic<uint64_t> numSnapshotCreations;
 
     SimpleLogger* myLog;
 };


### PR DESCRIPTION
* Since snapshot is created by the background commit thread, index inversion can happen if user explicitly calls manual creation API. In that case, the backgroudn thread will create a snapshot on an index that is older than the latest snapshot, which should not happen.

* To avoid such a case, added a logic to check the request commit index and the latest snapshot's index.