### PR TITLE
Fix changing busy connection limit

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -132,6 +132,7 @@ public:
             reconnect_limit_ = src.reconnect_limit_.load();
             leave_limit_ = src.leave_limit_.load();
             vote_limit_ = src.vote_limit_.load();
+            busy_connection_limit_ = src.busy_connection_limit_.load();
             return *this;
         }
 


### PR DESCRIPTION
`set_raft_limits` uses assignment operator so you couldn't change busy limit with it.