### PR TITLE
Commit is needs to be triggered when quorum size becomes 1

### DIFF
--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -188,6 +188,10 @@ bool raft_server::request_append_entries(ptr<peer> p) {
                     clone->custom_commit_quorum_size_ = 1;
                     clone->custom_election_quorum_size_ = 1;
                     ctx_->set_params(clone);
+                    // When the quorum size is 1 and the server is idle, there is no
+                    // opportunity to commit pending logs
+                    uint64_t leader_index = get_current_leader_index();
+                    commit(leader_index);
                 }
             }
 


### PR DESCRIPTION
Conditions:
    1、cluster has only 2 nodes
    2、leader yield_leadership
    3、option auto_adjust_quorum_for_small_cluster_ is true
    4、anthor node become leader and old leader down
    5、cluster is idle

Pending cluster configuration has no chance to commit
