### PR TITLE
Fix to bug regarding int32 overflow

### DIFF
--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -1032,17 +1032,17 @@ protected:
     int32 get_quorum_for_election();
     int32 get_quorum_for_commit();
     int32 get_leadership_expiry();
-    std::list<ptr<peer>> get_not_responding_peers(int expiry = 0);
+    std::list<ptr<peer>> get_not_responding_peers(uint64_t expiry = 0);
     size_t get_not_responding_peers_count(int expiry = 0, uint64_t required_log_idx = 0);
     size_t get_num_stale_peers();
     static bool is_excluded_from_quorum(const peer& pp,
-                                        int32_t resp_elapsed_ms,
-                                        int32_t expiry,
+                                        uint64_t resp_elapsed_ms,
+                                        uint64_t expiry,
                                         uint64_t required_log_idx,
                                         bool include_self_mark_down = true);
 
     void for_each_voting_members(
-        const std::function<void(const ptr<peer>&, int32_t)>& callback);
+        const std::function<void(const ptr<peer>&, uint64_t)>& callback);
 
     ptr<resp_msg> handle_append_entries(req_msg& req);
     ptr<resp_msg> handle_prevote_req(req_msg& req);

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -1033,7 +1033,8 @@ protected:
     int32 get_quorum_for_commit();
     int32 get_leadership_expiry();
     std::list<ptr<peer>> get_not_responding_peers(uint64_t expiry = 0);
