### PR TITLE
Fix: The snapshot installation blindly applies config to the server.

### DIFF
--- a/src/handle_snapshot_sync.cxx
+++ b/src/handle_snapshot_sync.cxx
@@ -572,6 +572,15 @@ bool raft_server::handle_snapshot_sync_req(snapshot_sync_req& req, std::unique_l
                 ctx_->state_mgr_->save_config(*snap_conf);
                 reconfigure(snap_conf);
                 c_conf = get_config();
+            } else {
+                p_in("snapshot config idx %" PRIu64 " prev idx %" PRIu64
+                     " is not newer than "
+                     "current config idx %" PRIu64 " prev idx %" PRIu64
+                     ", will not apply it",
+                     snap_conf->get_log_idx(),
+                     snap_conf->get_prev_log_idx(),
+                     c_conf->get_log_idx(),
+                     c_conf->get_prev_log_idx());
             }
 
             precommit_index_ = req.get_snapshot().get_last_log_idx();

--- a/src/handle_snapshot_sync.cxx
+++ b/src/handle_snapshot_sync.cxx
@@ -568,9 +568,9 @@ bool raft_server::handle_snapshot_sync_req(snapshot_sync_req& req, std::unique_l
 
             auto snap_conf = req.get_snapshot().get_last_config();
             ptr<cluster_config> c_conf = get_config();
-            if (snap_conf->get_log_idx() > get_config()->get_log_idx()) {
+            if (snap_conf->get_log_idx() > c_conf->get_log_idx()) {
                 ctx_->state_mgr_->save_config(*snap_conf);
-                reconfigure(req.get_snapshot().get_last_config());
+                reconfigure(snap_conf);
                 c_conf = get_config();
             }
 

--- a/src/handle_snapshot_sync.cxx
+++ b/src/handle_snapshot_sync.cxx
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include "raft_server.hxx"
 
+#include "cluster_config.hxx"
 #include "context.hxx"
 #include "error_code.hxx"
 #include "event_awaiter.hxx"
@@ -565,10 +566,13 @@ bool raft_server::handle_snapshot_sync_req(snapshot_sync_req& req, std::unique_l
                 // LCOV_EXCL_STOP
             }
 
-            reconfigure(req.get_snapshot().get_last_config());
-
+            auto snap_conf = req.get_snapshot().get_last_config();
             ptr<cluster_config> c_conf = get_config();
-            ctx_->state_mgr_->save_config(*c_conf);
+            if (snap_conf->get_log_idx() > get_config()->get_log_idx()) {
+                ctx_->state_mgr_->save_config(*snap_conf);
+                reconfigure(req.get_snapshot().get_last_config());
+                c_conf = get_config();
+            }
 
             precommit_index_ = req.get_snapshot().get_last_log_idx();
             sm_commit_index_ = req.get_snapshot().get_last_log_idx();


### PR DESCRIPTION
If the server was previously in the member set which was captured in the config of this snapshot, then the peer will appear to have "caught_up" in ::reconfigure. I do not believe there is value in rolling back the config just to reapply it later once log_sync occurs. `::commit_conf` performs a similar check.