### PR TITLE
Support external thread pool

### DIFF
--- a/include/libnuraft/asio_service_options.hxx
+++ b/include/libnuraft/asio_service_options.hxx
@@ -27,9 +27,9 @@ limitations under the License.
 typedef struct ssl_ctx_st SSL_CTX;
 
 #ifdef USE_BOOST_ASIO
-namespace boost::asio {
+namespace boost { namespace asio {
     class io_context;
-}
+} }
 #else
 namespace asio {
     class io_context;

--- a/include/libnuraft/asio_service_options.hxx
+++ b/include/libnuraft/asio_service_options.hxx
@@ -26,6 +26,16 @@ limitations under the License.
 
 typedef struct ssl_ctx_st SSL_CTX;
 
+#ifdef USE_BOOST_ASIO
+namespace boost::asio {
+    class io_context;
+}
+#else
+namespace asio {
+    class io_context;
+}
+#endif
+
 namespace nuraft {
 
 class buffer;
@@ -126,6 +136,7 @@ struct asio_service_options {
         , crc_on_payload_(false)
         , corrupted_msg_handler_(nullptr)
         , streaming_mode_(false)
+        , custom_io_context_(nullptr)
         {}
 
     /**
@@ -284,6 +295,17 @@ struct asio_service_options {
      * The order of responses will be identical to the order of requests.
      */
     bool streaming_mode_;
+
+    /**
+     * If given, it will disable the internal thread pool but instead
+     * rely on the external thread pool. The user is responsible for
+     * managing the thread pool, as well as handling the async tasks and timers.
+     */
+#ifdef USE_BOOST_ASIO
+    boost::asio::io_context* custom_io_context_;
+#else
+    asio::io_context* custom_io_context_;
+#endif
 };
 
 }

--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -200,7 +200,12 @@ public:
     ~asio_service_impl();
 
     const asio_service::options& get_options() const { return my_opt_; }
-    asio::io_service& get_io_svc() { return io_svc_; }
+    asio::io_service& get_io_svc() {
+        if (my_opt_.custom_io_context_) {
+            return *my_opt_.custom_io_context_;
+        }
+        return *io_svc_;
+    }
     uint64_t assign_client_id() { return client_id_counter_.fetch_add(1); }
 
 private:
@@ -213,10 +218,9 @@ private:
     void timer_handler(ERROR_CODE err);
 
 private:
-    asio::io_service io_svc_;
+    std::unique_ptr<asio::io_service> io_svc_;
     ssl_context ssl_server_ctx_;
     ssl_context ssl_client_ctx_;
-    asio::steady_timer asio_timer_;
     std::atomic_int continue_;
     std::atomic<uint8_t> stopping_status_;
     std::mutex stopping_lock_;
@@ -225,6 +229,7 @@ private:
     std::atomic<uint32_t> worker_id_;
     std::list< ptr<std::thread> > worker_handles_;
     asio_service::options my_opt_;
+    asio::steady_timer asio_timer_;
     std::atomic<uint64_t> client_id_counter_;
     ptr<logger> l_;
     friend asio_service;
@@ -1458,11 +1463,11 @@ private:
                           uint64_t send_timeout_ms) {
 
         resolver_.async_resolve
-        ( 
-            host, 
-            port, 
+        (
+            host,
+            port,
             asio::ip::tcp::resolver::flags::all_matching,
-            [self, this, req, when_done, host, port, send_timeout_ms]( 
+            [self, this, req, when_done, host, port, send_timeout_ms](
                 const std::error_code& err,
                 asio::ip::tcp::resolver::results_type endpoints ) -> void
         {
@@ -2036,28 +2041,28 @@ ssl_context get_or_create_ssl_context(std::function<SSL_CTX* (void)> ctx_provide
 
 #endif
 
-asio_service_impl::asio_service_impl(const asio_service::options& _opt,
+asio_service_impl::asio_service_impl(const asio_service::options& opt,
                                      ptr<logger> l)
-    : io_svc_()
+    : io_svc_(opt.custom_io_context_ ? nullptr : (new asio::io_context()))
 #if (ASIO_VERSION >= 101601) && \
     (OPENSSL_VERSION_NUMBER >= 0x10100000L) && \
     !defined(LIBRESSL_VERSION_NUMBER)
-    , ssl_server_ctx_(get_or_create_ssl_context(_opt.ssl_context_provider_server_,
+    , ssl_server_ctx_(get_or_create_ssl_context(opt.ssl_context_provider_server_,
                                                 DEFAULT_SERVER_CTX))
-    , ssl_client_ctx_(get_or_create_ssl_context(_opt.ssl_context_provider_client_,
+    , ssl_client_ctx_(get_or_create_ssl_context(opt.ssl_context_provider_client_,
                                                 DEFAULT_CLIENT_CTX))
 #else
     , ssl_server_ctx_(DEFAULT_SERVER_CTX)  // Any version
     , ssl_client_ctx_(DEFAULT_CLIENT_CTX)
 #endif
-    , asio_timer_(io_svc_)
     , continue_(1)
     , stopping_status_(0)
     , stopping_lock_()
     , stopping_cv_()
     , num_active_workers_(0)
     , worker_id_(0)
-    , my_opt_(_opt)
+    , my_opt_(opt)
+    , asio_timer_(get_io_svc())
     , client_id_counter_(1)
     , l_(l)
 {
@@ -2067,7 +2072,7 @@ asio_service_impl::asio_service_impl(const asio_service::options& _opt,
 #else
 
         // Provider gives properly configured server contex
-        if (!_opt.ssl_context_provider_server_) {
+        if (!my_opt_.ssl_context_provider_server_) {
             p_in("server SSL context method %d", DEFAULT_SERVER_CTX);
 
             // For server (listener)
@@ -2080,23 +2085,30 @@ asio_service_impl::asio_service_impl(const asio_service::options& _opt,
                                          std::placeholders::_1,
                                          std::placeholders::_2 ) );
             ssl_server_ctx_.use_certificate_chain_file
-                            ( _opt.server_cert_file_ );
-            ssl_server_ctx_.use_private_key_file( _opt.server_key_file_,
+                            ( my_opt_.server_cert_file_ );
+            ssl_server_ctx_.use_private_key_file( my_opt_.server_key_file_,
                                                   ssl_context::pem );
         } else {
             p_in("custom server SSL context is given");
         }
 
         // Provider gives properly configured client contex
-        if (!_opt.ssl_context_provider_client_) {
+        if (!my_opt_.ssl_context_provider_client_) {
             p_in("client SSL context method %d", DEFAULT_CLIENT_CTX);
 
             // For client
-            ssl_client_ctx_.load_verify_file(_opt.root_cert_file_);
+            ssl_client_ctx_.load_verify_file(my_opt_.root_cert_file_);
         } else {
             p_in("custom client SSL context is given");
         }
 #endif
+    }
+
+    if (my_opt_.custom_io_context_) {
+        // If the external io_context is provided, we should not create
+        // internal threads.
+        p_in("custom io_context is provided, thread pool will not be created");
+        return;
     }
 
     // set expires_after to a very large value so that
@@ -2109,7 +2121,7 @@ asio_service_impl::asio_service_impl(const asio_service::options& _opt,
                      this,
                      std::placeholders::_1 ) );
 
-    unsigned int cpu_cnt = _opt.thread_pool_size_;
+    unsigned int cpu_cnt = my_opt_.thread_pool_size_;
     if (!cpu_cnt) {
         cpu_cnt = std::thread::hardware_concurrency();
     }
@@ -2153,6 +2165,10 @@ void asio_service_impl::worker_entry() {
     pthread_setname_np(thread_name.c_str());
 #endif
 
+    p_in("spawned asio worker thread %s, current threads: %u",
+         thread_name.c_str(),
+         num_active_workers_.load());
+
     if (my_opt_.worker_start_) {
         my_opt_.worker_start_(worker_id);
     }
@@ -2164,7 +2180,7 @@ void asio_service_impl::worker_entry() {
     do {
         try {
             num_active_workers_.fetch_add(1);
-            io_svc_.run();
+            get_io_svc().run();
             num_active_workers_.fetch_sub(1);
 
         } catch (std::exception& ee) {
@@ -2199,7 +2215,8 @@ void asio_service_impl::worker_entry() {
         my_opt_.worker_stop_(worker_id);
     }
 
-    p_in("end of asio worker thread, remaining threads: %u",
+    p_in("end of asio worker thread %s, remaining threads: %u",
+         thread_name.c_str(),
          num_active_workers_.load());
 }
 
@@ -2225,6 +2242,13 @@ void asio_service_impl::timer_handler(ERROR_CODE err) {
 }
 
 void asio_service_impl::stop() {
+    if (my_opt_.custom_io_context_) {
+        // If custom io_context is provided, nothing to do here.
+        p_in("custom io_context is provided, no need to stop the asio service "
+             "and worker threads");
+        return;
+    }
+
     int running = 1;
     if (continue_.compare_exchange_strong(running, 0)) {
         std::unique_lock<std::mutex> lock(stopping_lock_);
@@ -2241,8 +2265,8 @@ void asio_service_impl::stop() {
     // Stop all workers.
     stopping_status_ = 1;
 
-    io_svc_.stop();
-    while (!io_svc_.stopped()) {
+    get_io_svc().stop();
+    while (!get_io_svc().stopped()) {
         std::this_thread::yield();
     }
 
@@ -2264,7 +2288,7 @@ asio_service::~asio_service() {
 
 void asio_service::schedule(ptr<delayed_task>& task, int32 milliseconds) {
     if (task->get_impl_context() == nilptr) {
-        task->set_impl_context( new asio::steady_timer(impl_->io_svc_),
+        task->set_impl_context( new asio::steady_timer(impl_->get_io_svc()),
                                 &_free_timer_ );
     }
     // ensure it's not in cancelled state
@@ -2335,7 +2359,7 @@ ptr<rpc_client> asio_service::create_client(const std::string& endpoint) {
 
     return cs_new< asio_rpc_client >
                  ( impl_,
-                   impl_->io_svc_,
+                   impl_->get_io_svc(),
                    impl_->ssl_client_ctx_,
                    hostname,
                    port,
@@ -2349,7 +2373,7 @@ ptr<rpc_listener> asio_service::create_rpc_listener( ushort listening_port,
     try {
         return cs_new< asio_rpc_listener >
                      ( impl_,
-                       impl_->io_svc_,
+                       impl_->get_io_svc(),
                        impl_->ssl_server_ctx_,
                        listening_port,
                        impl_->my_opt_.enable_ssl_,

--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -40,9 +40,9 @@ limitations under the License.
 
 #ifdef USE_BOOST_ASIO
     #include <boost/asio.hpp>
-    namespace boost::asio {
+    namespace boost { namespace asio {
         using io_service = io_context;
-    }
+    } }
     using namespace boost;
     #define ERROR_CODE system::error_code
 

--- a/tests/unit/asio_service_test.cxx
+++ b/tests/unit/asio_service_test.cxx
@@ -23,6 +23,13 @@ limitations under the License.
 #include "event_awaiter.hxx"
 #include "test_common.h"
 
+#ifdef USE_BOOST_ASIO
+    #include <boost/asio.hpp>
+    using namespace boost;
+#else
+    #include <asio.hpp>
+#endif
+
 #include <unordered_map>
 
 #include <stdio.h>
@@ -2867,6 +2874,108 @@ int log_timestamp_test() {
     return 0;
 }
 
+int custom_io_context_test() {
+    reset_log_files();
+
+    std::string s1_addr = "tcp://127.0.0.1:20010";
+    std::string s2_addr = "tcp://127.0.0.1:20020";
+    std::string s3_addr = "tcp://127.0.0.1:20030";
+
+    asio::io_context custom_io_context;
+    asio::steady_timer custom_timer(custom_io_context);
+    custom_timer.expires_after(std::chrono::seconds(3600));
+    custom_timer.async_wait([](const asio::error_code& ec) {
+        if (ec) {
+            TestSuite::_msg("custom timer error: %s\n", ec.message().c_str());
+        } else {
+            TestSuite::_msg("custom timer expired\n");
+        }
+    });
+
+    RaftAsioPkg s1(1, s1_addr);
+    RaftAsioPkg s2(2, s2_addr);
+    RaftAsioPkg s3(3, s3_addr);
+    std::vector<RaftAsioPkg*> pkgs = {&s1, &s2, &s3};
+
+    s1.customIoContext = s2.customIoContext = s3.customIoContext = &custom_io_context;
+    auto custom_worker = [&]() {
+        TestSuite::_msg("custom worker spawned\n");
+        custom_io_context.run();
+        TestSuite::_msg("custom worker finished\n");
+    };
+    // Create 6 workers.
+    std::vector<std::thread> workers;
+    for (size_t ii = 0; ii < 6; ++ii) {
+        workers.emplace_back(custom_worker);
+    }
+
+    _msg("launching asio-raft servers\n");
+    CHK_Z( launch_servers(pkgs, false) );
+
+    _msg("organizing raft group\n");
+    CHK_Z( make_group(pkgs) );
+
+    // Set async.
+    for (auto& entry: pkgs) {
+        RaftAsioPkg* pp = entry;
+        raft_params param = pp->raftServer->get_current_params();
+        param.return_method_ = raft_params::async_handler;
+        pp->raftServer->update_params(param);
+    }
+
+    // Append messages asynchronously.
+    const size_t NUM = 10;
+    std::list< ptr< cmd_result< ptr<buffer> > > > handlers;
+    std::list<ulong> idx_list;
+    std::mutex idx_list_lock;
+    for (size_t ii=0; ii<NUM; ++ii) {
+        std::string test_msg = "test" + std::to_string(ii);
+        ptr<buffer> msg = buffer::alloc(test_msg.size() + 1);
+        msg->put(test_msg);
+        ptr< cmd_result< ptr<buffer> > > ret =
+            s1.raftServer->append_entries( {msg} );
+
+        cmd_result< ptr<buffer> >::handler_type my_handler =
+            std::bind( async_handler,
+                       &idx_list,
+                       &idx_list_lock,
+                       std::placeholders::_1,
+                       std::placeholders::_2 );
+        ret->when_ready( my_handler );
+
+        handlers.push_back(ret);
+    }
+    TestSuite::sleep_sec(1, "replication");
+
+    // Now all async handlers should have result.
+    {
+        std::lock_guard<std::mutex> l(idx_list_lock);
+        CHK_EQ(NUM, idx_list.size());
+    }
+
+    // State machine should be identical.
+    CHK_OK( s2.getTestSm()->isSame( *s1.getTestSm() ) );
+    CHK_OK( s3.getTestSm()->isSame( *s1.getTestSm() ) );
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+
+    custom_io_context.stop();
+    while (!custom_io_context.stopped()) {
+        TestSuite::sleep_sec(1, "waiting for io_context to stop");
+    }
+    for (auto& worker: workers) {
+        worker.join();
+    }
+
+    TestSuite::sleep_sec(1, "shutting down");
+
+    SimpleLogger::shutdown();
+    return 0;
+}
+
+
 }  // namespace asio_service_test;
 using namespace asio_service_test;
 
@@ -2982,6 +3091,9 @@ int main(int argc, char** argv) {
 
     ts.doTest( "log timestamp test",
                log_timestamp_test );
+
+    ts.doTest( "custom io_context test",
+               custom_io_context_test );
 
 #ifdef ENABLE_RAFT_STATS
     _msg("raft stats: ENABLED\n");

--- a/tests/unit/asio_service_test.cxx
+++ b/tests/unit/asio_service_test.cxx
@@ -26,8 +26,10 @@ limitations under the License.
 #ifdef USE_BOOST_ASIO
     #include <boost/asio.hpp>
     using namespace boost;
+    using asio_error_code = system::error_code;
 #else
     #include <asio.hpp>
+    using asio_error_code = asio::error_code;
 #endif
 
 #include <unordered_map>
@@ -2884,7 +2886,7 @@ int custom_io_context_test() {
     asio::io_context custom_io_context;
     asio::steady_timer custom_timer(custom_io_context);
     custom_timer.expires_after(std::chrono::seconds(3600));
-    custom_timer.async_wait([](const asio::error_code& ec) {
+    custom_timer.async_wait([](const asio_error_code& ec) {
         if (ec) {
             TestSuite::_msg("custom timer error: %s\n", ec.message().c_str());
         } else {

--- a/tests/unit/raft_package_asio.hxx
+++ b/tests/unit/raft_package_asio.hxx
@@ -55,6 +55,7 @@ public:
         , useCustomResolver(false)
         , useLogTimestamp(false)
         , useCrcOnEntireMessage(false)
+        , customIoContext(nullptr)
         , myLogWrapper(nullptr)
         , myLog(nullptr)
         {}
@@ -104,7 +105,7 @@ public:
         if (use_stream_asio) {
             asio_opt.streaming_mode_ = true;
         }
-        
+
         if (enable_ssl) {
             asio_opt.enable_ssl_        = enable_ssl;
             asio_opt.verify_sn_         = RaftAsioPkg::verifySn;
@@ -149,6 +150,9 @@ public:
         asio_opt.invoke_req_cb_on_empty_meta_ = alwaysInvokeCb;
         asio_opt.invoke_resp_cb_on_empty_meta_ = alwaysInvokeCb;
 
+        if (customIoContext) {
+            asio_opt.custom_io_context_ = customIoContext;
+        }
         asioSvc = use_global_asio
                   ? nuraft_global_mgr::init_asio_service(asio_opt, myLog)
                   : cs_new<asio_service>(asio_opt, myLog);
@@ -282,6 +286,8 @@ public:
     bool useLogTimestamp;
 
     bool useCrcOnEntireMessage;
+
+    asio::io_context* customIoContext;
 
     ptr<logger_wrapper> myLogWrapper;
     ptr<logger> myLog;

--- a/tests/unit/raft_package_asio.hxx
+++ b/tests/unit/raft_package_asio.hxx
@@ -287,7 +287,11 @@ public:
 
     bool useCrcOnEntireMessage;
 
+#ifdef USE_BOOST_ASIO
+    boost::asio::io_context* customIoContext;
+#else
     asio::io_context* customIoContext;
+#endif
 
     ptr<logger_wrapper> myLogWrapper;
     ptr<logger> myLog;


### PR DESCRIPTION
* Added `custom_io_context_` to `asio_service_options`. If it is given, `asio_service` will not create the internal threads. The user is responsible for managing the thread pool and handling the async tasks and timers requested by NuRaft.