### PR TITLE
Add more sanity checks on a new connection

### DIFF
--- a/include/libnuraft/msg_type.hxx
+++ b/include/libnuraft/msg_type.hxx
@@ -64,7 +64,7 @@ enum msg_type {
 
 inline bool ATTR_UNUSED is_valid_msg(msg_type type) {
     if ( type >= request_vote_request &&
-         type <= other_response ) {
+         type <= custom_notification_response ) {
         return true;
     }
     return false;


### PR DESCRIPTION
* If there is an incoming random message, where `CRC_ON_ENTIRE_MESSAGE` flag is randomly set, NuRaft tries to read the entire message for CRC check. That requires allocating a memory blob with the given size (also a random number) which most likely causes problem.

* Added more sanity checks before the memory allocation.