### PR TITLE
Implement stream mode in peer and raft server(a proposal)

### DIFF
--- a/include/libnuraft/raft_params.hxx
+++ b/include/libnuraft/raft_params.hxx
@@ -97,6 +97,7 @@ struct raft_params {
         , use_bg_thread_for_snapshot_io_(false)
         , use_full_consensus_among_healthy_members_(false)
         , parallel_log_appending_(false)
+        , enable_stream_mode_(false)
         {}
 
     /**
@@ -604,6 +605,8 @@ public:
      * before returning the response.
      */
     bool parallel_log_appending_;
+
+    bool enable_stream_mode_;
 };
 
 }

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -893,6 +893,7 @@ protected:
     void apply_to_not_responding_peers(const std::function<void(const ptr<peer>&)>&, int expiry = 0);
 
     ptr<resp_msg> handle_append_entries(req_msg& req);
+    bool try_start_append(ptr<peer>& p, bool make_busy_success);
     ptr<resp_msg> handle_prevote_req(req_msg& req);
     ptr<resp_msg> handle_vote_req(req_msg& req);
     ptr<resp_msg> handle_cli_req_prelock(req_msg& req, const req_ext_params& ext_params);


### PR DESCRIPTION
1. it is a proposal for stream mode. I keep the make_busy and set_free for append-log requests
2. most of changes in peer is used in raft server. so I merge the change of peer and raft server to see if it is a proper way to implement stream mode.
3. I will split it into 2 PR and add tests separately once this proposal is accepted.