### PR TITLE
Add an API to subscribe state machine's commit

### DIFF
--- a/include/libnuraft/async.hxx
+++ b/include/libnuraft/async.hxx
@@ -296,7 +296,7 @@ public:
             return empty_result_;
         }
 
-        cv_.wait(lock);
+        cv_.wait(lock, [this]{ return (err_ != nullptr || has_result_); } );
         if (err_ == nullptr) {
             return result_;
         }

--- a/include/libnuraft/peer.hxx
+++ b/include/libnuraft/peer.hxx
@@ -50,6 +50,7 @@ public:
         , max_hb_interval_( ctx.get_params()->max_hb_interval() )
         , next_log_idx_(0)
         , last_accepted_log_idx_(0)
+        , sm_committed_idx_(0)
         , next_batch_size_hint_in_bytes_(0)
         , matched_idx_(0)
         , busy_flag_(false)
@@ -169,6 +170,14 @@ public:
 
     void set_last_accepted_log_idx(uint64_t to) {
         last_accepted_log_idx_ = to;
+    }
+
+    uint64_t get_sm_committed_idx() const {
+        return sm_committed_idx_;
+    }
+
+    void set_sm_committed_idx(uint64_t to) {
+        sm_committed_idx_ = to;
     }
 
     int64 get_next_batch_size_hint_in_bytes() const {
@@ -430,6 +439,11 @@ private:
      * The last log index accepted by this server.
      */
     std::atomic<uint64_t> last_accepted_log_idx_;
+
+    /**
+     * The committed log index of the state machine of this peer.
+     */
+    std::atomic<uint64_t> sm_committed_idx_;
 
     /**
      * Hint of the next log batch size in bytes.

--- a/include/libnuraft/raft_params.hxx
+++ b/include/libnuraft/raft_params.hxx
@@ -98,6 +98,7 @@ struct raft_params {
         , use_new_joiner_type_(false)
         , use_bg_thread_for_snapshot_io_(false)
         , use_full_consensus_among_healthy_members_(false)
+        , track_peers_sm_commit_idx_(false)
         , parallel_log_appending_(false)
         , max_log_gap_in_stream_(0)
         , max_bytes_in_flight_in_stream_(0)
@@ -610,6 +611,13 @@ public:
      * request for a configured time (`response_limit_`).
      */
     bool use_full_consensus_among_healthy_members_;
+
+    /**
+     * (Experimental)
+     * If `true`, the leader will track the commit index of each peers' state machine.
+     * It can be used along with `use_full_consensus_among_healthy_members_`
+     */
+    bool track_peers_sm_commit_idx_;
 
     /**
      * (Experimental)

--- a/src/handle_client_request.hxx
+++ b/src/handle_client_request.hxx
@@ -48,5 +48,18 @@ struct raft_server::commit_ret_elem {
     bool callback_invoked_;
 };
 
+struct raft_server::sm_watcher_elem {
+    sm_watcher_elem()
+        : idx_(0)
+        {}
+
+    uint64_t idx_;
+
+    /**
+     * Watchers subscribing to the state machine commit of `idx_`.
+     */
+    std::list<ptr<cmd_result<bool>>> watchers_;
+};
+
 } // namespace nuraft;
 

