### PR TITLE
<fix>: prevent a server joining another cluster whlit it is already in one.

### DIFF
--- a/src/handle_join_leave.cxx
+++ b/src/handle_join_leave.cxx
@@ -153,6 +153,12 @@ ptr<resp_msg> raft_server::handle_join_cluster_req(req_msg& req) {
         return resp;
     }
 
+    ptr<cluster_config> cur_config = get_config();
+    if (cur_config->get_servers().size() > 1) {
+        p_in("this server is already in a cluster, ignore the request");
+        return resp;
+    }
+
     // MONSTOR-8244:
     //   Adding server may be called multiple times while previous process is
     //   in progress. It should gracefully handle the new request and should


### PR DESCRIPTION
This a pull request for fixing the problem mentioned in issue #233 
I've added an additional check to prevent a node from joining multiple clusters.
