### PR TITLE
give a chance for the last obj to retry

### DIFF
--- a/include/libnuraft/state_machine.hxx
+++ b/include/libnuraft/state_machine.hxx
@@ -200,13 +200,20 @@ public:
      *     this parameter.
      * @param data Payload of given object.
      * @param is_first_obj `true` if this is the first object.
-     * @param is_last_obj `true` if this is the last object.
+     * @param is_last_obj[in,out] 
+     *     when [in]
+     *     `true` if this is the last object indicated by the sender.
+     * 
+     *     when [out]
+     *     As a result of this API call, if the receiver wants the sender 
+     *     to resend the last object, it should set this parameter to `false`，
+     *     so that apply_snapshot() will not be called.
      */
     virtual void save_logical_snp_obj(snapshot& s,
                                       ulong& obj_id,
                                       buffer& data,
                                       bool is_first_obj,
-                                      bool is_last_obj) {}
+                                      bool& is_last_obj) {}
 
     /**
      * Apply received snapshot to state machine.


### PR DESCRIPTION
when install snapshot happens , if something off (for example, data crc mismatch)happens to the last obj, we have no chance to ask leader to resend the last obj, since https://github.com/eBay/NuRaft/blob/99eeef34a2620686e0dd40ad7fbd5cab561140fc/src/handle_snapshot_sync.cxx#L520 will definitely apply_snapshot when is_last_obj is true.

this change give a chance for follower to ask leader to resend the last obj. for example , if follower find the data crc mismatch, it can set is_last_obj to false , which means this is not the last obj the follower wants. meanwhile , follower can set obj_id to the last_obj_id, so that leader will resend the last obj to follower