### PR TITLE
Fix bugs in streaming mode

### DIFF
--- a/include/libnuraft/peer.hxx
+++ b/include/libnuraft/peer.hxx
@@ -66,6 +66,7 @@ public:
         , network_recoveries_(0)
         , manual_free_(false)
         , rpc_errs_(0)
+        , stale_rpc_responses_(0)
         , last_sent_idx_(0)
         , cnt_not_applied_(0)
         , leave_requested_(false)
@@ -259,6 +260,10 @@ public:
     void reset_rpc_errs()   { rpc_errs_ = 0; }
     void inc_rpc_errs()     { rpc_errs_.fetch_add(1); }
     int32 get_rpc_errs()    { return rpc_errs_; }
+
+    void reset_stale_rpc_responses()    { stale_rpc_responses_ = 0; }
+    int32_t inc_stale_rpc_responses()   { return stale_rpc_responses_.fetch_add(1); }
+    int32_t get_stale_rpc_responses()   { return stale_rpc_responses_; }
 
     void set_last_sent_idx(ulong to)    { last_sent_idx_ = to; }
     ulong get_last_sent_idx() const     { return last_sent_idx_.load(); }
@@ -489,6 +494,11 @@ private:
      * For tracking RPC error.
      */
     std::atomic<int32> rpc_errs_;
+
+    /**
+     * For tracking stale RPC responses from the old client.
+     */
+    std::atomic<int32> stale_rpc_responses_;
 
     /**
      * Start log index of the last sent append entries request.

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -1166,7 +1166,12 @@ void raft_server::handle_append_entries_resp(resp_msg& resp) {
               resp.get_next_idx(), p->get_next_log_idx() );
 
         // disable stream
+        uint64_t last_streamed_log_idx = p->get_last_streamed_log_idx();
         p->reset_stream();
+        if (last_streamed_log_idx) {
+            p_in("stop stream mode for peer %d at idx: %" PRIu64 "",
+                 p->get_id(), last_streamed_log_idx);
+        }
     }
 
     if (!config_changing_ && p->get_config().is_new_joiner()) {

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -403,7 +403,8 @@ void raft_server::apply_and_log_current_params() {
           "leadership transfer wait time %d, "
           "grace period of lagging state machine %d, "
           "snapshot IO: %s, "
-          "parallel log appending: %s",
+          "parallel log appending: %s, "
+          "streaming mode max log gap %d, max bytes %" PRIu64,
           params->election_timeout_lower_bound_,
           params->election_timeout_upper_bound_,
           params->heart_beat_interval_,
@@ -425,7 +426,9 @@ void raft_server::apply_and_log_current_params() {
           params->leadership_transfer_min_wait_time_,
           params->grace_period_of_lagging_state_machine_,
           params->use_bg_thread_for_snapshot_io_ ? "ASYNC" : "BLOCKING",
-          params->parallel_log_appending_ ? "ON" : "OFF" );
+          params->parallel_log_appending_ ? "ON" : "OFF",
+          params->max_log_gap_in_stream_,
+          params->max_bytes_in_flight_in_stream_ );
 
     status_check_timer_.set_duration_ms(params->heart_beat_interval_);
     status_check_timer_.reset();


### PR DESCRIPTION
* If connection is suddenly closed before handling the response, queue may become empty when a callback function is invoked. It should be handled safely.

* Added more logs regarding streaming mode.