### PR TITLE
Matching format specifies type to argument type to eliminate compile …

### DIFF
--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -1198,7 +1198,7 @@ void raft_server::check_leadership_transfer() {
         uint64_t last_resp_ms = peer_elem->get_resp_timer_us() / 1000;
         if (last_resp_ms > election_lower) {
             // This replica is not responding.
-            p_tr("peer %d is not responding, %llu ms ago",
+            p_tr("peer %d is not responding, %" PRIu64 " ms ago",
                  s_conf.get_id(), last_resp_ms);
             return;
         }

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -1189,7 +1189,7 @@ void raft_server::check_leadership_transfer() {
         if (peer_elem->get_matched_idx() + params->stale_log_gap_ <
                 cur_commit_idx) {
             // This peer is lagging behind.
-            p_tr("peer %d is lagging behind, %lu < %lu",
+            p_tr("peer %d is lagging behind, %llu < %llu",
                  s_conf.get_id(), peer_elem->get_matched_idx(),
                  cur_commit_idx);
             return;
@@ -1198,7 +1198,7 @@ void raft_server::check_leadership_transfer() {
         uint64_t last_resp_ms = peer_elem->get_resp_timer_us() / 1000;
         if (last_resp_ms > election_lower) {
             // This replica is not responding.
-            p_tr("peer %d is not responding, %lu ms ago",
+            p_tr("peer %d is not responding, %llu ms ago",
                  s_conf.get_id(), last_resp_ms);
             return;
         }

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -1189,7 +1189,7 @@ void raft_server::check_leadership_transfer() {
         if (peer_elem->get_matched_idx() + params->stale_log_gap_ <
                 cur_commit_idx) {
             // This peer is lagging behind.
-            p_tr("peer %d is lagging behind, %llu < %llu",
+            p_tr("peer %d is lagging behind, %" PRIu64 " < %" PRIu64,
                  s_conf.get_id(), peer_elem->get_matched_idx(),
                  cur_commit_idx);
             return;


### PR DESCRIPTION
…warnings

format specifies type 'unsigned long' but the argument has type 'ulong' (aka 'unsigned long long'). 