### PR TITLE
Expose per-peer committed log index in peer_info

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -653,6 +653,7 @@ public:
         peer_info()
             : id_(-1)
             , last_log_idx_(0)
+            , last_committed_idx_(0)
             , last_succ_resp_us_(0)
             {}
 
@@ -665,6 +666,18 @@ public:
          * The last log index that the peer has, from this server's point of view.
          */
         ulong last_log_idx_;
+
+        /**
+         * The last committed log index of the peer's state machine,
+         * from this server's point of view. It can be smaller than
+         * `last_log_idx_` if the peer has appended the log but has not
+         * committed it yet (e.g., due to slow or deadlocked commit threads).
+         *
+         * NOTE: This field is meaningful only when
+         * `raft_params::track_peers_sm_commit_idx_` is enabled. Otherwise,
+         * it will always be 0.
+         */
+        ulong last_committed_idx_;
 
         /**
          * The elapsed time since the last successful response from this peer,

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -653,7 +653,7 @@ public:
         peer_info()
             : id_(-1)
             , last_log_idx_(0)
-            , last_committed_idx_(0)
+            , last_sm_committed_idx_(0)
             , last_succ_resp_us_(0)
             {}
 
@@ -677,7 +677,7 @@ public:
          * `raft_params::track_peers_sm_commit_idx_` is enabled. Otherwise,
          * it will always be 0.
          */
