### PR TITLE
Fix to pause state machine bug

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -791,7 +791,7 @@ public:
      *                   there is a possibility that the state machine execution
      *                   is still happening.
      */
-    void pause_state_machine_exeuction(size_t timeout_ms = 0);
+    void pause_state_machine_execution(size_t timeout_ms = 0);
 
     /**
      * Resume the background execution of state machine.

--- a/src/handle_commit.cxx
+++ b/src/handle_commit.cxx
@@ -981,7 +981,7 @@ void raft_server::remove_peer_from_peers(const ptr<peer>& pp) {
     peers_.erase(pp->get_id());
 }
 
-void raft_server::pause_state_machine_exeuction(size_t timeout_ms) {
+void raft_server::pause_state_machine_execution(size_t timeout_ms) {
     p_in( "pause state machine execution, previously %s, state machine %s, "
           "timeout %zu ms",
           sm_commit_paused_ ? "PAUSED" : "ACTIVE",

--- a/src/handle_commit.cxx
+++ b/src/handle_commit.cxx
@@ -106,8 +106,12 @@ void raft_server::commit_in_bg() {
 
     while (true) {
      try {
+        // WARNING:
+        //   If `sm_commit_paused_` is set, we shouldn't enter
+        //   `commit_in_bg_exec()`, as it will cause an infinite loop.
         while ( quick_commit_index_ <= sm_commit_index_ ||
-                sm_commit_index_ >= log_store_->next_slot() - 1 ) {
+                sm_commit_index_ >= log_store_->next_slot() - 1 ||
+                sm_commit_paused_ ) {
             std::unique_lock<std::mutex> lock(commit_cv_lock_);
 
             auto wait_check = [this]() {

--- a/src/handle_snapshot_sync.cxx
+++ b/src/handle_snapshot_sync.cxx
@@ -530,7 +530,7 @@ bool raft_server::handle_snapshot_sync_req(snapshot_sync_req& req, std::unique_l
         // let's pause committing in backgroud so it doesn't access logs
         // while they are being compacted
         guard.unlock();
-        pause_state_machine_exeuction();
+        pause_state_machine_execution();
         size_t wait_count = 0;
         while (!wait_for_state_machine_pause(500)) {
             p_in("waiting for state machine pause before applying snapshot: count %zu",

--- a/tests/asio/asio_service_test.cxx
+++ b/tests/asio/asio_service_test.cxx
@@ -1427,7 +1427,7 @@ int pause_state_machine_execution_test(bool use_global_mgr) {
         }
         if (type == cb_func::Type::StateMachineExecution) {
             std::thread pause_thread([&]() {
-                s3.raftServer->pause_state_machine_exeuction(1);
+                s3.raftServer->pause_state_machine_execution(1);
                 _msg("state machine of S3 is paused\n");
                 ea_commit_thread.invoke();
             });
@@ -1483,7 +1483,7 @@ int pause_state_machine_execution_test(bool use_global_mgr) {
     };
 
     // Pause S3's state machine.
-    s3.raftServer->pause_state_machine_exeuction(1000);
+    s3.raftServer->pause_state_machine_execution(1000);
     CHK_TRUE( s3.raftServer->is_state_machine_execution_paused() );
 
     do_async_append();
@@ -1507,7 +1507,7 @@ int pause_state_machine_execution_test(bool use_global_mgr) {
     CHK_OK( s3.getTestSm()->isSame( *s1.getTestSm() ) );
 
     // Pause again.
-    s3.raftServer->pause_state_machine_exeuction(1000);
+    s3.raftServer->pause_state_machine_execution(1000);
 
     // Do append again.
     do_async_append();


### PR DESCRIPTION
* If `pause_state_machine_exeuction` is invoked while the state machine is lagging behind the latest log of the log store, it will end up with an infinite loop.