### PR TITLE
fix: Reopen the peer if it was shutdown previously

### DIFF
--- a/include/libnuraft/peer.hxx
+++ b/include/libnuraft/peer.hxx
@@ -241,6 +241,10 @@ public:
 
     void shutdown();
 
+    void reopen(context& ctx, timer_task<int32>::executor& hb_exec);
+
+    bool is_shutdown() const { return is_shutdown_; }
+
     // Time that sent the last request.
     void reset_ls_timer()       { last_sent_timer_.reset(); }
     uint64_t get_ls_timer_us()  { return last_sent_timer_.get_us(); }
@@ -625,6 +629,8 @@ private:
      * If `true`, this peer marks itself down.
      */
     std::atomic<bool> self_mark_down_;
+
+    std::atomic<bool> is_shutdown_{false};
 
     /**
      * Logger instance.

--- a/include/libnuraft/peer.hxx
+++ b/include/libnuraft/peer.hxx
@@ -243,7 +243,7 @@ public:
 
     void reopen(context& ctx, timer_task<int32>::executor& hb_exec);
 
-    bool is_shutdown() const { return is_shutdown_; }
+    bool is_abandoned() const { return abandoned_; }
 
     // Time that sent the last request.
     void reset_ls_timer()       { last_sent_timer_.reset(); }
@@ -630,7 +630,6 @@ private:
      */
     std::atomic<bool> self_mark_down_;
 
