### PR TITLE
let auto forward mode get result_code

### DIFF
--- a/src/handle_user_cmd.cxx
+++ b/src/handle_user_cmd.cxx
@@ -340,6 +340,7 @@ void raft_server::auto_fwd_resp_handler( ptr<cmd_result<ptr<buffer>>> presult,
 {
     ptr<buffer> resp_ctx(nullptr);
     ptr<std::exception> perr;
+    cmd_result_code code = cmd_result_code::OK;
     if (err) {
         perr = err;
     } else {
@@ -347,9 +348,9 @@ void raft_server::auto_fwd_resp_handler( ptr<cmd_result<ptr<buffer>>> presult,
             resp_ctx = resp->get_ctx();
             presult->accept();
         }
+        code = resp->get_result_code();
     }
-
-    presult->set_result(resp_ctx, perr);
+    presult->set_result(resp_ctx, perr, code);
     auto_fwd_release_rpc_cli(cur_pkg, rpc_cli);
 }
 


### PR DESCRIPTION
Some interfaces use result_code as an error code, such as add_srv and rm_srv. When auto forward is enabled, let the result_code be forwarded.