### PR TITLE
Fix race on precommit when cluster is changed

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -1459,7 +1459,7 @@ protected:
     /**
      * Lock of handling client request and role change.
      */
-    std::mutex cli_lock_;
+    std::recursive_mutex cli_lock_;
 
     /**
      * Condition variable to invoke BG commit thread.

--- a/src/handle_client_request.cxx
+++ b/src/handle_client_request.cxx
@@ -51,7 +51,7 @@ ptr<resp_msg> raft_server::handle_cli_req_prelock(req_msg& req,
         case raft_params::dual_mutex:
         default: {
             // TODO: Use RW lock here.
-            auto_lock(cli_lock_);
+            recur_lock(cli_lock_);
             resp = handle_cli_req(req, ext_params, timestamp_us);
             break;
         }


### PR DESCRIPTION
On config changes, the precommit index will be updated instantly to index of config change.
After it, `request_append_entries` is called which instantly commits up to `precommit` index if a node was removed from 2-node cluster.
If logs were being applied at the same time it could lead to commit thread trying to commit logs that were still not precommitted.
I couldn't find another explanation for such scenario.
If my conclusions are wrong feel free to correct me. :pray: 
I also couldn't find a better way to fix it quickly.