-        ulong last_committed_idx_;
+        ulong last_sm_committed_idx_;
 
         /**
          * The elapsed time since the last successful response from this peer,

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -1905,6 +1905,7 @@ raft_server::peer_info raft_server::get_peer_info(int32 srv_id) const {
     ptr<peer> pp = entry->second;
     ret.id_ = pp->get_id();
     ret.last_log_idx_ = pp->get_last_accepted_log_idx();
+    ret.last_committed_idx_ = pp->get_sm_committed_idx();
     ret.last_succ_resp_us_ = pp->get_resp_timer_us();
     return ret;
 }
@@ -1919,6 +1920,7 @@ std::vector<raft_server::peer_info> raft_server::get_peer_info_all() const {
         ptr<peer> pp = entry.second;
         pi.id_ = pp->get_id();
         pi.last_log_idx_ = pp->get_last_accepted_log_idx();
+        pi.last_committed_idx_ = pp->get_sm_committed_idx();
         pi.last_succ_resp_us_ = pp->get_resp_timer_us();
         ret.push_back(pi);
     }

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -1905,7 +1905,7 @@ raft_server::peer_info raft_server::get_peer_info(int32 srv_id) const {
     ptr<peer> pp = entry->second;
     ret.id_ = pp->get_id();
     ret.last_log_idx_ = pp->get_last_accepted_log_idx();
-    ret.last_committed_idx_ = pp->get_sm_committed_idx();
+    ret.last_sm_committed_idx_ = pp->get_sm_committed_idx();
     ret.last_succ_resp_us_ = pp->get_resp_timer_us();
     return ret;
 }
@@ -1920,7 +1920,7 @@ std::vector<raft_server::peer_info> raft_server::get_peer_info_all() const {
         ptr<peer> pp = entry.second;
         pi.id_ = pp->get_id();
         pi.last_log_idx_ = pp->get_last_accepted_log_idx();
-        pi.last_committed_idx_ = pp->get_sm_committed_idx();
+        pi.last_sm_committed_idx_ = pp->get_sm_committed_idx();
         pi.last_succ_resp_us_ = pp->get_resp_timer_us();
         ret.push_back(pi);
     }

--- a/tests/asio/asio_service_test.cxx
+++ b/tests/asio/asio_service_test.cxx
@@ -83,11 +83,11 @@ int make_group_test() {
         CHK_EQ(srv_id, pi.id_);
         CHK_EQ(last_log_idx, pi.last_log_idx_);
         // `track_peers_sm_commit_idx_` is not enabled by default,
-        // so `last_committed_idx_` should be 0.
-        CHK_EQ(0, pi.last_committed_idx_);
+        // so `last_sm_committed_idx_` should be 0.
+        CHK_EQ(0, pi.last_sm_committed_idx_);
         TestSuite::Msg mm;
         mm << "srv " << pi.id_ << ": " << pi.last_log_idx_
-           << ", committed " << pi.last_committed_idx_
+           << ", committed " << pi.last_sm_committed_idx_
            << ", responded " << std::fixed
            << std::setprecision(1) << pi.last_succ_resp_us_ / 1000.0 << " ms ago"
            << std::endl;
@@ -102,11 +102,11 @@ int make_group_test() {
         uint64_t last_log_idx = s1.raftServer->get_last_log_idx();
         CHK_EQ(last_log_idx, pi.last_log_idx_);
         // `track_peers_sm_commit_idx_` is not enabled by default,
-        // so `last_committed_idx_` should be 0.
-        CHK_EQ(0, pi.last_committed_idx_);
+        // so `last_sm_committed_idx_` should be 0.
+        CHK_EQ(0, pi.last_sm_committed_idx_);
         TestSuite::Msg mm;
         mm << "srv " << pi.id_ << ": " << pi.last_log_idx_
-           << ", committed " << pi.last_committed_idx_
+           << ", committed " << pi.last_sm_committed_idx_
            << ", responded " << std::fixed
            << std::setprecision(1) << pi.last_succ_resp_us_ / 1000.0 << " ms ago"
            << std::endl;

--- a/tests/asio/asio_service_test.cxx
+++ b/tests/asio/asio_service_test.cxx
@@ -82,8 +82,13 @@ int make_group_test() {
         uint64_t last_log_idx = s1.raftServer->get_last_log_idx();
         CHK_EQ(srv_id, pi.id_);
         CHK_EQ(last_log_idx, pi.last_log_idx_);
+        // `track_peers_sm_commit_idx_` is not enabled by default,
+        // so `last_committed_idx_` should be 0.
+        CHK_EQ(0, pi.last_committed_idx_);
         TestSuite::Msg mm;
-        mm << "srv " << pi.id_ << ": " << pi.last_log_idx_ << ", responded " << std::fixed
+        mm << "srv " << pi.id_ << ": " << pi.last_log_idx_
+           << ", committed " << pi.last_committed_idx_
+           << ", responded " << std::fixed
            << std::setprecision(1) << pi.last_succ_resp_us_ / 1000.0 << " ms ago"
            << std::endl;
     }
@@ -96,8 +101,13 @@ int make_group_test() {
     for (raft_server::peer_info& pi: v_pi) {
         uint64_t last_log_idx = s1.raftServer->get_last_log_idx();
         CHK_EQ(last_log_idx, pi.last_log_idx_);
+        // `track_peers_sm_commit_idx_` is not enabled by default,
+        // so `last_committed_idx_` should be 0.
+        CHK_EQ(0, pi.last_committed_idx_);
         TestSuite::Msg mm;
-        mm << "srv " << pi.id_ << ": " << pi.last_log_idx_ << ", responded " << std::fixed
+        mm << "srv " << pi.id_ << ": " << pi.last_log_idx_
+           << ", committed " << pi.last_committed_idx_
+           << ", responded " << std::fixed
            << std::setprecision(1) << pi.last_succ_resp_us_ / 1000.0 << " ms ago"
            << std::endl;
     }

--- a/tests/asio/custom_quorum_test.cxx
+++ b/tests/asio/custom_quorum_test.cxx
@@ -1385,7 +1385,7 @@ int full_consensus_with_snapshot_transfer_test() {
         CHK_GT(v_pi.size(), 0);
         for (auto& pi: v_pi) {
             CHK_GT(pi.last_log_idx_, 0);
-            CHK_GTEQ(leader_committed, pi.last_committed_idx_);
+            CHK_GTEQ(leader_committed, pi.last_sm_committed_idx_);
         }
     }
 

--- a/tests/asio/custom_quorum_test.cxx
+++ b/tests/asio/custom_quorum_test.cxx
@@ -1377,6 +1377,18 @@ int full_consensus_with_snapshot_transfer_test() {
     do_async_append(s1, 5);
     TestSuite::sleep_ms(RaftAsioPkg::HEARTBEAT_MS * 2, "wait for replication of 5 msgs");
 
+    // Verify peer info exposes both log and committed indices when
+    // `track_peers_sm_commit_idx_` is enabled.
+    {
+        uint64_t leader_committed = s1.raftServer->get_committed_log_idx();
+        std::vector<raft_server::peer_info> v_pi = s1.raftServer->get_peer_info_all();
+        CHK_GT(v_pi.size(), 0);
+        for (auto& pi: v_pi) {
+            CHK_GT(pi.last_log_idx_, 0);
+            CHK_GTEQ(leader_committed, pi.last_committed_idx_);
+        }
+    }
+
     // Bring down S3.
     s3.raftServer->shutdown();
     s3.stopAsio();


### PR DESCRIPTION
Add `last_committed_idx_` to `raft_server::peer_info` so callers can detect peers that have appended logs but cannot commit them (e.g., due to deadlocked commit threads). The value is populated from the existing `peer::get_sm_committed_idx()` and is meaningful only when `raft_params::track_peers_sm_commit_idx_` is enabled.