### PR TITLE
Support new joiner functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,6 +331,7 @@ if (CODE_COVERAGE GREATER 0)
         strfmt_test
         stat_mgr_test
         logger_test
+        new_joiner_test
     )
 
     # lcov

--- a/include/libnuraft/peer.hxx
+++ b/include/libnuraft/peer.hxx
@@ -99,6 +99,10 @@ public:
         return config_->is_learner();
     }
 
+    bool is_new_joiner() const {
+        return config_->is_new_joiner();
+    }
+
     const srv_config& get_config() {
         return *config_;
     }

--- a/include/libnuraft/raft_params.hxx
+++ b/include/libnuraft/raft_params.hxx
@@ -94,6 +94,7 @@ struct raft_params {
         , return_method_(blocking)
         , auto_forwarding_req_timeout_(0)
         , grace_period_of_lagging_state_machine_(0)
+        , use_new_joiner_type_(false)
         , use_bg_thread_for_snapshot_io_(false)
         , use_full_consensus_among_healthy_members_(false)
         , parallel_log_appending_(false)
@@ -552,6 +553,20 @@ public:
      * not contain the latest data yet) being a leader.
      */
     int32 grace_period_of_lagging_state_machine_;
+
+    /**
+     * If `true`, the new joiner will be added to cluster config as a `new_joiner`
+     * even before syncing all data. The new joiner will not initiate a vote or
+     * participate in leader election.
+     *
+     * Once the log gap becomes smaller than `log_sync_stop_gap_`, the new joiner
+     * will be a regular member.
+     *
+     * The purpose of this featuer is to preserve the new joiner information
+     * even after leader re-election, in order to let the new leader continue
+     * the sync process without calling `add_srv` again.
+     */
+    bool use_new_joiner_type_;
 
     /**
      * (Experimental)

--- a/include/libnuraft/srv_config.hxx
+++ b/include/libnuraft/srv_config.hxx
@@ -41,6 +41,7 @@ public:
         , dc_id_(0)
         , endpoint_(endpoint)
         , learner_(false)
+        , new_joiner_(false)
         , priority_(INIT_PRIORITY)
         {}
 
@@ -55,6 +56,7 @@ public:
         , endpoint_(endpoint)
         , aux_(aux)
         , learner_(learner)
+        , new_joiner_(false)
         , priority_(priority)
         {}
 
@@ -74,6 +76,10 @@ public:
     const std::string& get_aux() const { return aux_; }
 
     bool is_learner() const { return learner_; }
+
+    bool is_new_joiner() const { return new_joiner_; }
+
+    void set_new_joiner(bool to) { new_joiner_ = to; }
 
     int32 get_priority() const { return priority_; }
 
@@ -110,6 +116,12 @@ private:
      * Learner will not initiate or participate in leader election.
      */
     bool learner_;
