### PR TITLE
Do `system_exit` on recurring pre-vote failure due to busy connection

### DIFF
--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -1102,7 +1102,7 @@ void raft_server::become_leader() {
     next_leader_candidate_ = -1;
     initialized_ = true;
     pre_vote_.quorum_reject_count_ = 0;
-    pre_vote_.failure_count_ = 0;
+    pre_vote_.no_response_failure_count_ = 0;
     data_fresh_ = true;
 
     request_append_entries();
@@ -1418,7 +1418,7 @@ void raft_server::become_follower() {
         initialized_ = true;
         uncommitted_config_.reset();
         pre_vote_.quorum_reject_count_ = 0;
-        pre_vote_.failure_count_ = 0;
+        pre_vote_.no_response_failure_count_ = 0;
 
         ptr<raft_params> params = ctx_->get_params();
         if ( params->auto_adjust_quorum_for_small_cluster_ &&


### PR DESCRIPTION
* If a connection is stuck due to a network black hole or similar issues, the sender may not receive either a response to the previous request or an explicit error, preventing any progress through that connection.

* Such situations are unlikely to resolve on their own, and sometimes restarting the process is the only solution. If the connection remains busy beyond a certain threshold, `system_exit` will be invoked with `N22_unrecoverable_isolation`.