### PR TITLE
Add a flag to make a new leader wait for state machine catch-up

### DIFF
--- a/include/libnuraft/callback.hxx
+++ b/include/libnuraft/callback.hxx
@@ -229,6 +229,18 @@ public:
          * ctx: pointer to `ReqResp` instance.
          */
         ReceivedMisbehavingMessage = 29,
+
+        /**
+         * The node has become the leader, but its state machine is still
+         * behind the latest log, so it starts catching up before reporting
+         * itself as the leader.
+         *
+         * `BecomeLeader` callback will be invoked once the state machine catches
+         * up to the latest log index.
+         *
+         * ctx: pointer to term number.
+         */
+        LeaderSmCatchingUp = 30,
     };
 
     struct Param {

--- a/include/libnuraft/raft_params.hxx
+++ b/include/libnuraft/raft_params.hxx
@@ -119,6 +119,7 @@ struct raft_params {
         , max_log_gap_in_stream_(0)
         , max_bytes_in_flight_in_stream_(0)
         , priority_decay_method_(arithmetic_decay)
+        , wait_for_sm_catchup_on_becoming_leader_(false)
         {}
 
     /**
@@ -690,7 +691,20 @@ public:
      * This determines the priority decay method used in priority-based leader
      * election. By default, it uses an arithmetic decay approach.
      */
-    priority_decay_method priority_decay_method_;;
+    priority_decay_method priority_decay_method_;
+
+    /**
+     * If `true`, and if the state machine is behind the latest log
+     * in the log store when elected as a leader, wait for the state machine
+     * to catch up to the latest log index before reporting itself
+     * as a leader
+     *
+     *   - `is_leader()` API will return `false` until the state machine
+     *     has fully caught up.
+     *   - `BecomeLeader` callback will be invoked only after the
+     *     state machine catches up to the latest log index.
+     */
+    bool wait_for_sm_catchup_on_becoming_leader_;
 };
 
 }

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -541,6 +541,21 @@ public:
     }
 
     /**
+     * Check whether the state machine is fully caught up with the latest log
+     * at becoming leader, ensuring that the new leader does not return stale data.
+     *
+     * @return `true` if this server is a leader and its state machine is
+     *         fully caught up with the latest log.
+     */
+    bool is_leader_sm_fully_caught_up() const {
+        // NOTE: `index_at_becoming_leader_` itself is a conf log,
+        //       doesn't need to be committed to guarantee data freshness.
+        return is_leader() &&
+               index_at_becoming_leader_ > 0 &&
+               get_committed_log_idx() >= index_at_becoming_leader_ - 1;
+    }
+
+    /**
      * Calculate the log index to be committed
      * from current peers' matched indexes.
      *
@@ -598,11 +613,7 @@ public:
      *
      * @return `true` if it is leader.
      */
-    bool is_leader() const {
-        if ( leader_ == id_ &&
-             role_ == srv_role::leader ) return true;
-        return false;
-    }
+    bool is_leader() const;
 
     /**
      * Check if there is live leader in the current cluster.
@@ -1316,6 +1327,12 @@ protected:
      * Otherwise (if non-leader), the value will be 0.
      */
     std::atomic<uint64_t> index_at_becoming_leader_;
