### PR TITLE
Implement stream mode in peer and raft server(a proposal)

### DIFF
--- a/include/libnuraft/raft_params.hxx
+++ b/include/libnuraft/raft_params.hxx
@@ -97,6 +97,7 @@ struct raft_params {
         , use_bg_thread_for_snapshot_io_(false)
         , use_full_consensus_among_healthy_members_(false)
         , parallel_log_appending_(false)
+        , max_log_gap_in_stream_(0)
         {}
 
     /**
@@ -604,6 +605,8 @@ public:
      * before returning the response.
      */
     bool parallel_log_appending_;
+
+    int32 max_log_gap_in_stream_;
 };
 
 }

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -929,7 +929,7 @@ protected:
     void request_vote(bool force_vote);
     void request_append_entries();
     bool request_append_entries(ptr<peer> p);
-    bool send_request(ptr<peer>& p, ptr<req_msg>& msg, rpc_handler& m_handler);
+    bool send_request(ptr<peer>& p, ptr<req_msg>& msg, rpc_handler& m_handler, bool streaming = false);
     void handle_peer_resp(ptr<resp_msg>& resp, ptr<rpc_exception>& err);
     void handle_append_entries_resp(resp_msg& resp);
     void handle_install_snapshot_resp(resp_msg& resp);

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -893,6 +893,7 @@ protected:
     void apply_to_not_responding_peers(const std::function<void(const ptr<peer>&)>&, int expiry = 0);
 
     ptr<resp_msg> handle_append_entries(req_msg& req);
+    bool try_start_append(ptr<peer>& p, bool make_busy_success);
     ptr<resp_msg> handle_prevote_req(req_msg& req);
     ptr<resp_msg> handle_vote_req(req_msg& req);
     ptr<resp_msg> handle_cli_req_prelock(req_msg& req, const req_ext_params& ext_params);
@@ -929,6 +930,7 @@ protected:
     void request_vote(bool force_vote);
     void request_append_entries();
     bool request_append_entries(ptr<peer> p);
+    bool send_request(ptr<peer>& p, ptr<req_msg>& msg, rpc_handler& m_handler);
     void handle_peer_resp(ptr<resp_msg>& resp, ptr<rpc_exception>& err);
     void handle_append_entries_resp(resp_msg& resp);
     void handle_install_snapshot_resp(resp_msg& resp);
@@ -946,7 +948,7 @@ protected:
     void handle_join_leave_rpc_err(msg_type t_msg, ptr<peer> p);
     void reset_srv_to_join();
     void reset_srv_to_leave();
