### PR TITLE
Fix data race in asio service

### DIFF
--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -1462,6 +1462,15 @@ private:
             asio::ip::tcp::resolver::iterator itor ) -> void
         {
             if (!err) {
+                if (send_timeout_ms != 0) {
+                    operation_timer_.expires_after
+                    ( std::chrono::duration_cast<std::chrono::nanoseconds>
+                      ( std::chrono::milliseconds( send_timeout_ms ) ) );
+                    operation_timer_.async_wait(
+                        std::bind( &asio_rpc_client::cancel_socket,
+                                   this,
+                                   std::placeholders::_1 ) );
+                }
                 asio::async_connect
                     ( socket(),
                       itor,
@@ -1472,15 +1481,6 @@ private:
                                  send_timeout_ms,
                                  std::placeholders::_1,
                                  std::placeholders::_2 ) );
-                if (send_timeout_ms != 0) {
-                    operation_timer_.expires_after
-                    ( std::chrono::duration_cast<std::chrono::nanoseconds>
-                      ( std::chrono::milliseconds( send_timeout_ms ) ) );
-                    operation_timer_.async_wait(
-                        std::bind( &asio_rpc_client::cancel_socket,
-                                   this,
-                                   std::placeholders::_1 ) );
-                }
             } else {
                 std::string err_msg = lstrfmt("failed to resolve host %s "
                                               "due to error %d, %s")


### PR DESCRIPTION
We detected a data race with one of our tests
https://pastila.nl/?0003c12b/68530aca8742766996176fdebcede8dc#KBCq01QCyL4Qz2lDbsNzrA==

It's insanely hard to parse all that asio stacktrace but the race happens on `operation_timer_` inside `async_resolve` callback.
My theory is that `async_connect` got resolved and had its callback called before we setup the timer and started it.
So the problem should be solved with moving timer setup before we start the `async_connect`.

Now for the general issue.
Asio in NuRaft is run with a single io context on multiple threads. This can lead to data races in general (e.g. timer calls `socket.cancel()`). I'm not sure if `cancel` on socket is threadsafe (I assume it's not) but to avoid similar problems shouldn't `strand` be used for a single `asio_rpc_client`?
If you think I misunderstood something or there is a simpler solution, I'm open for discussion.
If not, I can introduce `strand` for the client.