### PR TITLE
Add timeout to async_connect operation

### DIFF
--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -1407,6 +1407,14 @@ private:
                                  send_timeout_ms,
                                  std::placeholders::_1,
                                  std::placeholders::_2 ) );
+                if (send_timeout_ms != 0) {
+                    operation_timer_.expires_after
+                    ( std::chrono::duration_cast<std::chrono::nanoseconds>
+                      ( std::chrono::milliseconds( send_timeout_ms ) ) );
+                    operation_timer_.async_wait( std::bind( &asio_rpc_client::cancel_socket,
+                                this,
+                                std::placeholders::_1 ) );
+                }
             } else {
                 ptr<resp_msg> rsp;
                 ptr<rpc_exception> except
@@ -1477,6 +1485,7 @@ private:
                    std::error_code err,
                    asio::ip::tcp::resolver::iterator itor)
     {
+        operation_timer_.cancel();
         if (!err) {
             p_in( "%p connected to %s:%s (as a client)",
                   this, host_.c_str(), port_.c_str() );

--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -1411,9 +1411,10 @@ private:
                     operation_timer_.expires_after
                     ( std::chrono::duration_cast<std::chrono::nanoseconds>
                       ( std::chrono::milliseconds( send_timeout_ms ) ) );
-                    operation_timer_.async_wait( std::bind( &asio_rpc_client::cancel_socket,
-                                this,
-                                std::placeholders::_1 ) );
+                    operation_timer_.async_wait(
+                        std::bind( &asio_rpc_client::cancel_socket,
+                                   this,
+                                   std::placeholders::_1 ) );
                 }
             } else {
                 ptr<resp_msg> rsp;


### PR DESCRIPTION
If the network goes down during a async_connect, we may end up being stuck forever in this function since there is no timeout to cancel it.