-    size_t get_not_responding_peers_count(int expiry = 0, uint64_t required_log_idx = 0);
+    size_t get_not_responding_peers_count(uint64_t expiry = 0,
+                                          uint64_t required_log_idx = 0);
     size_t get_num_stale_peers();
     static bool is_excluded_from_quorum(const peer& pp,
                                         uint64_t resp_elapsed_ms,

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -244,20 +244,20 @@ bool raft_server::request_append_entries(ptr<peer> p) {
     }
 
     bool need_to_reconnect = p->need_to_reconnect();
-    int32 last_active_time_ms = p->get_active_timer_us() / 1000;
+    uint64_t last_active_time_ms = p->get_active_timer_us() / 1000;
     if ( last_active_time_ms >
-             params->heart_beat_interval_ *
+             (uint64_t)params->heart_beat_interval_ *
                  raft_server::raft_limits_.reconnect_limit_ ) {
         if (srv_to_leave_ && srv_to_leave_->get_id() == p->get_id()) {
             // We should not re-establish the connection to
             // to-be-removed server, as it will block removing it
             // from `peers_` list.
-            p_wn( "connection to peer %d is not active long time: %d ms, "
+            p_wn( "connection to peer %d is not active long time: %" PRIu64 " ms, "
                   "but this peer should be removed. do nothing",
                   p->get_id(),
                   last_active_time_ms );
         } else {
-            p_wn( "connection to peer %d is not active long time: %d ms, "
+            p_wn( "connection to peer %d is not active long time: %" PRIu64 " ms, "
                   "force re-connect",
                   p->get_id(),
                   last_active_time_ms );

--- a/src/handle_join_leave.cxx
+++ b/src/handle_join_leave.cxx
@@ -86,7 +86,7 @@ ptr<resp_msg> raft_server::handle_add_srv_req(req_msg& req) {
         // Adding server is already in progress.
 
         // Check the last active time of that server.
-        ulong last_active_ms = srv_to_join_->get_active_timer_us() / 1000;
+        uint64_t last_active_ms = srv_to_join_->get_active_timer_us() / 1000;
         p_wn("previous adding server (%d) is in progress, "
              "last activity: %" PRIu64 " ms ago",
              srv_to_join_->get_id(),
@@ -95,10 +95,10 @@ ptr<resp_msg> raft_server::handle_add_srv_req(req_msg& req) {
         // NOTE:
         //   If snapshot transmission was in progress, we will follow the
         //   snapshot timeout. Otherwise, we will follow the response timeout.
-        ulong sync_timeout = (ulong)raft_limits_.response_limit_ *
-                             ctx_->get_params()->heart_beat_interval_;
+        uint64_t sync_timeout = (uint64_t)raft_limits_.response_limit_ *
+                                ctx_->get_params()->heart_beat_interval_;
         if (srv_to_join_->get_snapshot_sync_ctx()) {
-            sync_timeout = (ulong)get_snapshot_sync_ctx_timeout();
+            sync_timeout = (uint64_t)get_snapshot_sync_ctx_timeout();
         }
 
         if (last_active_ms <= sync_timeout) {

--- a/src/handle_vote.cxx
+++ b/src/handle_vote.cxx
@@ -64,12 +64,12 @@ void raft_server::request_prevote() {
                 recreate = pp->need_to_reconnect();
 
                 // Or if it is not active long time, reconnect as well.
-                int32 last_active_time_ms = pp->get_active_timer_us() / 1000;
+                uint64_t last_active_time_ms = pp->get_active_timer_us() / 1000;
                 if ( last_active_time_ms >
-                         params->heart_beat_interval_ *
+                         (uint64_t)params->heart_beat_interval_ *
                              raft_server::raft_limits_.reconnect_limit_ ) {
-                    p_wn( "connection to peer %d is not active long time: %d ms, "
-                          "need reconnection for prevote",
+                    p_wn( "connection to peer %d is not active long time: "
+                          "%" PRIu64 " ms, need reconnection for prevote",
                           pp->get_id(),
                           last_active_time_ms );
                     recreate = true;

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -644,17 +644,18 @@ int32 raft_server::get_leadership_expiry() {
     return expiry;
 }
 
-std::list<ptr<peer>> raft_server::get_not_responding_peers(int expiry) {
+std::list<ptr<peer>> raft_server::get_not_responding_peers(uint64_t expiry) {
     // Check if quorum nodes are not responding
     // (i.e., don't respond 20x heartbeat time long or expiry if sent as argument).
     // default argument for expiry is used in case user defines leadership_expiry_.
     ptr<raft_params> params = ctx_->get_params();
     if (expiry == 0) {
-        expiry = params->heart_beat_interval_ * raft_server::raft_limits_.response_limit_;
+        expiry = (uint64_t)params->heart_beat_interval_ *
+                 raft_server::raft_limits_.response_limit_;
     }
 
     std::list<ptr<peer>> rs;
-    auto cb = [&rs, expiry](const ptr<peer>& peer_ptr, int32_t resp_elapsed_ms) {
+    auto cb = [&rs, expiry](const ptr<peer>& peer_ptr, uint64_t resp_elapsed_ms) {
         if (resp_elapsed_ms <= expiry) {
             // Response time is within the expiry time.
             return;
@@ -666,8 +667,8 @@ std::list<ptr<peer>> raft_server::get_not_responding_peers(int expiry) {
 }
 
 bool raft_server::is_excluded_from_quorum(const peer& pp,
-                                          int32_t resp_elapsed_ms,
-                                          int32_t expiry,
+                                          uint64_t resp_elapsed_ms,
+                                          uint64_t expiry,
                                           uint64_t required_log_idx,
                                           bool include_self_mark_down)
 {
@@ -715,7 +716,7 @@ size_t raft_server::get_not_responding_peers_count(
 
     size_t num_not_resp_nodes = 0;
     auto cb = [&num_not_resp_nodes, required_log_idx, expiry]
-        (const ptr<peer>& pp, int32_t resp_elapsed_ms)
+        (const ptr<peer>& pp, uint64_t resp_elapsed_ms)
     {
         bool non_responding_peer =
             is_excluded_from_quorum(*pp, resp_elapsed_ms, expiry, required_log_idx);
@@ -729,7 +730,7 @@ size_t raft_server::get_not_responding_peers_count(
 }
 
 void raft_server::for_each_voting_members(
-    const std::function<void(const ptr<peer>&, int32_t)>& callback) {
+    const std::function<void(const ptr<peer>&, uint64_t)>& callback) {
 
     // Check not responding peers.
     for (auto& entry: peers_) {
@@ -737,8 +738,7 @@ void raft_server::for_each_voting_members(
 
         if (!is_regular_member(peer_ptr)) continue;
 
-        const auto resp_elapsed_ms =
-            static_cast<int32>(peer_ptr->get_resp_timer_us() / 1000);
+        uint64_t resp_elapsed_ms = peer_ptr->get_resp_timer_us() / 1000;
         callback(peer_ptr, resp_elapsed_ms);
     }
 }

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -704,7 +704,7 @@ bool raft_server::is_excluded_from_quorum(const peer& pp,
 }
 
 size_t raft_server::get_not_responding_peers_count(
-    int expiry, uint64_t required_log_idx)
+    uint64_t expiry, uint64_t required_log_idx)
 {
     // Check if quorum nodes are not responding
     // (i.e., don't respond 20x heartbeat time long or expiry if sent as argument).


### PR DESCRIPTION
* The peer response timer and connection activity timer return `uint64_t` values in microseconds. All related logic, including the non-responding member checker, should also use `uint64_t`, even when converting the values to milliseconds.

* Otherwise, a 32-bit integer overflow could cause incorrect behavior, such as including a non-responding member in the quorum. The overflow occurs at `2^31` milliseconds, or approximately 24.8 days.