-    ptr<req_msg> create_append_entries_req(ptr<peer>& pp);
+    ptr<req_msg> create_append_entries_req(ptr<peer>& pp, ulong last_streamed_log_idx = 0);
     ptr<req_msg> create_sync_snapshot_req(ptr<peer>& pp,
                                           ulong last_log_idx,
                                           ulong term,

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -947,7 +947,7 @@ protected:
     void handle_join_leave_rpc_err(msg_type t_msg, ptr<peer> p);
     void reset_srv_to_join();
     void reset_srv_to_leave();
-    ptr<req_msg> create_append_entries_req(ptr<peer>& pp, ulong last_streamed_log_idx = 0);
+    ptr<req_msg> create_append_entries_req(ptr<peer>& pp, ulong custom_last_log_idx = 0);
     ptr<req_msg> create_sync_snapshot_req(ptr<peer>& pp,
                                           ulong last_log_idx,
                                           ulong term,

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -893,7 +893,6 @@ protected:
     void apply_to_not_responding_peers(const std::function<void(const ptr<peer>&)>&, int expiry = 0);
 
     ptr<resp_msg> handle_append_entries(req_msg& req);
-    bool try_start_append(ptr<peer>& p, bool make_busy_success);
     ptr<resp_msg> handle_prevote_req(req_msg& req);
     ptr<resp_msg> handle_vote_req(req_msg& req);
     ptr<resp_msg> handle_cli_req_prelock(req_msg& req, const req_ext_params& ext_params);

--- a/scripts/test/runtests.sh
+++ b/scripts/test/runtests.sh
@@ -10,3 +10,4 @@ set -e
 ./tests/failure_test --abort-on-failure
 ./tests/asio_service_test --abort-on-failure
 ./tests/asio_service_stream_test --abort-on-failure
+./tests/asio_stream_test --abort-on-failure

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -271,88 +271,78 @@ bool raft_server::request_append_entries(ptr<peer> p) {
         }
     }
 
-    if (p->make_busy()) {
-        p_tr("send request to %d\n", (int)p->get_id());
-
+    if (p->is_streaming()) {
         // If reserved message exists, process it first.
         ptr<req_msg> msg = p->get_rsv_msg();
         rpc_handler m_handler = p->get_rsv_msg_handler();
         if (msg) {
-            // Clear the reserved message.
-            p->set_rsv_msg(nullptr, nullptr);
-            p_in("found reserved message to peer %d, type %d",
-                 p->get_id(), msg->get_type());
-
+            if (p->make_busy()) {
+                // Clear the reserved message.
+                p->set_rsv_msg(nullptr, nullptr);
+                p_in("found reserved message to peer %d, type %d",
+                        p->get_id(), msg->get_type());
+                return send_request(p, msg, m_handler);
+            }
         } else {
-            // Normal message.
-            msg = create_append_entries_req(p);
+            ulong last_streamed_log_idx = p->get_last_streamed_log_idx();
+            msg = create_append_entries_req(p, last_streamed_log_idx);
             m_handler = resp_handler_;
-        }
-
-        if (!msg) {
-            // Even normal message doesn't exist.
-            p->set_free();
-            if ( params->use_bg_thread_for_snapshot_io_ &&
-                 p->get_snapshot_sync_ctx() ) {
-                // If this is an async snapshot request, invoke IO thread.
-                snapshot_io_mgr::instance().invoke();
-            }
-            return true;
-        }
-
-        if (!p->is_manual_free()) {
-            // Actual recovery.
-            if ( p->get_long_puase_warnings() >=
-                     raft_server::raft_limits_.warning_limit_ ) {
-                int32 last_ts_ms = p->get_ls_timer_us() / 1000;
-                p->inc_recovery_cnt();
-                p_wn( "recovered from long pause to peer %d, %d warnings, "
-                      "%d ms, %d times",
-                      p->get_id(),
-                      p->get_long_puase_warnings(),
-                      last_ts_ms,
-                      p->get_recovery_cnt() );
-
-                if (p->get_recovery_cnt() >= 10) {
-                    // Re-connect client, just in case.
-                    //reconnect_client(*p);
-                    p->reset_recovery_cnt();
+            if (msg) {
+                if (msg->get_type() == msg_type::append_entries_request) {
+                    // two condition
+                    // 1. streaming is on
+                    // 2. streaming is off, but it is the first request
+                    if (last_streamed_log_idx == 0
+                            && p->start_append_entry() == 0) {
+                        return send_request(p, msg, m_handler);
+                    } else if (last_streamed_log_idx > 0) {
+                        p->add_append_entry_request();
+                        return send_request(p, msg, m_handler);
+                    }
+                } else {
+                    if (p->make_busy()) {
+                        return send_request(p, msg, m_handler);
+                    }
                 }
+            } else {
+                if ( params->use_bg_thread_for_snapshot_io_ &&
+                    p->get_snapshot_sync_ctx() ) {
+                    // If this is an async snapshot request, invoke IO thread.
+                    snapshot_io_mgr::instance().invoke();
+                }
+                return true;
             }
-            p->reset_long_pause_warnings();
-
-        } else {
-            // FIXME: `manual_free` is deprecated, need to get rid of it.
-
-            // It means that this is not an actual recovery,
-            // but just temporarily freed busy flag.
-            p->reset_manual_free();
         }
+    } else {
+        if (p->make_busy()) {
+            p_tr("send request to %d\n", (int)p->get_id());
 
-        p->send_req(p, msg, m_handler);
-        p->reset_ls_timer();
+            // If reserved message exists, process it first.
+            ptr<req_msg> msg = p->get_rsv_msg();
+            rpc_handler m_handler = p->get_rsv_msg_handler();
+            if (msg) {
+                // Clear the reserved message.
+                p->set_rsv_msg(nullptr, nullptr);
+                p_in("found reserved message to peer %d, type %d",
+                    p->get_id(), msg->get_type());
+            } else {
+                // Normal message.
+                msg = create_append_entries_req(p);
+                m_handler = resp_handler_;
+            }
 
-        cb_func::Param param(id_, leader_, p->get_id(), msg.get());
-        ctx_->cb_func_.call(cb_func::SentAppendEntriesReq, &param);
-
-        if ( srv_to_leave_ &&
-             srv_to_leave_->get_id() == p->get_id() &&
-             msg->get_commit_idx() >= srv_to_leave_target_idx_ &&
-             !srv_to_leave_->is_stepping_down() ) {
-            // If this is the server to leave, AND
-            // current request's commit index includes
-            // the target log index number, step down and remove it
-            // as soon as we get the corresponding response.
-            srv_to_leave_->step_down();
-            p_in("srv_to_leave_ %d is safe to be erased from peer list, "
-                 "log idx %" PRIu64 " commit idx %" PRIu64 ", set flag",
-                 srv_to_leave_->get_id(),
-                 msg->get_last_log_idx(),
-                 msg->get_commit_idx());
+            if (!msg) {
+                // Even normal message doesn't exist.
+                p->set_free();
+                if ( params->use_bg_thread_for_snapshot_io_ &&
+                    p->get_snapshot_sync_ctx() ) {
+                    // If this is an async snapshot request, invoke IO thread.
+                    snapshot_io_mgr::instance().invoke();
+                }
+                return true;
+            }
+            return send_request(p, msg, m_handler);
         }
-
-        p_tr("sent\n");
-        return true;
     }
 
     p_db("Server %d is busy, skip the request", p->get_id());
@@ -376,7 +366,65 @@ bool raft_server::request_append_entries(ptr<peer> p) {
     return false;
 }
 
-ptr<req_msg> raft_server::create_append_entries_req(ptr<peer>& pp) {
+
+
+bool raft_server::send_request(ptr<peer>& p, ptr<req_msg>& msg, rpc_handler& m_handler) {
+    if (!p->is_manual_free()) {
+        // Actual recovery.
+        if ( p->get_long_puase_warnings() >=
+                    raft_server::raft_limits_.warning_limit_ ) {
+            int32 last_ts_ms = p->get_ls_timer_us() / 1000;
+            p->inc_recovery_cnt();
+            p_wn( "recovered from long pause to peer %d, %d warnings, "
+                    "%d ms, %d times",
+                    p->get_id(),
+                    p->get_long_puase_warnings(),
+                    last_ts_ms,
+                    p->get_recovery_cnt() );
+
+            if (p->get_recovery_cnt() >= 10) {
+                // Re-connect client, just in case.
+                //reconnect_client(*p);
+                p->reset_recovery_cnt();
+            }
+        }
+        p->reset_long_pause_warnings();
+
+    } else {
+        // FIXME: `manual_free` is deprecated, need to get rid of it.
+
+        // It means that this is not an actual recovery,
+        // but just temporarily freed busy flag.
+        p->reset_manual_free();
+    }
+
+    p->send_req(p, msg, m_handler);
+    p->reset_ls_timer();
+
+    cb_func::Param param(id_, leader_, p->get_id(), msg.get());
+    ctx_->cb_func_.call(cb_func::SentAppendEntriesReq, &param);
+
+    if ( srv_to_leave_ &&
+            srv_to_leave_->get_id() == p->get_id() &&
+            msg->get_commit_idx() >= srv_to_leave_target_idx_ &&
+            !srv_to_leave_->is_stepping_down() ) {
+        // If this is the server to leave, AND
+        // current request's commit index includes
+        // the target log index number, step down and remove it
+        // as soon as we get the corresponding response.
+        srv_to_leave_->step_down();
+        p_in("srv_to_leave_ %d is safe to be erased from peer list, "
+                "log idx %" PRIu64 " commit idx %" PRIu64 ", set flag",
+                srv_to_leave_->get_id(),
+                msg->get_last_log_idx(),
+                msg->get_commit_idx());
+    }
+
+    p_tr("sent\n");
+    return true;
+}
+
+ptr<req_msg> raft_server::create_append_entries_req(ptr<peer>& pp ,ulong last_streamed_log_idx) {
     peer& p = *pp;
     ulong cur_nxt_idx(0L);
     ulong commit_idx(0L);
@@ -398,7 +446,11 @@ ptr<req_msg> raft_server::create_append_entries_req(ptr<peer>& pp) {
             p.set_next_log_idx(cur_nxt_idx);
         }
 
-        last_log_idx = p.get_next_log_idx() - 1;
+        if (last_streamed_log_idx > 0) {
+            last_log_idx = last_streamed_log_idx;
+        } else {
+            last_log_idx = p.get_next_log_idx() - 1;
+        }
     }
 
     if (last_log_idx >= cur_nxt_idx) {
@@ -428,6 +480,10 @@ ptr<req_msg> raft_server::create_append_entries_req(ptr<peer>& pp) {
     // return nullptr to indicate such errors.
     ulong end_idx = std::min( cur_nxt_idx,
                               last_log_idx + 1 + ctx_->get_params()->max_append_size_ );
+    if (last_streamed_log_idx > 0) {
+        end_idx = std::min( end_idx, last_log_idx + (p.get_max_log_gap_in_stream() - 
+                            last_streamed_log_idx - p.get_next_log_idx() + 1) );
+    }
 
     // NOTE: If this is a retry, probably the follower is down.
     //       Send just one log until it comes back
@@ -547,6 +603,10 @@ ptr<req_msg> raft_server::create_append_entries_req(ptr<peer>& pp) {
         v.insert(v.end(), log_entries->begin(), log_entries->end());
     }
     p.set_last_sent_idx(last_log_idx + 1);
+    if (last_streamed_log_idx > 0) {
+        p.set_last_streamed_log_idx(last_streamed_log_idx,
+        last_log_idx + req->log_entries().size());
+    }
 
     return req;
 }
@@ -1022,8 +1082,25 @@ void raft_server::handle_append_entries_resp(resp_msg& resp) {
         // Try to commit with this response.
         ulong committed_index = get_expected_committed_log_idx();
         commit( committed_index );
+
+        // Try enable stream here
+        ulong accepted_pre_commit_idx = resp.get_next_idx() +
+                                        p->get_max_log_gap_in_stream();
+        if (p->is_streaming() &&
+            p->get_last_streamed_log_idx() == 0 && 
+            resp.get_next_idx() > 0 && p->is_streaming() &&
+            p->get_last_sent_idx() < resp.get_next_idx() && 
+            precommit_index_ < accepted_pre_commit_idx) {
+            p->set_last_streamed_log_idx(0, resp.get_next_idx() - 1);
+        }
+
+        // Even we check streamed log index here, catch up may send empty request.
+        ulong next_sent_log = p->get_last_streamed_log_idx() + 1;
+        if (next_sent_log == 1) {
+            next_sent_log = resp.get_next_idx();
+        }
         need_to_catchup = p->clear_pending_commit() ||
-                          resp.get_next_idx() < log_store_->next_slot();
+                          next_sent_log < log_store_->next_slot();
 
     } else {
         std::lock_guard<std::mutex> guard(p->get_lock());
@@ -1066,6 +1143,9 @@ void raft_server::handle_append_entries_resp(resp_msg& resp) {
               "resp next %" PRIu64 ", new next log idx %" PRIu64,
               p->get_id(), prev_next_log,
               resp.get_next_idx(), p->get_next_log_idx() );
+        
+        // disable stream
+        p->reset_stream();
     }
 
     // NOTE:

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -296,10 +296,10 @@ bool raft_server::request_append_entries(ptr<peer> p) {
                             msg->get_type() == msg_type::append_entries_request;
                 bool make_busy_result = p->is_busy();
                 if (streaming) {
-                    // trottling
+                    // throttling
                     if (ctx_->get_params()->max_log_gap_in_stream_ + 
                         p->get_next_log_idx() < (last_streamed_log_idx + 1)) {
-                        p_wn("flying log entry exceeds %d in stream mode, skip this request",
+                        p_db("flying log entry exceeds %d in stream mode, skip this request",
                              ctx_->get_params()->max_log_gap_in_stream_);
                         streaming = false;
                     } else {

--- a/src/peer.cxx
+++ b/src/peer.cxx
@@ -189,8 +189,9 @@ void peer::try_set_free(msg_type type) {
     }
 
     if (type == msg_type::append_entries_request) {
-        flying_append_entry_request_.fetch_sub(1);
-        if (!is_streaming()) {
+        if (is_streaming()) {
+            flying_append_entry_request_.fetch_sub(1);
+        } else {
             set_free();
         }
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,17 @@ target_link_libraries(asio_service_stream_test
                       ${BUILD_DIR}/${LIBRARY_OUTPUT_NAME}
                       ${LIBRARIES})
 
+add_executable(asio_stream_test
+               unit/asio_stream_test.cxx
+               ${EXAMPLES_SRC}/logger.cc
+               ${EXAMPLES_SRC}/in_memory_log_store.cxx)
+add_dependencies(asio_stream_test
+                 static_lib
+                 build_ssl_key)
+target_link_libraries(asio_stream_test
+                      ${BUILD_DIR}/${LIBRARY_OUTPUT_NAME}
+                      ${LIBRARIES})
+
 # === Benchmark ===
 add_executable(raft_bench
                bench/raft_bench.cxx

--- a/tests/unit/asio_stream_test.cxx
+++ b/tests/unit/asio_stream_test.cxx
@@ -1,0 +1,166 @@
+/************************************************************************
+Copyright 2017-2019 eBay Inc.
+Author/Developer(s): Jung-Sang Ahn
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+**************************************************************************/
+
+#include "buffer_serializer.hxx"
+#include "debugging_options.hxx"
+#include "in_memory_log_store.hxx"
+#include "raft_package_asio.hxx"
+
+#include "event_awaiter.hxx"
+#include "test_common.h"
+
+#include <unordered_map>
+
+#include <stdio.h>
+
+using namespace nuraft;
+using namespace raft_functional_common;
+
+namespace asio_stream_test {
+
+int launch_servers(const std::vector<RaftAsioPkg*>& pkgs,
+                   bool enable_ssl,
+                   bool use_global_asio = false,
+                   bool use_bg_snapshot_io = true,
+                   const raft_server::init_options & opt = raft_server::init_options())
+{
+    size_t num_srvs = pkgs.size();
+    CHK_GT(num_srvs, 0);
+
+    for (auto& entry: pkgs) {
+        RaftAsioPkg* pp = entry;
+        pp->initServer(enable_ssl, use_global_asio, use_bg_snapshot_io, opt, true);
+        raft_params param = pp->raftServer->get_current_params();
+        param.max_log_gap_in_stream_ = 500;
+        pp->raftServer->update_params(param);
+    }
+    // Wait longer than upper timeout.
+    TestSuite::sleep_sec(1);
+    return 0;
+}
+
+int make_group(const std::vector<RaftAsioPkg*>& pkgs) {
+    size_t num_srvs = pkgs.size();
+    CHK_GT(num_srvs, 0);
+
+    RaftAsioPkg* leader = pkgs[0];
+
+    for (size_t ii = 1; ii < num_srvs; ++ii) {
+        RaftAsioPkg* ff = pkgs[ii];
+
+        // Add to leader.
+        leader->raftServer->add_srv( *(ff->getTestMgr()->get_srv_config()) );
+
+        // Wait longer than upper timeout.
+        TestSuite::sleep_sec(1);
+    }
+    return 0;
+}
+
+static void async_handler(std::list<ulong>* idx_list,
+                          std::mutex* idx_list_lock,
+                          ptr<buffer>& result,
+                          ptr<std::exception>& err)
+{
+    result->pos(0);
+    ulong idx = result->get_ulong();
+    if (idx_list) {
+        std::lock_guard<std::mutex> l(*idx_list_lock);
+        idx_list->push_back(idx);
+    }
+}
+
+int stream_mode_test() {
+    reset_log_files();
+
+    std::string s1_addr = "tcp://127.0.0.1:20010";
+    std::string s2_addr = "tcp://127.0.0.1:20020";
+    std::string s3_addr = "tcp://127.0.0.1:20030";
+
+    RaftAsioPkg s1(1, s1_addr);
+    RaftAsioPkg s2(2, s2_addr);
+    RaftAsioPkg s3(3, s3_addr);
+    std::vector<RaftAsioPkg*> pkgs = {&s1, &s2, &s3};
+
+    _msg("launching asio-raft servers\n");
+    CHK_Z( launch_servers(pkgs, false) );
+
+    _msg("organizing raft group\n");
+    CHK_Z( make_group(pkgs) );
+
+    // Set async.
+    for (auto& entry: pkgs) {
+        RaftAsioPkg* pp = entry;
+        raft_params param = pp->raftServer->get_current_params();
+        param.return_method_ = raft_params::async_handler;
+        pp->raftServer->update_params(param);
+    }
+
+    // Append messages asynchronously.
+    const size_t NUM = 100;
+    std::list< ptr< cmd_result< ptr<buffer> > > > handlers;
+    std::list<ulong> idx_list;
+    std::mutex idx_list_lock;
+    for (size_t ii=0; ii<NUM; ++ii) {
+        std::string test_msg = "test" + std::to_string(ii);
+        ptr<buffer> msg = buffer::alloc(test_msg.size() + 1);
+        msg->put(test_msg);
+        ptr< cmd_result< ptr<buffer> > > ret =
+            s1.raftServer->append_entries( {msg} );
+
+        cmd_result< ptr<buffer> >::handler_type my_handler =
+            std::bind( async_handler,
+                       &idx_list,
+                       &idx_list_lock,
+                       std::placeholders::_1,
+                       std::placeholders::_2 );
+        ret->when_ready( my_handler );
+
+        handlers.push_back(ret);
+    }
+    TestSuite::sleep_sec(1, "replication");
+
+    // Now all async handlers should have result.
+    {
+        std::lock_guard<std::mutex> l(idx_list_lock);
+        CHK_EQ(NUM, idx_list.size());
+    }
+
+    // State machine should be identical.
+    CHK_OK( s2.getTestSm()->isSame( *s1.getTestSm() ) );
+    CHK_OK( s3.getTestSm()->isSame( *s1.getTestSm() ) );
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+    TestSuite::sleep_sec(1, "shutting down");
+
+    SimpleLogger::shutdown();
+    return 0;
+}
+
+}  // namespace asio_stream_test;
+using namespace asio_stream_test;
+
+int main(int argc, char** argv) {
+    TestSuite ts(argc, argv);
+
+    ts.options.printTestMessage = true;
+    ts.doTest( "stream mode test",
+               stream_mode_test );
+    return 0;
+}

--- a/tests/unit/raft_package_asio.hxx
+++ b/tests/unit/raft_package_asio.hxx
@@ -90,7 +90,8 @@ public:
     void initServer(bool enable_ssl = false,
                     bool use_global_asio = false,
                     bool use_bg_snapshot_io = true,
-                    const raft_server::init_options& opt = raft_server::init_options()) {
+                    const raft_server::init_options& opt = raft_server::init_options(),
+                    bool use_stream_asio = false) {
         std::string log_file_name = "./srv" + std::to_string(myId) + ".log";
         myLogWrapper = cs_new<logger_wrapper>(log_file_name);
         myLog = myLogWrapper;
@@ -100,6 +101,10 @@ public:
 
         asio_service::options asio_opt;
         asio_opt.thread_pool_size_  = 4;
+        if (use_stream_asio) {
+            asio_opt.streaming_mode_ = true;
+        }
+        
         if (enable_ssl) {
             asio_opt.enable_ssl_        = enable_ssl;
             asio_opt.verify_sn_         = RaftAsioPkg::verifySn;


### PR DESCRIPTION
  add an additional flag: flying_append_entry_request.
  it is used to present if it is the first request. if streaming is disable in the middle, we can only send the new request when flying request = 0