+
+    /**
+     * `true` if this server is waiting for state machine to catch up.
+     * Used only when `wait_for_sm_catchup_on_becoming_leader_` option is enabled.
+     */
+    std::atomic<bool> waiting_for_sm_catchup_;
 
     /**
      * (Read-only)

--- a/src/handle_commit.cxx
+++ b/src/handle_commit.cxx
@@ -161,23 +161,6 @@ void raft_server::commit_in_bg() {
         }
 
         commit_in_bg_exec();
-        if (role_ == srv_role::leader &&
-            waiting_for_sm_catchup_ &&
-            index_at_becoming_leader_ > 0) {
-            // NOTE: `index_at_becoming_leader_` itself is a conf log,
-            //       doesn't need to be committed to guarantee data freshness.
-            if (sm_commit_index_ >= index_at_becoming_leader_ - 1) {
-                p_in("[BECOME LEADER] state machine caught up to index %" PRIu64
-                     ", current sm commit index %" PRIu64,
-                     index_at_becoming_leader_.load() - 1, sm_commit_index_.load());
-                waiting_for_sm_catchup_ = false;
-                cb_func::Param param(id_, leader_);
-                ulong my_term = state_->get_term();
-                param.ctx = &my_term;
-                CbReturnCode rc = ctx_->cb_func_.call(cb_func::BecomeLeader, &param);
-                (void)rc; // nothing to do in this callback.
-            }
-        }
 
         if (sm_commit_notifier_target_idx_ > sm_commit_notifier_notified_idx_) {
             uint64_t target_idx = sm_commit_notifier_target_idx_;
@@ -363,6 +346,26 @@ bool raft_server::commit_in_bg_exec(size_t timeout_ms) {
             p_tr("sm commit notify ready: %" PRIu64 ", target idx: %" PRIu64
                  ", notified idx: %" PRIu64,
                  target_idx, target_idx2, sm_commit_notifier_notified_idx_.load());
+        }
+    }
+
+    ll.unlock(); // unlock --------------------------------------------------------
+
+    if (role_ == srv_role::leader &&
+        waiting_for_sm_catchup_ &&
+        index_at_becoming_leader_ > 0) {
+        // NOTE: `index_at_becoming_leader_` itself is a conf log,
+        //       doesn't need to be committed to guarantee data freshness.
+        if (sm_commit_index_ >= index_at_becoming_leader_ - 1) {
+            p_in("[BECOME LEADER] state machine caught up to index %" PRIu64
+                 ", current sm commit index %" PRIu64,
+                 index_at_becoming_leader_.load() - 1, sm_commit_index_.load());
+            waiting_for_sm_catchup_ = false;
+            cb_func::Param param(id_, leader_);
+            ulong my_term = state_->get_term();
+            param.ctx = &my_term;
+            CbReturnCode rc = ctx_->cb_func_.call(cb_func::BecomeLeader, &param);
+            (void)rc; // nothing to do in this callback.
         }
     }
 

--- a/src/handle_commit.cxx
+++ b/src/handle_commit.cxx
@@ -351,22 +351,25 @@ bool raft_server::commit_in_bg_exec(size_t timeout_ms) {
 
     ll.unlock(); // unlock --------------------------------------------------------
 
+    // NOTE: `index_at_becoming_leader_` itself is a conf log,
+    //       doesn't need to be committed to guarantee data freshness.
     if (role_ == srv_role::leader &&
         waiting_for_sm_catchup_ &&
-        index_at_becoming_leader_ > 0) {
-        // NOTE: `index_at_becoming_leader_` itself is a conf log,
-        //       doesn't need to be committed to guarantee data freshness.
-        if (sm_commit_index_ >= index_at_becoming_leader_ - 1) {
-            p_in("[BECOME LEADER] state machine caught up to index %" PRIu64
-                 ", current sm commit index %" PRIu64,
-                 index_at_becoming_leader_.load() - 1, sm_commit_index_.load());
-            waiting_for_sm_catchup_ = false;
-            cb_func::Param param(id_, leader_);
-            ulong my_term = state_->get_term();
-            param.ctx = &my_term;
-            CbReturnCode rc = ctx_->cb_func_.call(cb_func::BecomeLeader, &param);
-            (void)rc; // nothing to do in this callback.
-        }
+        index_at_becoming_leader_ > 0 &&
+        sm_commit_index_ >= index_at_becoming_leader_ - 1) {
+
+        // `BecomeLeader` callback should be serialized, hence
+        // acquiring the lock.
+        recur_lock(lock_);
+        p_in("[BECOME LEADER] state machine caught up to index %" PRIu64
+             ", current sm commit index %" PRIu64,
+             index_at_becoming_leader_.load() - 1, sm_commit_index_.load());
+        waiting_for_sm_catchup_ = false;
+        cb_func::Param param(id_, leader_);
+        ulong my_term = state_->get_term();
+        param.ctx = &my_term;
+        CbReturnCode rc = ctx_->cb_func_.call(cb_func::BecomeLeader, &param);
+        (void)rc; // nothing to do in this callback.
     }
 
     return finished_in_time;

--- a/src/handle_commit.cxx
+++ b/src/handle_commit.cxx
@@ -161,6 +161,23 @@ void raft_server::commit_in_bg() {
         }
 
         commit_in_bg_exec();
+        if (role_ == srv_role::leader &&
+            waiting_for_sm_catchup_ &&
+            index_at_becoming_leader_ > 0) {
+            // NOTE: `index_at_becoming_leader_` itself is a conf log,
+            //       doesn't need to be committed to guarantee data freshness.
+            if (sm_commit_index_ >= index_at_becoming_leader_ - 1) {
+                p_in("[BECOME LEADER] state machine caught up to index %" PRIu64
+                     ", current sm commit index %" PRIu64,
+                     index_at_becoming_leader_.load() - 1, sm_commit_index_.load());
+                waiting_for_sm_catchup_ = false;
+                cb_func::Param param(id_, leader_);
+                ulong my_term = state_->get_term();
+                param.ctx = &my_term;
+                CbReturnCode rc = ctx_->cb_func_.call(cb_func::BecomeLeader, &param);
+                (void)rc; // nothing to do in this callback.
+            }
+        }
 
         if (sm_commit_notifier_target_idx_ > sm_commit_notifier_notified_idx_) {
             uint64_t target_idx = sm_commit_notifier_target_idx_;

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -1207,6 +1207,10 @@ void raft_server::become_leader() {
         config_changing_ = true;
     }
 
+    cb_func::Param param(id_, leader_);
+    ulong my_term = state_->get_term();
+    param.ctx = &my_term;
+
     // If `wait_for_sm_catchup_on_becoming_leader_` option is set,
     // `BecomeLeader` will be invoked only when the state machine catches up
     // with `index_at_becoming_leader_`.
@@ -1214,9 +1218,6 @@ void raft_server::become_leader() {
         sm_commit_index_ + 1 >= index_at_becoming_leader_) {
         waiting_for_sm_catchup_ = false;
 
-        cb_func::Param param(id_, leader_);
-        ulong my_term = state_->get_term();
-        param.ctx = &my_term;
         CbReturnCode rc = ctx_->cb_func_.call(cb_func::BecomeLeader, &param);
         (void)rc; // nothing to do in this callback.
 
@@ -1225,6 +1226,9 @@ void raft_server::become_leader() {
         p_in("[BECOME LEADER] waiting for state machine to catch up "
              "to index %" PRIu64 ", current sm commit index %" PRIu64,
              index_at_becoming_leader_.load() - 1, sm_commit_index_.load());
+
+         CbReturnCode rc = ctx_->cb_func_.call(cb_func::LeaderSmCatchingUp, &param);
+        (void)rc; // nothing to do in this callback.
     }
 
     if (write_paused_) {

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -60,6 +60,7 @@ raft_server::raft_server(context* ctx, const init_options& opt)
     , quick_commit_index_(ctx->state_machine_->last_commit_index())
     , sm_commit_index_(ctx->state_machine_->last_commit_index())
     , index_at_becoming_leader_(0)
+    , waiting_for_sm_catchup_(false)
     , initial_commit_index_(ctx->state_machine_->last_commit_index())
     , hb_alive_(false)
     , election_completed_(true)
@@ -420,7 +421,8 @@ void raft_server::apply_and_log_current_params() {
           "parallel log appending: %s, "
           "streaming mode max log gap %d, max bytes %" PRIu64 ", "
           "full consensus mode: %s, "
-          "tracking peer sm committed index: %s",
+          "tracking peer sm committed index: %s"
+          "waiting for state machine catchup on becoming leader: %s",
           params->election_timeout_lower_bound_,
           params->election_timeout_upper_bound_,
           params->heart_beat_interval_,
@@ -446,7 +448,8 @@ void raft_server::apply_and_log_current_params() {
           params->max_log_gap_in_stream_,
           params->max_bytes_in_flight_in_stream_,
           params->use_full_consensus_among_healthy_members_ ? "ON" : "OFF",
-          params->track_peers_sm_commit_idx_ ? "ON" : "OFF"
+          params->track_peers_sm_commit_idx_ ? "ON" : "OFF",
+          params->wait_for_sm_catchup_on_becoming_leader_ ? "YES" : "NO"
         );
 
     status_check_timer_.set_duration_ms(params->heart_beat_interval_);
@@ -1195,16 +1198,34 @@ void raft_server::become_leader() {
                 log_val_type::conf,
                 timer_helper::get_timeofday_us() ) );
         index_at_becoming_leader_ = store_log_entry(entry);
-        p_in("[BECOME LEADER] appended new config at %" PRIu64,
-             index_at_becoming_leader_.load());
+        p_in("[BECOME LEADER] appended new config at %" PRIu64
+             ", current state machine commit index %" PRIu64
+             ", target index %" PRIu64,
+             index_at_becoming_leader_.load(),
+             sm_commit_index_.load(),
+             quick_commit_index_.load());
         config_changing_ = true;
     }
 
-    cb_func::Param param(id_, leader_);
-    ulong my_term = state_->get_term();
-    param.ctx = &my_term;
-    CbReturnCode rc = ctx_->cb_func_.call(cb_func::BecomeLeader, &param);
-    (void)rc; // nothing to do in this callback.
+    // If `wait_for_sm_catchup_on_becoming_leader_` option is set,
+    // `BecomeLeader` will be invoked only when the state machine catches up
+    // with `index_at_becoming_leader_`.
+    if (!params->wait_for_sm_catchup_on_becoming_leader_ ||
+        sm_commit_index_ + 1 >= index_at_becoming_leader_) {
+        waiting_for_sm_catchup_ = false;
+
+        cb_func::Param param(id_, leader_);
+        ulong my_term = state_->get_term();
+        param.ctx = &my_term;
+        CbReturnCode rc = ctx_->cb_func_.call(cb_func::BecomeLeader, &param);
+        (void)rc; // nothing to do in this callback.
+
+    } else {
+        waiting_for_sm_catchup_ = true;
+        p_in("[BECOME LEADER] waiting for state machine to catch up "
+             "to index %" PRIu64 ", current sm commit index %" PRIu64,
+             index_at_becoming_leader_.load() - 1, sm_commit_index_.load());
+    }
 
     if (write_paused_) {
         write_paused_ = false;
@@ -1564,6 +1585,7 @@ void raft_server::become_follower() {
         uncommitted_config_.reset();
         pre_vote_.quorum_reject_count_ = 0;
         pre_vote_.no_response_failure_count_ = 0;
+        waiting_for_sm_catchup_ = false;
 
         ptr<raft_params> params = ctx_->get_params();
         if ( params->auto_adjust_quorum_for_small_cluster_ &&
@@ -1840,6 +1862,15 @@ std::string raft_server::get_aux(int32 srv_id) const {
     if (!s_conf) return std::string();
 
     return s_conf->get_aux();
+}
+
+bool raft_server::is_leader() const {
+    if ( leader_ == id_ &&
+         role_ == srv_role::leader &&
+         waiting_for_sm_catchup_ == false ) {
+        return true;
+    }
+    return false;
 }
 
 ptr<srv_config> raft_server::get_srv_config(int32 srv_id) const {

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -421,7 +421,7 @@ void raft_server::apply_and_log_current_params() {
           "parallel log appending: %s, "
           "streaming mode max log gap %d, max bytes %" PRIu64 ", "
           "full consensus mode: %s, "
-          "tracking peer sm committed index: %s"
+          "tracking peer sm committed index: %s, "
           "waiting for state machine catchup on becoming leader: %s",
           params->election_timeout_lower_bound_,
           params->election_timeout_upper_bound_,

--- a/tests/asio/asio_service_test.cxx
+++ b/tests/asio/asio_service_test.cxx
@@ -279,17 +279,27 @@ int sm_catchup_on_new_leader_test() {
     RaftAsioPkg* s3 = new RaftAsioPkg(3, s3_addr);
     std::vector<RaftAsioPkg*> pkgs = {s1, s2, s3};
 
-    std::atomic<bool> test_started = false;
-    std::atomic<bool> become_leader_called = false;
+    bool test_started = false;
+    bool become_leader_called = false;
+    bool leader_catchingup_called = false;
     raft_server::init_options i_opt;
     i_opt.raft_callback_ = [&](cb_func::Type type, cb_func::Param* param)
         -> cb_func::ReturnCode {
 
-        if (test_started &&
-            type == cb_func::BecomeLeader &&
+        if (!test_started) {
+            return cb_func::ReturnCode::Ok;
+        }
+
+        if (type == cb_func::BecomeLeader &&
             param && param->myId == 2) {
             become_leader_called = true;
             _msg("server %d got BecomeLeader callback\n", param->myId);
+            return cb_func::ReturnCode::Ok;
+        }
+        if (type == cb_func::LeaderSmCatchingUp &&
+            param && param->myId == 2) {
+            leader_catchingup_called = true;
+            _msg("server %d got LeaderSmCatchingUp callback\n", param->myId);
             return cb_func::ReturnCode::Ok;
         }
         return cb_func::ReturnCode::Ok;
@@ -366,14 +376,17 @@ int sm_catchup_on_new_leader_test() {
 
     s3 = new RaftAsioPkg(1, s1_addr);
     s3->initServer();
-    TestSuite::sleep_sec(1, "restart S3");
+    TestSuite::sleep_sec(2, "restart S3");
 
     // Nobody should be a leader now.
     CHK_FALSE( s2->raftServer->is_leader() );
     CHK_FALSE( s3->raftServer->is_leader() );
 
     // `BecomeLeader` callback should not have been called yet.
-    CHK_FALSE( become_leader_called.load() );
+    CHK_FALSE( become_leader_called );
+
+    // However, `LeaderSmCatchingUp` callback should have been called.
+    CHK_TRUE( leader_catchingup_called );
 
     // Now resume state machine of S2.
     s2->raftServer->resume_state_machine_execution();
@@ -383,7 +396,7 @@ int sm_catchup_on_new_leader_test() {
     CHK_TRUE( s2->raftServer->is_leader() );
 
     // `BecomeLeader` callback should have been called.
-    CHK_TRUE( become_leader_called.load() );
+    CHK_TRUE( become_leader_called );
 
     s2->raftServer->shutdown();
     s3->raftServer->shutdown();

--- a/tests/asio/asio_service_test.cxx
+++ b/tests/asio/asio_service_test.cxx
@@ -378,9 +378,8 @@ int sm_catchup_on_new_leader_test() {
     s3->initServer();
     TestSuite::sleep_sec(2, "restart S3");
 
-    // Nobody should be a leader now.
+    // S2 should not be a leader yet.
     CHK_FALSE( s2->raftServer->is_leader() );
-    CHK_FALSE( s3->raftServer->is_leader() );
 
     // `BecomeLeader` callback should not have been called yet.
     CHK_FALSE( become_leader_called );

--- a/tests/asio/asio_service_test.cxx
+++ b/tests/asio/asio_service_test.cxx
@@ -267,6 +267,137 @@ int leader_election_test(bool crc_on_entire_message) {
     return 0;
 }
 
+int sm_catchup_on_new_leader_test() {
+    reset_log_files();
+
+    std::string s1_addr = "tcp://localhost:20010";
+    std::string s2_addr = "tcp://localhost:20020";
+    std::string s3_addr = "tcp://localhost:20030";
+
+    RaftAsioPkg* s1 = new RaftAsioPkg(1, s1_addr);
+    RaftAsioPkg* s2 = new RaftAsioPkg(2, s2_addr);
+    RaftAsioPkg* s3 = new RaftAsioPkg(3, s3_addr);
+    std::vector<RaftAsioPkg*> pkgs = {s1, s2, s3};
+
+    std::atomic<bool> test_started = false;
+    std::atomic<bool> become_leader_called = false;
+    raft_server::init_options i_opt;
+    i_opt.raft_callback_ = [&](cb_func::Type type, cb_func::Param* param)
+        -> cb_func::ReturnCode {
+
+        if (test_started &&
+            type == cb_func::BecomeLeader &&
+            param && param->myId == 2) {
+            become_leader_called = true;
+            _msg("server %d got BecomeLeader callback\n", param->myId);
+            return cb_func::ReturnCode::Ok;
+        }
+        return cb_func::ReturnCode::Ok;
+    };
+
+    _msg("launching asio-raft servers\n");
+    CHK_Z( launch_servers(pkgs, false, false, true, i_opt) );
+
+    _msg("organizing raft group\n");
+    CHK_Z( make_group(pkgs) );
+
+    // Set `wait_for_sm_catchup_on_becoming_leader_` to true.
+    for (auto& pp: pkgs) {
+        raft_params param = pp->raftServer->get_current_params();
+        param.snapshot_distance_ = 100;
+        param.reserved_log_items_ = 100;
+        param.wait_for_sm_catchup_on_becoming_leader_ = true;
+        pp->raftServer->update_params(param);
+    }
+
+    CHK_TRUE( s1->raftServer->is_leader() );
+    CHK_EQ(1, s1->raftServer->get_leader());
+    CHK_EQ(1, s2->raftServer->get_leader());
+    CHK_EQ(1, s3->raftServer->get_leader());
+
+    std::list< ptr< cmd_result< ptr<buffer> > > > handlers;
+    std::list<ulong> idx_list;
+    std::mutex idx_list_lock;
+
+    auto do_async_append = [&](RaftAsioPkg& ss, size_t num) {
+        handlers.clear();
+        idx_list.clear();
+        for (size_t ii = 0; ii < num; ++ii) {
+            std::string test_msg = "test" + std::to_string(ii);
+            ptr<buffer> msg = buffer::alloc(test_msg.size() + 1);
+            msg->put(test_msg);
+            ptr< cmd_result< ptr<buffer> > > ret =
+                ss.raftServer->append_entries( {msg} );
+
+            cmd_result< ptr<buffer> >::handler_type my_handler =
+                std::bind( async_handler,
+                           &idx_list,
+                           &idx_list_lock,
+                           std::placeholders::_1,
+                           std::placeholders::_2 );
+            ret->when_ready( my_handler );
+
+            handlers.push_back(ret);
+        }
+    };
+
+    // Insert some data.
+    do_async_append(*s1, 10);
+
+    // Stop S3, pause state machine of S2, and insert more data.
+    s3->raftServer->shutdown();
+    s3->stopAsio();
+    delete s3;
+
+    s2->raftServer->pause_state_machine_execution();
+    TestSuite::sleep_sec(1, "S3 shutdown, S2 state machine pause");
+
+    // Insert more data.
+    do_async_append(*s1, 5);
+
+    test_started = true;
+
+    // Now stop S1, restart S3.
+    s1->raftServer->shutdown();
+    s1->stopAsio();
+    delete s1;
+    s1 = nullptr;
+    _msg("S1 shutdown\n");
+
+    s3 = new RaftAsioPkg(1, s1_addr);
+    s3->initServer();
+    TestSuite::sleep_sec(1, "restart S3");
+
+    // Nobody should be a leader now.
+    CHK_FALSE( s2->raftServer->is_leader() );
+    CHK_FALSE( s3->raftServer->is_leader() );
+
+    // `BecomeLeader` callback should not have been called yet.
+    CHK_FALSE( become_leader_called.load() );
+
+    // Now resume state machine of S2.
+    s2->raftServer->resume_state_machine_execution();
+    TestSuite::sleep_sec(1, "S2 state machine resumed");
+
+    // Now S2 should be a leader.
+    CHK_TRUE( s2->raftServer->is_leader() );
+
+    // `BecomeLeader` callback should have been called.
+    CHK_TRUE( become_leader_called.load() );
+
+    s2->raftServer->shutdown();
+    s3->raftServer->shutdown();
+    TestSuite::sleep_sec(1, "shutting down");
+
+    s2->stopAsio();
+    s3->stopAsio();
+    delete s2;
+    delete s3;
+
+    SimpleLogger::shutdown();
+    return 0;
+}
+
 int ssl_test() {
     reset_log_files();
 
@@ -2066,6 +2197,9 @@ int main(int argc, char** argv) {
     ts.doTest( "leader election test",
                leader_election_test,
                TestRange<bool>( {false, true} ) );
+
+    ts.doTest( "state machine catch-up on new leader test",
+               sm_catchup_on_new_leader_test );
 
 #if !SSL_LIBRARY_NOT_FOUND && (defined(__linux__) || defined(__APPLE__))
     ts.doTest( "ssl test",

--- a/tests/asio/asio_service_test.cxx
+++ b/tests/asio/asio_service_test.cxx
@@ -279,9 +279,9 @@ int sm_catchup_on_new_leader_test() {
     RaftAsioPkg* s3 = new RaftAsioPkg(3, s3_addr);
     std::vector<RaftAsioPkg*> pkgs = {s1, s2, s3};
 
-    bool test_started = false;
-    bool become_leader_called = false;
-    bool leader_catchingup_called = false;
+    std::atomic<bool> test_started(false);
+    std::atomic<bool> become_leader_called(false);
+    std::atomic<bool> leader_catchingup_called(false);
     raft_server::init_options i_opt;
     i_opt.raft_callback_ = [&](cb_func::Type type, cb_func::Param* param)
         -> cb_func::ReturnCode {
@@ -374,7 +374,7 @@ int sm_catchup_on_new_leader_test() {
     s1 = nullptr;
     _msg("S1 shutdown\n");
 
-    s3 = new RaftAsioPkg(1, s1_addr);
+    s3 = new RaftAsioPkg(3, s3_addr);
     s3->initServer();
     TestSuite::sleep_sec(2, "restart S3");
 


### PR DESCRIPTION
* If a new leader's state machine is behind the latest log entry in the log store, it may serve stale data until the state machine fully catches up.

* To prevent this, this change introduces a flag that delays leader readiness until the state machine has caught up to the latest log.

* When the flag is enabled:
  - The new leader will not report itself as the leader until its state machine has fully caught up.
  - The `BecomeLeader` callback will be invoked only after the catch-up is complete.