--- a/tests/asio/custom_quorum_test.cxx
+++ b/tests/asio/custom_quorum_test.cxx
@@ -567,7 +567,7 @@ int sm_commit_watcher_test() {
     uint64_t msg_idx = 0;
     _msg("appending and verifying state machine data\n");
     while (!tt.timeout()) {
-        std::string test_msg = "test" + std::to_string(msg_idx);
+        std::string test_msg = "test" + std::to_string(msg_idx++);
         ptr<buffer> msg = buffer::alloc(test_msg.size() + 4);
         buffer_serializer bs(msg);
         bs.put_str(test_msg);
@@ -593,6 +593,46 @@ int sm_commit_watcher_test() {
             std::string data_str = bs2.get_str();
             CHK_EQ(test_msg, data_str);
         }
+    }
+
+    // Wait for future commit.
+    {
+        uint64_t target_idx = s1.raftServer->get_committed_log_idx() + 1;
+
+        // Test multiple watchers for the same index.
+        auto ret1 = s3.raftServer->wait_for_state_machine_commit(target_idx);
+        auto ret2 = s3.raftServer->wait_for_state_machine_commit(target_idx);
+
+        EventAwaiter ea1, ea2;
+        bool is_ready1 = false, is_ready2 = false;
+        ret1->when_ready([&](cmd_result<bool, ptr<std::exception>>& cmd_res,
+                            ptr<std::exception>& err)
+            {
+                ea1.invoke();
+                is_ready1 = true;
+            });
+        ret2->when_ready([&](cmd_result<bool, ptr<std::exception>>& cmd_res,
+                            ptr<std::exception>& err)
+            {
+                ea2.invoke();
+                is_ready2 = true;
+            });
+
+        std::string test_msg = "test" + std::to_string(msg_idx++);
+        ptr<buffer> msg = buffer::alloc(test_msg.size() + 4);
+        buffer_serializer bs(msg);
+        bs.put_str(test_msg);
+        s1.raftServer->append_entries( {msg} );
+
+        ea1.wait_ms(1000);
+        ea2.wait_ms(1000);
+        CHK_TRUE(is_ready1);
+        CHK_TRUE(is_ready2);
+
+        auto data_buf = s3.getTestSm()->getData(target_idx);
+        buffer_serializer bs2(data_buf);
+        std::string data_str = bs2.get_str();
+        CHK_EQ(test_msg, data_str);
     }
 
     s1.raftServer->shutdown();

--- a/tests/asio/custom_quorum_test.cxx
+++ b/tests/asio/custom_quorum_test.cxx
@@ -537,6 +537,73 @@ int mark_down_by_log_index_test() {
     return 0;
 }
 
+int sm_commit_watcher_test() {
+    reset_log_files();
+
+    std::string s1_addr = "tcp://127.0.0.1:20010";
+    std::string s2_addr = "tcp://127.0.0.1:20020";
+    std::string s3_addr = "tcp://127.0.0.1:20030";
+
+    RaftAsioPkg s1(1, s1_addr);
+    RaftAsioPkg s2(2, s2_addr);
+    RaftAsioPkg s3(3, s3_addr);
+    std::vector<RaftAsioPkg*> pkgs = {&s1, &s2, &s3};
+
+    _msg("launching asio-raft servers\n");
+    CHK_Z( launch_servers(pkgs, false) );
+
+    _msg("organizing raft group\n");
+    CHK_Z( make_group(pkgs) );
+
+    // Set async mode.
+    for (auto& entry: pkgs) {
+        RaftAsioPkg* pp = entry;
+        raft_params param = pp->raftServer->get_current_params();
+        param.return_method_ = raft_params::async_handler;
+        pp->raftServer->update_params(param);
+    }
+
+    timer_helper tt(3 * 1000 * 1000); // 3 seconds
+    uint64_t msg_idx = 0;
+    _msg("appending and verifying state machine data\n");
+    while (!tt.timeout()) {
+        std::string test_msg = "test" + std::to_string(msg_idx);
+        ptr<buffer> msg = buffer::alloc(test_msg.size() + 4);
+        buffer_serializer bs(msg);
+        bs.put_str(test_msg);
+        s1.raftServer->append_entries( {msg} );
+        raft_server::req_ext_params ext_params;
+        uint64_t cur_log_idx = 0;
+        ext_params.after_precommit_ = [&](const raft_server::req_ext_cb_params& p) {
+            cur_log_idx = p.log_idx;
+        };
+        s1.raftServer->append_entries_ext({msg}, ext_params);
+
+        for (auto& ss: {&s3, &s2, &s1}) {
+            auto ret = ss->raftServer->wait_for_state_machine_commit(cur_log_idx);
+            EventAwaiter ea;
+            ret->when_ready([&](cmd_result<bool, ptr<std::exception>>& cmd_res,
+                                ptr<std::exception>& err)
+                {
+                    ea.invoke();
+                });
+            ea.wait_ms(1000);
+            auto data_buf = ss->getTestSm()->getData(cur_log_idx);
+            buffer_serializer bs2(data_buf);
+            std::string data_str = bs2.get_str();
+            CHK_EQ(test_msg, data_str);
+        }
+    }
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+    TestSuite::sleep_sec(1, "shutting down");
+
+    SimpleLogger::shutdown();
+    return 0;
+}
+
 int custom_commit_condition_test() {
     reset_log_files();
 
@@ -649,6 +716,9 @@ int main(int argc, char** argv) {
 
     ts.doTest( "mark down by log index test",
                mark_down_by_log_index_test );
+
+    ts.doTest( "sm commit watcher test",
+               sm_commit_watcher_test );
 
     ts.doTest( "custom commit condition test",
                custom_commit_condition_test );


### PR DESCRIPTION
* Added `wait_for_state_machine_commit`, that will notify the user when the state machine commits the required log index via the given callback.