### PR TITLE
Add a callback to handle misbehaving messages from peer

### DIFF
--- a/include/libnuraft/callback.hxx
+++ b/include/libnuraft/callback.hxx
@@ -18,6 +18,9 @@ limitations under the License.
 #ifndef _CALLBACK_H_
 #define _CALLBACK_H_
 
+#include "req_msg.hxx"
+#include "resp_msg.hxx"
+
 #include <cstdint>
 #include <functional>
 #include <string>
@@ -214,6 +217,18 @@ public:
          * ctx: null.
          */
         FollowerLost = 28,
+
+        /**
+         * When the server receives a misbehaving message from a peer,
+         * the callback has the ability to either ignore the message
+         * or respond normally by adjusting ReqResp.resp as indicated by ctx.
+         *
+         * Furthermore, the callback can opt to terminate
+         * if the situation is deemed critical.
+         *
+         * ctx: pointer to `ReqResp` instance.
+         */
+        ReceivedMisbehavingMessage = 29,
     };
 
     struct Param {
@@ -230,6 +245,12 @@ public:
         int32_t leaderId;
         int32_t peerId;
         void* ctx;
+    };
+
+    struct ReqResp {
+        ReqResp() : req(nullptr), resp(nullptr) {}
+        req_msg* req;
+        ptr<resp_msg> resp;
     };
 
     enum ReturnCode {


### PR DESCRIPTION
* Callback can decide whether to ignore or to die.