-    std::atomic<bool> is_shutdown_{false};
 
     /**
      * Logger instance.

--- a/src/handle_timeout.cxx
+++ b/src/handle_timeout.cxx
@@ -34,6 +34,14 @@ namespace nuraft {
 void raft_server::enable_hb_for_peer(peer& p) {
     p.enable_hb(true);
     p.resume_hb_speed();
+    if (p.is_shutdown()) {
+        timer_task<int32>::executor exec =
+        (timer_task<int32>::executor)
+        std::bind( &raft_server::handle_hb_timeout,
+                    this,
+                    std::placeholders::_1 );
+        p.reopen(*ctx_, exec);
+    }
     p_tr("peer %d, interval: %d\n", p.get_id(), p.get_current_hb_interval());
     schedule_task(p.get_hb_task(), p.get_current_hb_interval());
 }
@@ -343,6 +351,7 @@ void raft_server::cancel_schedulers() {
             cancel_task(p->get_hb_task());
         }
         // Shutdown peer to cut off smart pointers.
+        p_tr("cancel_schedulers shuntdown peer: %d", p->get_id());
         p->shutdown();
 
         // Free user context of snapshot if exists.

--- a/src/handle_timeout.cxx
+++ b/src/handle_timeout.cxx
@@ -34,7 +34,7 @@ namespace nuraft {
 void raft_server::enable_hb_for_peer(peer& p) {
     p.enable_hb(true);
     p.resume_hb_speed();
-    if (p.is_shutdown()) {
+    if (p.is_abandoned()) {
         timer_task<int32>::executor exec =
         (timer_task<int32>::executor)
         std::bind( &raft_server::handle_hb_timeout,
@@ -351,7 +351,7 @@ void raft_server::cancel_schedulers() {
             cancel_task(p->get_hb_task());
         }
         // Shutdown peer to cut off smart pointers.
-        p_tr("cancel_schedulers shuntdown peer: %d", p->get_id());
+        p_tr("cancel_schedulers shutdown peer: %d", p->get_id());
         p->shutdown();
 
         // Free user context of snapshot if exists.

--- a/src/peer.cxx
+++ b/src/peer.cxx
@@ -313,6 +313,7 @@ bool peer::recreate_rpc(ptr<srv_config>& config,
 }
 
 void peer::shutdown() {
+    p_db("call peer %d shutdown", get_id());
     // Should set the flag to block all incoming requests.
     abandoned_ = true;
 
@@ -324,6 +325,29 @@ void peer::shutdown() {
         rpc_.reset();
     }
     hb_task_.reset();
+    is_shutdown_ = true;
+}
+
+
+void peer::reopen(context& ctx, timer_task<int32>::executor& hb_exec) {
+    p_db("call peer %d reopen", get_id());
+    // Should set the flag to block all incoming requests.
+    abandoned_ = false;
+
+    // Cut off all shared pointers related to ASIO and Raft server.
+    scheduler_ = ctx.scheduler_;
+    // {   // To guarantee atomic reset
+    //     // (race between send_req()).
+    //     std::lock_guard<std::mutex> l(rpc_protector_);
+    //     recreate_rpc(config_, ctx);
+    // }
+    hb_task_ = cs_new< timer_task<int32>,
+                            timer_task<int32>::executor&,
+                            int32 >
+                          ( hb_exec, config_->get_id(),
+                            timer_task_type::heartbeat_timer ) ;
+    is_shutdown_ = false;
+    p_db("call peer %d reopen successed", get_id());
 }
 
 } // namespace nuraft;

--- a/src/peer.cxx
+++ b/src/peer.cxx
@@ -336,18 +336,13 @@ void peer::reopen(context& ctx, timer_task<int32>::executor& hb_exec) {
 
     // Cut off all shared pointers related to ASIO and Raft server.
     scheduler_ = ctx.scheduler_;
-    // {   // To guarantee atomic reset
-    //     // (race between send_req()).
-    //     std::lock_guard<std::mutex> l(rpc_protector_);
-    //     recreate_rpc(config_, ctx);
-    // }
     hb_task_ = cs_new< timer_task<int32>,
                             timer_task<int32>::executor&,
                             int32 >
                           ( hb_exec, config_->get_id(),
                             timer_task_type::heartbeat_timer ) ;
     is_shutdown_ = false;
-    p_db("call peer %d reopen successed", get_id());
+    p_tr("call peer %d reopen successed", get_id());
 }
 
 } // namespace nuraft;

--- a/src/peer.cxx
+++ b/src/peer.cxx
@@ -325,24 +325,20 @@ void peer::shutdown() {
         rpc_.reset();
     }
     hb_task_.reset();
-    is_shutdown_ = true;
 }
 
 
 void peer::reopen(context& ctx, timer_task<int32>::executor& hb_exec) {
     p_tr("peer %d reopen", get_id());
-    // Should set the flag to block all incoming requests.
     abandoned_ = false;
 
-    // Cut off all shared pointers related to ASIO and Raft server.
     scheduler_ = ctx.scheduler_;
     hb_task_ = cs_new< timer_task<int32>,
                             timer_task<int32>::executor&,
                             int32 >
                           ( hb_exec, config_->get_id(),
                             timer_task_type::heartbeat_timer ) ;
-    is_shutdown_ = false;
-    p_tr("call peer %d reopen successed", get_id());
+    p_tr("call peer %d reopen succeeded", get_id());
 }
 
 } // namespace nuraft;

--- a/src/peer.cxx
+++ b/src/peer.cxx
@@ -313,7 +313,7 @@ bool peer::recreate_rpc(ptr<srv_config>& config,
 }
 
 void peer::shutdown() {
-    p_tr("call peer %d shutdown", get_id());
+    p_tr("peer %d shutdown", get_id());
     // Should set the flag to block all incoming requests.
     abandoned_ = true;
 
@@ -330,7 +330,7 @@ void peer::shutdown() {
 
 
 void peer::reopen(context& ctx, timer_task<int32>::executor& hb_exec) {
-    p_tr("call peer %d reopen", get_id());
+    p_tr("peer %d reopen", get_id());
     // Should set the flag to block all incoming requests.
     abandoned_ = false;
 

--- a/src/peer.cxx
+++ b/src/peer.cxx
@@ -313,7 +313,7 @@ bool peer::recreate_rpc(ptr<srv_config>& config,
 }
 
 void peer::shutdown() {
-    p_db("call peer %d shutdown", get_id());
+    p_tr("call peer %d shutdown", get_id());
     // Should set the flag to block all incoming requests.
     abandoned_ = true;
 
@@ -330,7 +330,7 @@ void peer::shutdown() {
 
 
 void peer::reopen(context& ctx, timer_task<int32>::executor& hb_exec) {
-    p_db("call peer %d reopen", get_id());
+    p_tr("call peer %d reopen", get_id());
     // Should set the flag to block all incoming requests.
     abandoned_ = false;
 


### PR DESCRIPTION
Reopen the peer connection if it was previously shutdown

This is a backport of [ClickHouse/NuRaft#91](https://github.com/ClickHouse/NuRaft/pull/91).
