### PR TITLE
Fix to bug in `handle_cli_req`

### DIFF
--- a/src/handle_client_request.cxx
+++ b/src/handle_client_request.cxx
@@ -137,7 +137,7 @@ ptr<resp_msg> raft_server::handle_cli_req(req_msg& req,
         }
     }
     if (num_entries) {
-        log_store_->end_of_append_batch(last_idx - num_entries, num_entries);
+        log_store_->end_of_append_batch(last_idx - num_entries + 1, num_entries);
     }
     try_update_precommit_index(last_idx);
     resp_idx = log_store_->next_slot();


### PR DESCRIPTION
* When a leader invokes `end_of_append_batch`, the first parameter represents the starting index of the batch. There was missing `+1`.