### PR TITLE
Reset `snapshot_sync_is_needed` on disconnection or leader election

### DIFF
--- a/src/peer.cxx
+++ b/src/peer.cxx
@@ -186,6 +186,12 @@ void peer::handle_rpc_result( ptr<peer> myself,
                 reset_stale_rpc_responses();
                 reset_bytes_in_flight();
                 try_set_free(req->get_type(), streaming);
+
+                // On disconnection, reset `snapshot_sync_is_needed` flag.
+                // The first request on the next connection will re-check
+                // the flag.
+                set_snapshot_sync_is_needed(false);
+
             } else {
                 // WARNING (MONSTOR-9378):
                 //   RPC client has been reset before this request returns

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -1060,6 +1060,7 @@ void raft_server::become_leader() {
             pp->reset_stream();
             enable_hb_for_peer(*pp);
             pp->set_recovered();
+            pp->set_snapshot_sync_is_needed(false);
         }
 
         // If there are uncommitted logs, search if conf log exists.

--- a/tests/unit/snapshot_test.cxx
+++ b/tests/unit/snapshot_test.cxx
@@ -771,6 +771,12 @@ int snapshot_leader_switch_test() {
     // S3 should be in receiving snapshot state.
     CHK_TRUE( s3.raftServer->is_receiving_snapshot() );
 
+    // Make req to S3 failed, and invoke heartbeat.
+    // This will re-check the snapshot condition,
+    // and should resume the previous snapshot transmission.
+    s2.fNet->makeReqFail("S3");
+    s2.fTimer->invoke( timer_task_type::heartbeat_timer );
+
     // Send the entire snapshot.
     do {
         s2.fNet->execReqResp();


### PR DESCRIPTION
* If disconnection or leader election happens, the very first message should be `append_entries` so as to check whether we should send the snapshot again or not.