### PR TITLE
Fix an edge case of full consensus mode

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -1707,7 +1707,13 @@ protected:
 
     /**
      * Timer that will be reset on receiving
-     * a successful `AppendEntries` request.
+     * a valid `AppendEntries` request.
+     */
+    timer_helper last_rcvd_valid_append_entries_req_;
+
+    /**
+     * Timer that will be reset on receiving
+     * a `AppendEntries` request including invalid one too.
      */
     timer_helper last_rcvd_append_entries_req_;
 };

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -2047,7 +2047,7 @@ bool raft_server::is_part_of_full_consensus() {
     }
 
     // Follower.
-    if (last_rcvd_append_entries_req_.get_ms() >
+    if (last_rcvd_valid_append_entries_req_.get_ms() >
             (uint64_t)params.heart_beat_interval_ *
             raft_limits_.full_consensus_follower_limit_) {
         // If we have not received any append entries request for


### PR DESCRIPTION
* If heartbeat is extremely slow, there can be an edge case that the follower is excluded but the follower recognizes itself as a part of quorum. It should be handled gracefully.