### PR TITLE
Notify user code about follower loss

### DIFF
--- a/include/libnuraft/callback.hxx
+++ b/include/libnuraft/callback.hxx
@@ -207,6 +207,13 @@ public:
          */
         ResignationFromLeader = 27,
 
+        /**
+         * When a peer RPC errors count exceeds raft_server::limits.warning_limit_, or
+         * a peer doesn't respond for a long time (raft_params::leadership_expiry_),
+         * the peer is considered lost.
+         * ctx: null.
+         */
+        FollowerLost = 100,
     };
 
     struct Param {

--- a/include/libnuraft/callback.hxx
+++ b/include/libnuraft/callback.hxx
@@ -213,7 +213,7 @@ public:
          * the peer is considered lost.
          * ctx: null.
          */
-        FollowerLost = 100,
+        FollowerLost = 28,
     };
 
     struct Param {

--- a/include/libnuraft/peer.hxx
+++ b/include/libnuraft/peer.hxx
@@ -74,6 +74,7 @@ public:
         , reconn_backoff_(0)
         , suppress_following_error_(false)
         , abandoned_(false)
+        , lost_by_leader_(false)
         , rsv_msg_(nullptr)
         , rsv_msg_handler_(nullptr)
         , l_(logger)
@@ -502,7 +503,11 @@ private:
      */
     std::atomic<bool> abandoned_;
 
-    std::atomic<bool> lost_by_leader_ {false};
+    /**
+     * If `true`, this peer is considered unresponsive
+     * and treated as if it has been lost.
+     */
+    std::atomic<bool> lost_by_leader_;
 
     /**
      * Reserved message that should be sent next time.

--- a/include/libnuraft/peer.hxx
+++ b/include/libnuraft/peer.hxx
@@ -302,6 +302,10 @@ public:
     ptr<req_msg> get_rsv_msg() const { return rsv_msg_; }
     rpc_handler get_rsv_msg_handler() const { return rsv_msg_handler_; }
 
+    bool IsLost() const { return lost_by_leader_; }
+    void SetLost() { lost_by_leader_ = true; }
+    void SetRecovered() { lost_by_leader_ = false; }
+
 private:
     void handle_rpc_result(ptr<peer> myself,
                            ptr<rpc_client> my_rpc_client,
@@ -497,6 +501,8 @@ private:
      * All operations on this peer should be rejected.
      */
     std::atomic<bool> abandoned_;
+
+    std::atomic<bool> lost_by_leader_ {false};
 
     /**
      * Reserved message that should be sent next time.

--- a/include/libnuraft/peer.hxx
+++ b/include/libnuraft/peer.hxx
@@ -302,9 +302,9 @@ public:
     ptr<req_msg> get_rsv_msg() const { return rsv_msg_; }
     rpc_handler get_rsv_msg_handler() const { return rsv_msg_handler_; }
 
-    bool IsLost() const { return lost_by_leader_; }
-    void SetLost() { lost_by_leader_ = true; }
-    void SetRecovered() { lost_by_leader_ = false; }
+    bool is_lost() const { return lost_by_leader_; }
+    void set_lost() { lost_by_leader_ = true; }
+    void set_recovered() { lost_by_leader_ = false; }
 
 private:
     void handle_rpc_result(ptr<peer> myself,

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -886,9 +886,11 @@ protected:
     int32 get_quorum_for_election();
     int32 get_quorum_for_commit();
     int32 get_leadership_expiry();
-    std::vector<ptr<peer>> get_not_responding_peers();
+    std::list<ptr<peer>> get_not_responding_peers();
     size_t get_not_responding_peers_count();
     size_t get_num_stale_peers();
+
+    void apply_to_not_responding_peers(const std::function<void(const ptr<peer>&)>&);
 
     ptr<resp_msg> handle_append_entries(req_msg& req);
     ptr<resp_msg> handle_prevote_req(req_msg& req);

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -886,7 +886,8 @@ protected:
     int32 get_quorum_for_election();
     int32 get_quorum_for_commit();
     int32 get_leadership_expiry();
-    size_t get_not_responding_peers();
+    std::vector<ptr<peer>> get_not_responding_peers();
+    size_t get_not_responding_peers_count();
     size_t get_num_stale_peers();
 
     ptr<resp_msg> handle_append_entries(req_msg& req);

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -162,7 +162,7 @@ bool raft_server::request_append_entries(ptr<peer> p) {
          chk_timer.timeout_and_reset() ) {
         // If auto adjust mode is on for 2-node cluster, and
         // the follower is not responding, adjust the quorum.
-        size_t num_not_responding_peers = get_not_responding_peers();
+        size_t num_not_responding_peers = get_not_responding_peers_count();
         size_t cur_quorum_size = get_quorum_for_commit();
         size_t num_stale_peers = get_num_stale_peers();
         if (cur_quorum_size >= 1) {
@@ -1191,7 +1191,7 @@ ulong raft_server::get_expected_committed_log_idx() {
 
     size_t quorum_idx = get_quorum_for_commit();
     if (ctx_->get_params()->use_full_consensus_among_healthy_members_) {
-        size_t not_responding_peers = get_not_responding_peers();
+        size_t not_responding_peers = get_not_responding_peers_count();
         if (not_responding_peers < voting_members - quorum_idx) {
             // If full consensus option is on, commit should be
             // agreed by all healthy members, and the number of

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -1128,7 +1128,7 @@ bool raft_server::check_leadership_validity() {
              min_quorum_size);
 
         const auto nr_peers_list = get_not_responding_peers();
-        assert(nr_peers_list.size() == nr_peers);
+        assert(nr_peers_list.size() == static_cast<std::size_t>(nr_peers));
         for (auto& peer : nr_peers_list) {
             if (peer->is_lost()) {
                 continue;

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -861,10 +861,10 @@ void raft_server::handle_peer_resp(ptr<resp_msg>& resp, ptr<rpc_exception>& err)
             peer* pp = entry->second.get();
             int rpc_errs = pp->get_rpc_errs();
             if (rpc_errs >= raft_server::raft_limits_.warning_limit_) {
-                pp->set_recovered();
                 p_wn("recovered from RPC failure from peer %d, %d errors",
                      resp->get_src(), rpc_errs);
             }
+            pp->set_recovered();
             pp->reset_rpc_errs();
             pp->reset_resp_timer();
         }
@@ -1044,6 +1044,7 @@ void raft_server::become_leader() {
 
             pp->set_next_log_idx(log_store_->next_slot());
             enable_hb_for_peer(*pp);
+            pp->set_recovered();
         }
 
         // If there are uncommitted logs, search if conf log exists.


### PR DESCRIPTION
Hello, within this PR we suggest to introduce a new `cb_func::Type` enum item: `FollowerLost`, and, on detection of follower loss, call the callback function with the `type` parameter equal to `FollowerLost`.

Pavel Yurin, 
C++ developer
NXLog Ltd.
pavel.yurin@nxlog.org
www.nxlog.co