### PR TITLE
Handle resignation timeout in `process_req` as well

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -1126,6 +1126,7 @@ protected:
     void become_leader();
     void become_follower();
     void check_srv_to_leave_timeout();
+    bool check_resignation_timeout();
     void enable_hb_for_peer(peer& p);
     void stop_election_timer();
     void handle_hb_timeout(int32 srv_id);

--- a/src/handle_timeout.cxx
+++ b/src/handle_timeout.cxx
@@ -59,14 +59,8 @@ void raft_server::handle_hb_timeout(int32 srv_id) {
 
     check_srv_to_leave_timeout();
 
-    if (write_paused_ && reelection_timer_.timeout()) {
-        p_in("resign by timeout, %" PRIu64 " us elapsed, resign now",
-             reelection_timer_.get_us());
-        leader_ = -1;
-        become_follower();
-
-        // Clear this flag to avoid pre-vote rejection.
-        hb_alive_ = false;
+    if (check_resignation_timeout()) {
+        // Resignation timed out, became follower.
         return;
     }
 

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -786,6 +786,10 @@ ptr<resp_msg> raft_server::process_req(req_msg& req,
         return nullptr;
     }
 
+    if (write_paused_.load(std::memory_order_relaxed)) {
+        check_resignation_timeout();
+    }
+
     if ( req.get_type() == msg_type::client_request ) {
         // Client request doesn't need to go through below process.
         return handle_cli_req_prelock(req, ext_params);
@@ -1202,7 +1206,10 @@ void raft_server::become_leader() {
     CbReturnCode rc = ctx_->cb_func_.call(cb_func::BecomeLeader, &param);
     (void)rc; // nothing to do in this callback.
 
-    write_paused_ = false;
+    if (write_paused_) {
+        write_paused_ = false;
+        p_in(" --- WRITE RESUMED ---");
+    }
     next_leader_candidate_ = -1;
     initialized_ = true;
     pre_vote_.quorum_reject_count_ = 0;
@@ -1443,6 +1450,7 @@ void raft_server::yield_leadership(bool immediate_yield,
 
     // Pause write.
     write_paused_ = true;
+    p_in(" --- WRITE PAUSED ---");
 
     if (candidate_id > -1) {
         p_in("next leader candidate: id %d endpoint %s priority %d "
@@ -1468,6 +1476,21 @@ void raft_server::yield_leadership(bool immediate_yield,
     reelection_timer_.set_duration_ms
                       ( ctx_->get_params()->election_timeout_upper_bound_ );
     reelection_timer_.reset();
+}
+
+bool raft_server::check_resignation_timeout() {
+    if (write_paused_ && reelection_timer_.timeout()) {
+        p_in("resign by timeout, %" PRIu64 " us elapsed, resign now",
+             reelection_timer_.get_us());
+        leader_ = -1;
+        become_follower();
+
+        // Clear this flag to avoid pre-vote rejection.
+        hb_alive_ = false;
+        return true;
+    }
+
+    return false;
 }
 
 bool raft_server::request_leadership() {
@@ -1532,7 +1555,10 @@ void raft_server::become_follower() {
         param.ctx = &my_term;
         (void) ctx_->cb_func_.call(cb_func::BecomeFollower, &param);
 
-        write_paused_ = false;
+        if (write_paused_) {
+            write_paused_ = false;
+            p_in(" --- WRITE RESUMED ---");
+        }
         next_leader_candidate_ = -1;
         initialized_ = true;
         uncommitted_config_.reset();


### PR DESCRIPTION
* So far, we handled resignation timeout in `handle_hb_timeout` only.

* Above case works well in normal cases, but if the leader is isolated from all the other members, and also all the connections become zombie, then `handle_hb_timeout` won't be fired due to the stuck connections.

* As a result, write is paused, and nobody will clear it, and the leader keeps insisting itself as a leader.

* To avoid this situation, `process_req` should also do the same check, and release the write pause flag.