+
+    /**
+     * `true` if this node is a new joiner, but not yet fully synced.
+     * New joiner will not initiate or participate in leader election.
+     */
+    bool new_joiner_;
 
     /**
      * Priority of this node.

--- a/scripts/test/runtests.sh
+++ b/scripts/test/runtests.sh
@@ -7,5 +7,6 @@ set -e
 ./tests/strfmt_test --abort-on-failure
 ./tests/stat_mgr_test --abort-on-failure
 ./tests/raft_server_test --abort-on-failure
+./tests/new_joiner_test --abort-on-failure
 ./tests/failure_test --abort-on-failure
 ./tests/asio_service_test --abort-on-failure

--- a/src/handle_timeout.cxx
+++ b/src/handle_timeout.cxx
@@ -195,6 +195,7 @@ void raft_server::stop_election_timer() {
         return;
     }
 
+    p_tr("stop election timer");
     cancel_task(election_task_);
 }
 

--- a/src/handle_vote.cxx
+++ b/src/handle_vote.cxx
@@ -254,7 +254,7 @@ void raft_server::request_vote(bool force_vote) {
     for (peer_itor it = peers_.begin(); it != peers_.end(); ++it) {
         ptr<peer> pp = it->second;
         if (!is_regular_member(pp)) {
-            // Do not send voting request to learner.
+            // Do not send voting request to learner or new joiner.
             continue;
         }
         ptr<req_msg> req = cs_new<req_msg>

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -393,6 +393,7 @@ void raft_server::apply_and_log_current_params() {
           "max batch %d, backoff %d, snapshot distance %d, "
           "enable randomized snapshot creation %s, "
           "log sync stop gap %d, "
+          "use new joiner type %s, "
           "reserved logs %d, client timeout %d, "
           "auto forwarding %s, API call type %s, "
           "custom commit quorum size %d, "
@@ -411,6 +412,7 @@ void raft_server::apply_and_log_current_params() {
           params->snapshot_distance_,
           params->enable_randomized_snapshot_creation_ ? "YES" : "NO",
           params->log_sync_stop_gap_,
+          params->use_new_joiner_type_ ? "YES" : "NO",
           params->reserved_log_items_,
           params->client_req_timeout_,
           ( params->auto_forwarding_ ? "ON" : "OFF" ),
@@ -545,6 +547,9 @@ bool raft_server::is_regular_member(const ptr<peer>& p) {
 
     // Skip learner.
     if (p->is_learner()) return false;
+
+    // Skip new joiner.
+    if (p->is_new_joiner()) return false;
 
     return true;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# === Basic Raft server functionality test ===
+# === Basic Raft server functionality tests without real network stack ===
 add_executable(raft_server_test
                unit/raft_server_test.cxx
                unit/fake_network.cxx
@@ -8,6 +8,17 @@ add_dependencies(raft_server_test
                  static_lib)
 target_link_libraries(raft_server_test
                       ${BUILD_DIR}/${LIBRARY_OUTPUT_NAME})
+
+add_executable(new_joiner_test
+               unit/new_joiner_test.cxx
+               unit/fake_network.cxx
+               ${EXAMPLES_SRC}/logger.cc
+               ${EXAMPLES_SRC}/in_memory_log_store.cxx)
+add_dependencies(new_joiner_test
+                 static_lib)
+target_link_libraries(new_joiner_test
+                      ${BUILD_DIR}/${LIBRARY_OUTPUT_NAME})
+
 
 # === Failure recovery & conflict resolution test ===
 add_executable(failure_test

--- a/tests/unit/new_joiner_test.cxx
+++ b/tests/unit/new_joiner_test.cxx
@@ -1,0 +1,379 @@
+/************************************************************************
+Copyright 2017-present eBay Inc.
+Author/Developer(s): Jung-Sang Ahn
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+**************************************************************************/
+
+#include "debugging_options.hxx"
+#include "fake_network.hxx"
+#include "raft_package_fake.hxx"
+
+#include "raft_params.hxx"
+#include "test_common.h"
+
+#include <stdio.h>
+
+using namespace nuraft;
+using namespace raft_functional_common;
+
+using raft_result = cmd_result< ptr<buffer> >;
+
+namespace new_joiner_test {
+
+int append_logs(size_t num_appends,
+                RaftPkg& leader,
+                const std::vector<RaftPkg*>& pkgs)
+{
+    // Append messages asynchronously.
+    std::list< ptr< cmd_result< ptr<buffer> > > > handlers;
+    for (size_t ii = 0; ii < num_appends; ++ii) {
+        std::string test_msg = "test" + std::to_string(ii);
+        ptr<buffer> msg = buffer::alloc(test_msg.size() + 1);
+        msg->put(test_msg);
+        ptr< cmd_result< ptr<buffer> > > ret =
+            leader.raftServer->append_entries( {msg} );
+        CHK_TRUE( ret->get_accepted() );
+        handlers.push_back(ret);
+    }
+
+    // Packet for pre-commit.
+    leader.fNet->execReqResp();
+    // Packet for commit.
+    leader.fNet->execReqResp();
+    // Wait for bg commit.
+    CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+
+    // One more time to make sure.
+    leader.fNet->execReqResp();
+    leader.fNet->execReqResp();
+    CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+
+    return 0;
+}
+
+int add_new_joiner(RaftPkg& leader,
+                   RaftPkg& new_joiner,
+                   const std::vector<RaftPkg*>& pkgs_old,
+                   const std::vector<RaftPkg*>& pkgs_new)
+{
+    // Now add a new member.
+    leader.raftServer->add_srv( *(new_joiner.getTestMgr()->get_srv_config()) );
+
+    // Join req/resp.
+    leader.fNet->execReqResp();
+    // Add new server, notify existing peers.
+    // After getting response, it will make configuration commit.
+    leader.fNet->execReqResp();
+    // Notify new commit.
+    leader.fNet->execReqResp();
+    // Wait for bg commit for configuration change.
+    CHK_Z( wait_for_sm_exec(pkgs_new, COMMIT_TIMEOUT_SEC) );
+
+    // The original members should see S3 as a new joiner.
+    for (auto m: pkgs_old) {
+        CHK_TRUE( m->raftServer->get_srv_config(new_joiner.myId)->is_new_joiner() );
+    }
+
+    return 0;
+}
+
+int basic_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+
+    // Exclude s3 at first.
+    std::vector<RaftPkg*> pkgs_old = {&s1, &s2};
+    std::vector<RaftPkg*> pkgs_new = {&s1, &s2, &s3};
+
+    CHK_Z( launch_servers( pkgs_new ) );
+    CHK_Z( make_group( pkgs_old ) );
+
+    for (auto& entry: pkgs_new) {
+        RaftPkg* pp = entry;
+        raft_params param = pp->raftServer->get_current_params();
+        param.return_method_ = raft_params::async_handler;
+        param.use_new_joiner_type_ = true;
+        pp->raftServer->update_params(param);
+    }
+
+    const size_t NUM = 10;
+    CHK_Z( append_logs(NUM, s1, pkgs_old) );
+    CHK_Z( add_new_joiner(s1, s3, pkgs_old, pkgs_new) );
+
+    // Send snapshot.
+    s1.fTimer->invoke( timer_task_type::heartbeat_timer );
+    for (size_t ii = 0; ii < NUM + 5; ++ii) {
+        s1.fNet->execReqResp();
+    }
+    // Wait for bg commit for configuration change.
+    CHK_Z( wait_for_sm_exec(pkgs_new, COMMIT_TIMEOUT_SEC) );
+    // After getting response, it will make configuration commit.
+    s1.fNet->execReqResp();
+    // Notify new commit.
+    s1.fNet->execReqResp();
+
+    // Now all of them see S3 as a normal member.
+    CHK_FALSE( s1.raftServer->get_srv_config(3)->is_new_joiner() );
+    CHK_FALSE( s2.raftServer->get_srv_config(3)->is_new_joiner() );
+    CHK_FALSE( s3.raftServer->get_srv_config(3)->is_new_joiner() );
+
+    print_stats(pkgs_new);
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+
+    f_base->destroy();
+
+    return 0;
+}
+
+int initiate_vote_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+    std::string s4_addr = "S4";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    RaftPkg s4(f_base, 4, s4_addr);
+
+    // Exclude s3 at first.
+    std::vector<RaftPkg*> pkgs_quorum = {&s1, &s2};
+    std::vector<RaftPkg*> pkgs_old = {&s1, &s2, &s3};
+    std::vector<RaftPkg*> pkgs_new = {&s1, &s2, &s3, &s4};
+
+    CHK_Z( launch_servers( pkgs_new ) );
+    CHK_Z( make_group( pkgs_old ) );
+
+    for (auto& entry: pkgs_new) {
+        RaftPkg* pp = entry;
+        raft_params param = pp->raftServer->get_current_params();
+        param.return_method_ = raft_params::async_handler;
+        param.use_new_joiner_type_ = true;
+
+        // Avoid snapshot.
+        param.reserved_log_items_ = 1000;
+        param.snapshot_distance_ = 1000;
+        pp->raftServer->update_params(param);
+    }
+
+    const size_t NUM = 10;
+    CHK_Z( append_logs(NUM, s1, pkgs_old) );
+    CHK_Z( add_new_joiner(s1, s4, pkgs_old, pkgs_new) );
+
+    // Append more logs, but replicate to S2 only.
+    // It should be able to commit even with 2 servers, as S4 is still new joiner.
+    std::list< ptr< cmd_result< ptr<buffer> > > > handlers;
+    for (size_t ii = 0; ii < NUM; ++ii) {
+        std::string test_msg = "test" + std::to_string(ii);
+        ptr<buffer> msg = buffer::alloc(test_msg.size() + 1);
+        msg->put(test_msg);
+        ptr< cmd_result< ptr<buffer> > > ret =
+            s1.raftServer->append_entries( {msg} );
+        CHK_TRUE( ret->get_accepted() );
+        handlers.push_back(ret);
+    }
+
+    s1.fNet->execReqResp(s2_addr);
+    s1.fNet->execReqResp(s2_addr);
+    CHK_Z( wait_for_sm_exec(pkgs_quorum, COMMIT_TIMEOUT_SEC) );
+
+    s1.fNet->execReqResp(s2_addr);
+    s1.fNet->execReqResp(s2_addr);
+    CHK_Z( wait_for_sm_exec(pkgs_quorum, COMMIT_TIMEOUT_SEC) );
+
+    // Even with 2 servers, all logs should be committed.
+    CHK_EQ( s1.raftServer->get_last_log_idx(),
+            s1.raftServer->get_committed_log_idx() );
+
+    // Replicate logs to S4, up to the first config, but not all.
+    // As a result, S4 will recognize itself as a new joiner,
+    // but still there is a log gap.
+    for (auto& entry: pkgs_new) {
+        RaftPkg* pp = entry;
+        raft_params param = pp->raftServer->get_current_params();
+        param.max_append_size_ = 1;
+        pp->raftServer->update_params(param);
+    }
+
+    s1.fTimer->invoke( timer_task_type::heartbeat_timer );
+    for (size_t ii = 0; ii < NUM + 5; ++ii) {
+        s1.fNet->execReqResp();
+    }
+    CHK_Z( wait_for_sm_exec(pkgs_new, COMMIT_TIMEOUT_SEC) );
+
+    // Initiate election timer for S4, it should do nothing.
+    s4.fTimer->invoke( timer_task_type::election_timer );
+    for (const auto& endpoint: {s1_addr, s2_addr, s3_addr}) {
+        CHK_Z( s4.fNet->getNumPendingReqs(endpoint) );
+    }
+    CHK_Z( s4.fTimer->getNumPendingTasks() );
+
+    // Initiate election timer for S3, it should start election,
+    // but it should not send vote request to S4.
+    s3.fTimer->invoke( timer_task_type::election_timer );
+    CHK_Z( s3.fNet->getNumPendingReqs(s4_addr) );
+
+    s2.fTimer->invoke( timer_task_type::election_timer );
+    CHK_Z( s2.fNet->getNumPendingReqs(s4_addr) );
+
+    // Leader election should succeed by only vote from S2.
+    s3.fNet->execReqResp(s2_addr);
+    s3.fNet->execReqResp(s2_addr);
+    CHK_Z( wait_for_sm_exec(pkgs_new, COMMIT_TIMEOUT_SEC) );
+
+    s3.fNet->execReqResp(s2_addr);
+    s3.fNet->execReqResp(s2_addr);
+    CHK_Z( wait_for_sm_exec(pkgs_new, COMMIT_TIMEOUT_SEC) );
+
+    CHK_TRUE( s3.raftServer->is_leader() );
+    CHK_EQ(3, s2.raftServer->get_leader() );
+
+    print_stats(pkgs_new);
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+
+    f_base->destroy();
+
+    return 0;
+}
+
+int new_joiner_take_over_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+    std::string s4_addr = "S4";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    RaftPkg s4(f_base, 4, s4_addr);
+
+    // Exclude s3 at first.
+    std::vector<RaftPkg*> pkgs_quorum = {&s1, &s2};
+    std::vector<RaftPkg*> pkgs_old = {&s1, &s2, &s3};
+    std::vector<RaftPkg*> pkgs_new = {&s1, &s2, &s3, &s4};
+
+    CHK_Z( launch_servers( pkgs_new ) );
+    CHK_Z( make_group( pkgs_old ) );
+
+    for (auto& entry: pkgs_new) {
+        RaftPkg* pp = entry;
+        raft_params param = pp->raftServer->get_current_params();
+        param.return_method_ = raft_params::async_handler;
+        param.use_new_joiner_type_ = true;
+        pp->raftServer->update_params(param);
+    }
+
+    // Setting it to 8, as 10 makes the last config index 15.
+    const size_t NUM = 8;
+    CHK_Z( append_logs(NUM, s1, pkgs_old) );
+    CHK_Z( add_new_joiner(s1, s4, pkgs_old, pkgs_new) );
+
+    // Now S3 takes over the leadership.
+    s2.fTimer->invoke( timer_task_type::election_timer );
+    s3.fTimer->invoke( timer_task_type::election_timer );
+
+    s3.fNet->execReqResp();
+    s3.fNet->execReqResp();
+    CHK_Z( wait_for_sm_exec(pkgs_new, COMMIT_TIMEOUT_SEC) );
+
+    s3.fNet->execReqResp();
+    s3.fNet->execReqResp();
+    CHK_Z( wait_for_sm_exec(pkgs_new, COMMIT_TIMEOUT_SEC) );
+
+    // S3 takes over the new joiner and send snapshot.
+    s3.fTimer->invoke( timer_task_type::heartbeat_timer );
+    for (size_t ii = 0; ii < NUM + 5; ++ii) {
+        s3.fNet->execReqResp();
+    }
+    // Wait for bg commit for configuration change.
+    CHK_Z( wait_for_sm_exec(pkgs_new, COMMIT_TIMEOUT_SEC) );
+    // After getting response, it will make configuration commit.
+    s3.fNet->execReqResp();
+    // Notify new commit.
+    s3.fNet->execReqResp();
+
+    // Now all of them see S4 as a normal member.
+    for (auto& ss: pkgs_new) {
+        TestSuite::setInfo("server id %d", ss->myId);
+        CHK_FALSE( ss->raftServer->get_srv_config(4)->is_new_joiner() );
+    }
+
+    print_stats(pkgs_new);
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+
+    f_base->destroy();
+
+    return 0;
+}
+
+}  // namespace new_joiner_test;
+using namespace new_joiner_test;
+
+int main(int argc, char** argv) {
+    TestSuite ts(argc, argv);
+
+    ts.options.printTestMessage = true;
+
+    // Disable reconnection timer for deterministic test.
+    debugging_options::get_instance().disable_reconn_backoff_ = true;
+
+    ts.doTest( "basic test",
+               basic_test );
+
+    ts.doTest( "initiate vote test",
+               initiate_vote_test );
+
+    ts.doTest( "new joiner take over test",
+               new_joiner_take_over_test );
+
+#ifdef ENABLE_RAFT_STATS
+    _msg("raft stats: ENABLED\n");
+#else
+    _msg("raft stats: DISABLED\n");
+#endif
+    _msg("num allocs: %zu\n"
+         "amount of allocs: %zu bytes\n"
+         "num active buffers: %zu\n"
+         "amount of active buffers: %zu bytes\n",
+         raft_server::get_stat_counter("num_buffer_allocs"),
+         raft_server::get_stat_counter("amount_buffer_allocs"),
+         raft_server::get_stat_counter("num_active_buffers"),
+         raft_server::get_stat_counter("amount_active_buffers"));
+
+    return 0;
+}
+


### PR DESCRIPTION
* A new setting, `use_new_joiner_type_`, has been introduced, which defaults to false.

* When activated, any new members are immediately added to the cluster configuration as a "new joiner." Similar to learners, new joiners do not participate in the quorum; they cannot initiate or partake in voting.

* Once the log gap of a new joiner narrows to less than `log_sync_stop_gap_`, the member transitions to a regular status and becomes eligible to engage in the leader election process.

* The advantage of this feature is that it allows a newly elected leader to continue the synchronization process with the new joiner without needing to invoke the `add_srv()` API again.